### PR TITLE
feat: 主题跟随加固 + 调试日志系统（v0.10.6）

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
     // (the embedded engine, bash, and every child command would need linker64
     // wrappers); 34 keeps native exec working on Android 15/16 devices.
     targetSdk = 34
-    versionCode = 6
-    versionName = "0.10.5"
+    versionCode = 7
+    versionName = "0.10.6"
   }
 
   androidResources {

--- a/app/src/main/java/com/dshmobile/shell/AndroidBridge.kt
+++ b/app/src/main/java/com/dshmobile/shell/AndroidBridge.kt
@@ -16,6 +16,7 @@ class AndroidBridge(
   private val onKeepScreen: (enable: Boolean) -> Unit,
   private val onNotify: (title: String, text: String) -> Unit,
   private val onAllFilesAccessRequest: () -> Unit = {},
+  private val onDebugLogsRequest: () -> Unit = {},
   private val pickToken: String? = null,
 ) {
 
@@ -38,6 +39,12 @@ class AndroidBridge(
   @JavascriptInterface
   fun pickDirectory(callbackId: String) {
     onPickRequest(callbackId)
+  }
+
+  /** 调试日志导出：引擎日志 + 环境信息打包 zip（走会话导出同款下载/弹窗链路）。 */
+  @JavascriptInterface
+  fun downloadDebugLogs() {
+    onDebugLogsRequest()
   }
 
   /** True when the app holds All Files Access (external workspace requirement). */

--- a/app/src/main/java/com/dshmobile/shell/MainActivity.kt
+++ b/app/src/main/java/com/dshmobile/shell/MainActivity.kt
@@ -112,6 +112,8 @@ class MainActivity : ComponentActivity() {
     super.onResume()
     // Back from the directory picker / Termux: re-route if the engine came up.
     if (!EngineProbe.check().optBoolean("running", false)) startEngineFlow()
+    // 主题补推：从系统设置/SAF 返回时系统主题可能已变（兜底桥时序覆盖）。
+    if (::webView.isInitialized) pushSystemDark(webView)
   }
 
   override fun onDestroy() {
@@ -206,6 +208,7 @@ class MainActivity : ComponentActivity() {
         onKeepScreen = { enable -> keepScreenOn(enable) },
         onNotify = { title, text -> showTestNotification(title, text) },
         onAllFilesAccessRequest = { openAllFilesAccessSettings() },
+        onDebugLogsRequest = { downloadDebugLogs() },
         pickToken = pickToken,
       ),
       "androidBridge",
@@ -438,9 +441,80 @@ class MainActivity : ComponentActivity() {
     }
   }
 
+  /** 调试日志导出（2026-08-16）：引擎日志 + 环境信息打包 zip。
+   *  入口：加号菜单「导出调试日志」→ androidBridge.downloadDebugLogs()。
+   *  优先写 Documents/dshdata/exports/（MANAGE_EXTERNAL_STORAGE 已授），
+   *  未授权回退 MediaStore.Downloads；结果复用导出弹窗（同 session 下载）。 */
+  private val debugLogging = java.util.concurrent.atomic.AtomicBoolean(false)
+
+  private fun downloadDebugLogs() {
+    if (!debugLogging.compareAndSet(false, true)) return
+    Thread {
+      try {
+        val ts = java.text.SimpleDateFormat("yyyyMMdd-HHmmss", java.util.Locale.US)
+          .format(java.util.Date())
+        val filename = "dsh-debug-logs-$ts.zip"
+        // 先写私有缓存，成功后再落最终位置（跨挂载只能 copy）。
+        val cacheFile = File(cacheDir, filename)
+        java.util.zip.ZipOutputStream(java.io.FileOutputStream(cacheFile)).use { zos ->
+          val log = File(filesDir, "engine.log")
+          if (log.exists()) {
+            zos.putNextEntry(java.util.zip.ZipEntry("engine.log"))
+            log.inputStream().use { it.copyTo(zos) }
+            zos.closeEntry()
+          }
+          zos.putNextEntry(java.util.zip.ZipEntry("info.txt"))
+          zos.write(buildDebugInfoText().toByteArray(Charsets.UTF_8))
+          zos.closeEntry()
+        }
+        val saved = if (android.os.Build.VERSION.SDK_INT >= 30 &&
+          android.os.Environment.isExternalStorageManager()
+        ) {
+          val exportDir = File(engineManager.dshDataDir, "exports").apply { mkdirs() }
+          File(engineManager.dshDataDir, ".nomedia").writeText("")
+          val target = uniqueExportFile(exportDir, filename)
+          val tmp = File(exportDir, "." + target.name + ".tmp")
+          cacheFile.inputStream().use { input -> java.io.FileOutputStream(tmp).use { out -> input.copyTo(out) } }
+          if (!tmp.renameTo(target)) throw java.io.IOException("rename failed")
+          "文档/dshdata/exports/" + target.name
+        } else {
+          cacheFile.inputStream().use { input -> saveToDownloadsStreamed(filename, input) }
+          "下载/" + filename
+        }
+        pushExportResult(true, "已保存到 $saved")
+      } catch (t: Throwable) {
+        pushExportResult(false, t.message ?: "导出失败")
+      } finally {
+        debugLogging.set(false)
+      }
+    }.start()
+  }
+
+  /** 调试日志附带的环境信息（不含任何密钥；版本/设备/布局/插件摘要）。 */
+  private fun buildDebugInfoText(): String {
+    val sb = StringBuilder()
+    sb.append("dsh-mobile debug info\n")
+    sb.append("time: ").append(java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss", java.util.Locale.US)
+      .format(java.util.Date())).append('\n')
+    val pkg = try { packageManager.getPackageInfo(packageName, 0) } catch (_: Exception) { null }
+    sb.append("app version: ").append(pkg?.versionName ?: "?").append(" (").append(pkg?.longVersionCode ?: 0).append(")\n")
+    sb.append("android: ").append(android.os.Build.VERSION.RELEASE).append(" / SDK ").append(android.os.Build.VERSION.SDK_INT).append('\n')
+    sb.append("device: ").append(android.os.Build.MANUFACTURER).append(' ').append(android.os.Build.MODEL).append('\n')
+    sb.append("engine: ").append(EngineProbe.check().toString()).append('\n')
+    sb.append("dshdata: ").append(engineManager.dshDataDir.absolutePath)
+      .append(" (nomedia=").append(File(engineManager.dshDataDir, ".nomedia").exists())
+      .append(", private-layout=").append(File(File(engineManager.homeDir, ".dsh"), ".private-layout").exists())
+      .append(")\n")
+    return sb.toString()
+  }
+
   /** 系统深色状态推送：某些厂商 WebView 的 prefers-color-scheme 不跟随
    *  uiMode（vivo/Android 16 实测），UI 插件经 matchMedia hook 消费此桥值
-   *  （window.__dshThemeBridge.setDark）驱动上游 system 主题。 */
+   *  （window.__dshThemeBridge.setDark）驱动上游 system 主题。
+   *  推送时机加固（2026-08-16）：兜底桥（ui-responsive client bundle 内的
+   *  ThemeBridge）可能晚于 onPageFinished 才安装——单次推送会静默落空
+   *  （`window.__dshThemeBridge &&` 短路），主题不跟随。延迟 800ms 再推
+   *  一次覆盖该时序；onResume 亦补推（覆盖从系统设置/SAF 返回后主题变化）。 */
   private fun pushSystemDark(view: android.webkit.WebView) {
     val dark = (resources.configuration.uiMode and
       android.content.res.Configuration.UI_MODE_NIGHT_MASK) ==
@@ -449,6 +523,11 @@ class MainActivity : ComponentActivity() {
       view.evaluateJavascript(
         "window.__dshThemeBridge && window.__dshThemeBridge.setDark(" + dark + ")", null,
       )
+      view.postDelayed({
+        view.evaluateJavascript(
+          "window.__dshThemeBridge && window.__dshThemeBridge.setDark(" + dark + ")", null,
+        )
+      }, 800)
     } catch (_: Exception) {
       // 页面未就绪：onPageFinished 会再推一次。
     }


### PR DESCRIPTION
## 变更说明

v0.10.6：

- **主题跟随加固（Closes #21）**：壳侧 `pushSystemDark` 推送时机加固——`onPageFinished` 后延迟 800ms 重推 + `onResume` 补推。根因链：注入守卫 bug（§8.5）致 early-inject 主题桥缺失 → 兜底桥（client bundle 内）晚于 onPageFinished 安装 → 单次推送被短路落空（厂商 WebView prefers-color-scheme 不跟随 uiMode 的场景）。
- **调试日志系统（新增）**：`androidBridge.downloadDebugLogs()` → zip 打包 `engine.log` + `info.txt`（版本/设备/引擎状态/数据布局，不含密钥）→ `文档/dshdata/exports/dsh-debug-logs-<时间>.zip`（MANAGE_EXTERNAL_STORAGE 直写，未授权回退 MediaStore.Downloads）→ 复用导出结果弹窗。
- versionCode 7 / versionName 0.10.6。

## 关联 issue

Closes #21

## 测试

- [x] 构建通过（gradle assembleDebug --offline）
- [x] 部署验证（MuMu x86_64）：深浅主题切换跟随（深→浅→深）；「导出调试日志」zip 落 `dshdata/exports/` + 弹窗显示路径；目录选择/上传文件回归正常
- [x] 安全自查：git grep 无 sk-/ghp_

## 破坏性变更

无
