### PR TITLE
chore: 版本 0.10.4(5)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
     // (the embedded engine, bash, and every child command would need linker64
     // wrappers); 34 keeps native exec working on Android 15/16 devices.
     targetSdk = 34
-    versionCode = 4
-    versionName = "0.10.3"
+    versionCode = 5
+    versionName = "0.10.4"
   }
 
   androidResources {


### PR DESCRIPTION
## 变更说明
- versionName 0.10.4 / versionCode 5（含导出结果应用内弹窗）。

## 关联 issue
Closes #16

## 测试
- [x] 弹窗功能已在真机 v0.10.3 上实测（成功路径 + 失败 HTTP 404）
- [x] 发布前将跑 build-release 门禁

## 破坏性变更
无