### PR TITLE
chore: 版本 0.10.3(4) + .gitignore 修复

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,10 @@ build/
 local.properties
 snapshot/
 app/src/main/assets/snapshot.tar.xz
-`n# 敏感数据（安全审计 2026-08-14）`n*.credentials.yaml`ntoken*`n*.key`n*.pem`n*.p12
+# 敏感数据（安全审计 2026-08-14）
+*.credentials.yaml
+token*
+*.key
+*.pem
+*.p12
 .kotlin/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
     // (the embedded engine, bash, and every child command would need linker64
     // wrappers); 34 keeps native exec working on Android 15/16 devices.
     targetSdk = 34
-    versionCode = 3
-    versionName = "0.10.2"
+    versionCode = 4
+    versionName = "0.10.3"
   }
 
   androidResources {


### PR DESCRIPTION
## 变更说明
- versionName 0.10.3 / versionCode 4。
- 修复 .gitignore 反引号 n 行。

## 关联 issue
Closes #12

## 测试
- [x] 真机 arm64 debug APK 全链路验证（对应代码，发布前将再跑 build-release 门禁）
- [x] 安全自查：git grep 无 sk-/ghp_

## 破坏性变更
无