### PR TITLE
fix: session 导出改 app 内下载（403 修复）+ 主题/导出既有工作 (#10)

### DIFF
--- a/app/src/main/java/com/dshmobile/shell/MainActivity.kt
+++ b/app/src/main/java/com/dshmobile/shell/MainActivity.kt
@@ -157,7 +157,7 @@ class MainActivity : ComponentActivity() {
         }
         // 只允许引擎同源页面留在 WebView（特权桥 + 下载能力仅对引擎可信）；
         // 外部链接交给系统浏览器，防止不可信页面获得桥能力（社工/通知轰炸/任意下载）。
-        if (url.startsWith(EngineProbe.ENGINE_URL)) {
+        if (isEngineSource(url)) {
           view.loadUrl(url)
           return true
         }
@@ -166,7 +166,7 @@ class MainActivity : ComponentActivity() {
       }
 
       override fun onReceivedError(view: WebView, errorCode: Int, description: String, failingUrl: String) {
-        if (failingUrl.startsWith(EngineProbe.ENGINE_URL)) showGuide()
+        if (isEngineSource(failingUrl)) showGuide()
       }
 
       override fun onPageFinished(view: WebView, url: String) {
@@ -174,15 +174,12 @@ class MainActivity : ComponentActivity() {
         pushSystemDark(view)
       }
     }
-    // WebView 下载：会话日志导出（/api/session.export）跳系统浏览器下载
-    // （issue apk#6，用户要求）；其余引擎源下载维持 MediaStore 兜底。
+    // WebView 下载：会话日志导出（/api/session.export）与其余引擎源下载
+    // 统一走 app 内 MediaStore 下载——浏览器导航带 Origin:null 会被 dsh
+    // 的 /api browser-trust fence 拒绝（403），app 内 HttpURLConnection
+    // 无浏览器标记 → fence 放行（403 修复路径，见 downloadToDownloads）。
     webView.setDownloadListener { url, _userAgent, contentDisposition, _mimeType, _contentLength ->
-      if (isSessionExport(url, "GET")) {
-        // 同上：app 内下载（fence 放行），不再跳浏览器（403）。
-        downloadToDownloads(url, contentDisposition)
-      } else {
-        downloadToDownloads(url, contentDisposition)
-      }
+      downloadToDownloads(url, contentDisposition)
     }
     webView.webChromeClient = object : WebChromeClient() {
       override fun onShowFileChooser(
@@ -272,33 +269,42 @@ class MainActivity : ComponentActivity() {
    * app 内 HttpURLConnection 请求无浏览器标记（Origin/sec-fetch-site），
    * 通过 dsh 的 /api browser-trust fence（浏览器导航 403 的修复路径）。
    */
+  /** 下载 in-flight 守卫：shouldOverrideUrlLoading 与 downloadListener 双入口去重。 */
+  private val exportDownloading = java.util.concurrent.atomic.AtomicBoolean(false)
+
   private fun downloadToDownloads(url: String, contentDisposition: String?) {
-    if (!url.startsWith(EngineProbe.ENGINE_URL)) {
+    if (!isEngineSource(url)) {
       showTestNotification("下载被拒绝", "仅支持从本机引擎导出文件")
       return
     }
+    if (!exportDownloading.compareAndSet(false, true)) return
     if (Build.VERSION.SDK_INT < 29) {
       showTestNotification("导出失败", "当前系统版本不支持下载，请升级到 Android 10+")
       return
     }
     val filename = sanitizeFilename(parseDownloadFilename(url, contentDisposition))
     Thread {
+      var conn: HttpURLConnection? = null
       try {
-        val conn = URL(url).openConnection() as HttpURLConnection
-        conn.connectTimeout = 15_000
-        conn.readTimeout = 60_000
-        conn.requestMethod = "GET"
-        if (conn.responseCode != HttpURLConnection.HTTP_OK) {
-          throw java.io.IOException("HTTP " + conn.responseCode)
+        val c = URL(url).openConnection() as HttpURLConnection
+        conn = c
+        c.connectTimeout = 15_000
+        c.readTimeout = 60_000
+        c.requestMethod = "GET"
+        if (c.responseCode != HttpURLConnection.HTTP_OK) {
+          throw java.io.IOException("HTTP " + c.responseCode)
         }
         var saved: String? = null
-        conn.inputStream.use { input ->
+        c.inputStream.use { input ->
           saved = saveToDownloadsStreamed(filename, input)
         }
         val finalName = saved
         runOnUiThread { showTestNotification("会话日志已导出", "已保存到 下载/$finalName") }
       } catch (t: Throwable) {
         runOnUiThread { showTestNotification("导出失败", t.message ?: "未知错误") }
+      } finally {
+        conn?.disconnect()
+        exportDownloading.set(false)
       }
     }.start()
   }
@@ -374,12 +380,30 @@ class MainActivity : ComponentActivity() {
     }
   }
 
-  /** 命中判定：引擎源 + 会话导出路径 + GET（HEAD 是前端预检，不得触发跳转）。 */
-  private fun isSessionExport(url: String, method: String): Boolean {
-    return method == "GET" && url.startsWith(EngineProbe.ENGINE_URL) && url.contains(SESSION_EXPORT_PATH)
+  /**
+   * 引擎源判定：精确匹配本机引擎的 scheme/host/port（防前缀欺骗，
+   * 如 127.0.0.1:30800 或 127.0.0.1:3080.evil.com 误判为引擎源）。
+   */
+  private fun isEngineSource(url: String): Boolean {
+    return try {
+      val base = Uri.parse(EngineProbe.ENGINE_URL)
+      val uri = Uri.parse(url)
+      uri.scheme == base.scheme && uri.host == base.host && uri.port == base.port
+    } catch (_: Exception) {
+      false
+    }
   }
 
-  /** 原子防重放的外部浏览器打开；失败返回 false 供调用方回退。 */
+  /** 命中判定：引擎源 + 会话导出路径 + GET（HEAD 是前端预检，不得触发跳转）。 */
+  private fun isSessionExport(url: String, method: String): Boolean {
+    return method == "GET" && isEngineSource(url) && url.contains(SESSION_EXPORT_PATH)
+  }
+
+  /**
+   * 原子防重放的外部浏览器打开（非导出外链）。尽力而为：启动失败时
+   * 静默（调用方不读返回值），不再有 MediaStore 回退契约——回退仅
+   * 存在于导出路径（downloadToDownloads 内）。
+   */
   private val exportLaunching = java.util.concurrent.atomic.AtomicBoolean(false)
 
   private fun openInExternalBrowser(uri: android.net.Uri): Boolean {

--- a/app/src/main/java/com/dshmobile/shell/MainActivity.kt
+++ b/app/src/main/java/com/dshmobile/shell/MainActivity.kt
@@ -71,6 +71,9 @@ class MainActivity : ComponentActivity() {
 
     /** 导出文件大小上限（防恶意/异常大文件 OOM）。 */
     const val MAX_DOWNLOAD_BYTES = 200L * 1024 * 1024
+
+    /** 会话日志导出端点路径（WebView 内双拦截识别用）。 */
+    const val SESSION_EXPORT_PATH = "/api/session.export"
   }
 
   // 文件上传（<input type=file> → WebView onShowFileChooser → 系统文件选择器）。
@@ -115,11 +118,20 @@ class MainActivity : ComponentActivity() {
     engineManager.stopEngine()
   }
 
+  override fun onConfigurationChanged(newConfig: android.content.res.Configuration) {
+    super.onConfigurationChanged(newConfig)
+    pushSystemDark(webView)
+  }
+
   override fun onBackPressed() {
     if (webView.canGoBack()) webView.goBack() else super.onBackPressed()
   }
 
   private fun configureWebView() {
+    // WebView 远程调试（debug 构建）：真机/模拟器 CDP 自动化验证 UI 行为。
+    // AGP 8 默认不生成 BuildConfig，用 debuggable 标志判断。
+    val debuggable = (applicationInfo.flags and android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE) != 0
+    if (debuggable) android.webkit.WebView.setWebContentsDebuggingEnabled(true)
     webView.settings.apply {
       javaScriptEnabled = true
       domStorageEnabled = true
@@ -135,27 +147,42 @@ class MainActivity : ComponentActivity() {
     webView.webViewClient = object : WebViewClient() {
       override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
         val url = request.url.toString()
+        // 会话日志导出（issue apk#6 + 403 修复）：浏览器导航带 Origin:null /
+        // sec-fetch-site 标记，会被 dsh 的 /api browser-trust fence 拒绝
+        // （403 forbidden，防 DNS rebinding/跨站）。改为 app 内下载：
+        // HttpURLConnection 无浏览器标记 → fence 放行（MuMu 实测验证）。
+        if (isSessionExport(url, request.method)) {
+          downloadToDownloads(url, null)
+          return true
+        }
         // 只允许引擎同源页面留在 WebView（特权桥 + 下载能力仅对引擎可信）；
         // 外部链接交给系统浏览器，防止不可信页面获得桥能力（社工/通知轰炸/任意下载）。
         if (url.startsWith(EngineProbe.ENGINE_URL)) {
           view.loadUrl(url)
           return true
         }
-        try {
-          startActivity(Intent(Intent.ACTION_VIEW, request.url))
-        } catch (_: Exception) {
-          // 无浏览器可处理：忽略。
-        }
+        openInExternalBrowser(request.url)
         return true
       }
 
       override fun onReceivedError(view: WebView, errorCode: Int, description: String, failingUrl: String) {
         if (failingUrl.startsWith(EngineProbe.ENGINE_URL)) showGuide()
       }
+
+      override fun onPageFinished(view: WebView, url: String) {
+        super.onPageFinished(view, url)
+        pushSystemDark(view)
+      }
     }
-    // WebView 下载（会话日志导出等 <a download>）：拉到系统下载目录。
+    // WebView 下载：会话日志导出（/api/session.export）跳系统浏览器下载
+    // （issue apk#6，用户要求）；其余引擎源下载维持 MediaStore 兜底。
     webView.setDownloadListener { url, _userAgent, contentDisposition, _mimeType, _contentLength ->
-      downloadToDownloads(url, contentDisposition)
+      if (isSessionExport(url, "GET")) {
+        // 同上：app 内下载（fence 放行），不再跳浏览器（403）。
+        downloadToDownloads(url, contentDisposition)
+      } else {
+        downloadToDownloads(url, contentDisposition)
+      }
     }
     webView.webChromeClient = object : WebChromeClient() {
       override fun onShowFileChooser(
@@ -242,6 +269,8 @@ class MainActivity : ComponentActivity() {
    * 下载引擎侧 URL 到系统下载目录（会话日志 ZIP 导出）。API 29+ 走
    * MediaStore.Downloads（免权限）；更老系统不支持（实际设备均为新版本）。
    * 仅接受引擎同源 URL（防本机 SSRF/恶意文件投放）；流式写入并设大小上限。
+   * app 内 HttpURLConnection 请求无浏览器标记（Origin/sec-fetch-site），
+   * 通过 dsh 的 /api browser-trust fence（浏览器导航 403 的修复路径）。
    */
   private fun downloadToDownloads(url: String, contentDisposition: String?) {
     if (!url.startsWith(EngineProbe.ENGINE_URL)) {
@@ -326,6 +355,43 @@ class MainActivity : ComponentActivity() {
       if (sid != null) "dsh-session-$sid.zip" else "dsh-session-export.zip"
     } catch (_: Exception) {
       "dsh-session-export.zip"
+    }
+  }
+
+  /** 系统深色状态推送：某些厂商 WebView 的 prefers-color-scheme 不跟随
+   *  uiMode（vivo/Android 16 实测），UI 插件经 matchMedia hook 消费此桥值
+   *  （window.__dshThemeBridge.setDark）驱动上游 system 主题。 */
+  private fun pushSystemDark(view: android.webkit.WebView) {
+    val dark = (resources.configuration.uiMode and
+      android.content.res.Configuration.UI_MODE_NIGHT_MASK) ==
+      android.content.res.Configuration.UI_MODE_NIGHT_YES
+    try {
+      view.evaluateJavascript(
+        "window.__dshThemeBridge && window.__dshThemeBridge.setDark(" + dark + ")", null,
+      )
+    } catch (_: Exception) {
+      // 页面未就绪：onPageFinished 会再推一次。
+    }
+  }
+
+  /** 命中判定：引擎源 + 会话导出路径 + GET（HEAD 是前端预检，不得触发跳转）。 */
+  private fun isSessionExport(url: String, method: String): Boolean {
+    return method == "GET" && url.startsWith(EngineProbe.ENGINE_URL) && url.contains(SESSION_EXPORT_PATH)
+  }
+
+  /** 原子防重放的外部浏览器打开；失败返回 false 供调用方回退。 */
+  private val exportLaunching = java.util.concurrent.atomic.AtomicBoolean(false)
+
+  private fun openInExternalBrowser(uri: android.net.Uri): Boolean {
+    if (!exportLaunching.compareAndSet(false, true)) return true // 已在途：吞掉重复触发
+    return try {
+      startActivity(Intent(Intent.ACTION_VIEW, uri))
+      true
+    } catch (_: Exception) {
+      // 无浏览器可处理：回退 MediaStore 下载路径
+      false
+    } finally {
+      exportLaunching.set(false)
     }
   }
 


### PR DESCRIPTION
Closes #10

## 变更
1. **导出 403 修复**：浏览器导航带 Origin:null 被 dsh /api browser-trust fence 拒绝（403 forbidden）。导出改为 app 内 HttpURLConnection 下载（无浏览器标记 → fence 放行，MuMu 实测验证）→ MediaStore.Downloads + 通知"已保存到 下载/xxx.zip"
2. 顺带包含此前 stash 的主题跟随（pushSystemDark/onConfigurationChanged）与会话导出拦截（SESSION_EXPORT_PATH/isSessionExport）实现

## 验证
- MuMu：fence 行为实测（无 Origin 放行 404-session-not-found / Origin:null 403 / cross-site 403）
- APK 构建通过（assembleDebug --offline）
- 真机待验证（用户环境就绪后）