### PR TITLE
feat: 设置页开发者选项（重启/刷新/控制台/日志开关）+ 启动测试界面

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
     // (the embedded engine, bash, and every child command would need linker64
     // wrappers); 34 keeps native exec working on Android 15/16 devices.
     targetSdk = 34
-    versionCode = 9
-    versionName = "0.10.8"
+    versionCode = 10
+    versionName = "0.11.0"
   }
 
   androidResources {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,5 +29,12 @@
         <category android:name="android.intent.category.LAUNCHER" />
       </intent-filter>
     </activity>
+
+    <!-- 内置控制台：快照 bash 交互终端（引擎未运行时也可排查）。 -->
+    <activity
+      android:name=".ConsoleActivity"
+      android:exported="false"
+      android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|uiMode"
+      android:windowSoftInputMode="adjustResize" />
   </application>
 </manifest>

--- a/app/src/main/assets/console.html
+++ b/app/src/main/assets/console.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>dsh 控制台</title>
+<style>
+  :root {
+    --bg: #0b0e14;
+    --fg: #d0d7de;
+    --dim: #8b949e;
+    --accent: #3fb950;
+    --warn: #d29922;
+    --border: #21262d;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; margin: 0; }
+  body {
+    background: var(--bg);
+    color: var(--fg);
+    font-family: "Cascadia Mono", "JetBrains Mono", ui-monospace, Menlo, Consolas, monospace;
+    font-size: 13px;
+    display: flex;
+    flex-direction: column;
+  }
+  #statusbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 10px;
+    background: #10151d;
+    border-bottom: 1px solid var(--border);
+    font-size: 12px;
+    flex: none;
+    -webkit-user-select: none;
+    user-select: none;
+  }
+  #statusbar .title { font-weight: 600; color: var(--fg); }
+  #statusbar .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--dim); flex: none; }
+  #statusbar .dot.ok { background: var(--accent); }
+  #statusbar .dot.err { background: #f85149; }
+  #statusbar #engineStatus { color: var(--dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  #statusbar #consoleStatus { color: var(--dim); margin-left: auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  #output {
+    flex: 1;
+    overflow-y: auto;
+    padding: 8px 10px;
+    white-space: pre-wrap;
+    word-break: break-all;
+    line-height: 1.45;
+  }
+  #output .prompt { color: var(--accent); }
+  #inputrow {
+    display: flex;
+    gap: 8px;
+    padding: 8px 10px;
+    border-top: 1px solid var(--border);
+    flex: none;
+  }
+  #cmd {
+    flex: 1;
+    background: #10151d;
+    color: var(--fg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 8px 10px;
+    font-family: inherit;
+    font-size: 13px;
+    outline: none;
+  }
+  #cmd:focus { border-color: #388bfd; }
+  #send {
+    background: #1f6feb;
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    padding: 0 16px;
+    font-size: 13px;
+    flex: none;
+  }
+  #send:active { background: #388bfd; }
+</style>
+</head>
+<body>
+  <div id="statusbar">
+    <span class="title">dsh 控制台</span>
+    <span class="dot" id="engineDot"></span>
+    <span id="engineStatus">引擎检测中…</span>
+    <span id="consoleStatus">启动中…</span>
+  </div>
+  <div id="output"><span class="prompt">$ </span>dsh 控制台：底层为快照内嵌 Termux bash，可执行任意排查命令。<br>引擎未运行时也可使用本控制台（例如排查引擎启动失败）。<br><br></div>
+  <div id="inputrow">
+    <input id="cmd" type="text" placeholder="输入命令，回车执行" autocomplete="off" autocapitalize="off" spellcheck="false">
+    <button id="send" type="button">发送</button>
+  </div>
+<script>
+(function () {
+  var output = document.getElementById('output');
+  var cmd = document.getElementById('cmd');
+  var send = document.getElementById('send');
+  var engineStatus = document.getElementById('engineStatus');
+  var engineDot = document.getElementById('engineDot');
+  var consoleStatus = document.getElementById('consoleStatus');
+  var maxLines = 2000;
+
+  function trimOutput() {
+    var children = output.childNodes;
+    if (children.length > maxLines) {
+      for (var i = 0; i < children.length - maxLines + 500; i++) {
+        var el = children[i];
+        if (el && el.parentNode) el.parentNode.removeChild(el);
+      }
+    }
+  }
+
+  function scrollBottom() { output.scrollTop = output.scrollHeight; }
+
+  window.__consoleAppend = function (text) {
+    if (!text) return;
+    var node = document.createElement('span');
+    node.textContent = text;
+    output.appendChild(node);
+    trimOutput();
+    scrollBottom();
+  };
+
+  window.__consoleStatus = function (text) {
+    consoleStatus.textContent = text || '';
+  };
+
+  function refreshEngine() {
+    try {
+      var raw = window.consoleBridge.engineStatus();
+      var info = JSON.parse(raw);
+      if (info && info.running) {
+        engineStatus.textContent = '引擎运行中（' + info.latencyMs + 'ms）';
+        engineDot.className = 'dot ok';
+      } else {
+        engineStatus.textContent = '引擎未运行' + (info && info.error ? '：' + info.error : '');
+        engineDot.className = 'dot err';
+      }
+    } catch (e) {
+      engineStatus.textContent = '引擎检测失败';
+      engineDot.className = 'dot err';
+    }
+  }
+
+  function submit() {
+    var text = cmd.value;
+    if (!text.trim()) return;
+    cmd.value = '';
+    var node = document.createElement('span');
+    node.textContent = '\n';
+    output.appendChild(node);
+    var prompt = document.createElement('span');
+    prompt.className = 'prompt';
+    prompt.textContent = '$ ';
+    output.appendChild(prompt);
+    var echo = document.createElement('span');
+    echo.textContent = text + '\n';
+    output.appendChild(echo);
+    trimOutput();
+    scrollBottom();
+    try { window.consoleBridge.submit(text); } catch (e) {}
+  }
+
+  send.addEventListener('click', submit);
+  cmd.addEventListener('keydown', function (e) {
+    if (e.key === 'Enter') { e.preventDefault(); submit(); }
+  });
+
+  refreshEngine();
+  setInterval(refreshEngine, 3000);
+})();
+</script>
+</body>
+</html>

--- a/app/src/main/java/com/dshmobile/shell/AndroidBridge.kt
+++ b/app/src/main/java/com/dshmobile/shell/AndroidBridge.kt
@@ -19,6 +19,11 @@ class AndroidBridge(
   private val onDebugLogsRequest: () -> Unit = {},
   private val onGetSystemDark: () -> Boolean = { false },
   private val pickToken: String? = null,
+  private val onRestartEngine: () -> Unit = {},
+  private val onReloadWebUI: () -> Unit = {},
+  private val onOpenConsole: () -> Unit = {},
+  private val onGetDevLogEnabled: () -> Boolean = { false },
+  private val onSetDevLogEnabled: (Boolean) -> Unit = {},
 ) {
 
   @JavascriptInterface
@@ -70,6 +75,34 @@ class AndroidBridge(
   /** 目录选择桥的一次性会话 token（引擎侧 pick 端点校验；null = 未启用）。 */
   @JavascriptInterface
   fun getPickToken(): String? = pickToken
+
+  /** 重启引擎服务进程：kill 引擎进程，EngineService 看门狗自动拉起。 */
+  @JavascriptInterface
+  fun restartEngine() {
+    onRestartEngine()
+  }
+
+  /** 刷新 Web UI（重载当前引擎页面，issue apk#29 需求 1）。 */
+  @JavascriptInterface
+  fun reloadWebUI() {
+    onReloadWebUI()
+  }
+
+  /** 打开内置控制台（快照 bash 交互终端，引擎未运行时也可排查）。 */
+  @JavascriptInterface
+  fun openConsole() {
+    onOpenConsole()
+  }
+
+  /** 开发者调试日志开关状态（默认关；SharedPreferences 持久化）。 */
+  @JavascriptInterface
+  fun getDevLogEnabled(): Boolean = onGetDevLogEnabled()
+
+  /** 设置开发者调试日志开关；开启后按天写入 dshdata/log/。 */
+  @JavascriptInterface
+  fun setDevLogEnabled(enabled: Boolean) {
+    onSetDevLogEnabled(enabled)
+  }
 
   companion object {
     /**

--- a/app/src/main/java/com/dshmobile/shell/ConsoleActivity.kt
+++ b/app/src/main/java/com/dshmobile/shell/ConsoleActivity.kt
@@ -1,0 +1,102 @@
+package com.dshmobile.shell
+
+import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.JavascriptInterface
+import android.webkit.WebSettings
+import android.webkit.WebView
+import androidx.activity.ComponentActivity
+
+/**
+ * 内置控制台：WebView 加载 assets/console.html（终端样式 UI），
+ * ConsoleSession spawn 快照 bash（env 与引擎一致）→ stdin 管道写命令、
+ * 输出经 consoleBridge JS 接口回 UI。引擎未运行时也可用（排查场景）。
+ */
+class ConsoleActivity : ComponentActivity() {
+
+  private lateinit var webView: WebView
+  private val session = ConsoleSession(this)
+  private val handler = android.os.Handler(android.os.Looper.getMainLooper())
+  private var sessionStarted = false
+
+  /** 最近状态文案（onPageFinished 重推用；页面加载前丢失的状态补投）。 */
+  private var lastStatus: String? = null
+
+  /** 状态推送（主线程调用）。 */
+  private fun pushStatus(text: String) {
+    webView.evaluateJavascript("window.__consoleStatus(" + jsString(text) + ")", null)
+  }
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    webView = WebView(this).apply {
+      id = View.generateViewId()
+      layoutParams = ViewGroup.LayoutParams(
+        ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT,
+      )
+    }
+    webView.settings.apply {
+      javaScriptEnabled = true
+      domStorageEnabled = true
+      allowFileAccess = false
+      if (android.os.Build.VERSION.SDK_INT >= 29) {
+        @Suppress("DEPRECATION")
+        forceDark = WebSettings.FORCE_DARK_AUTO
+      }
+    }
+    // 页面加载完成后重推状态：bash 可能在 onStart 就绪而 console.html
+    // 的 JS 桥晚于其才定义，早到的 evaluateJavascript 会静默丢失。
+    webView.webViewClient = object : android.webkit.WebViewClient() {
+      override fun onPageFinished(view: android.webkit.WebView, url: String) {
+        super.onPageFinished(view, url)
+        lastStatus?.let { pushStatus(it) }
+      }
+    }
+    webView.addJavascriptInterface(ConsoleBridge(), "consoleBridge")
+    setContentView(webView)
+    webView.loadUrl("file:///android_asset/console.html")
+  }
+
+  override fun onStart() {
+    super.onStart()
+    if (sessionStarted) return
+    sessionStarted = session.start(object : ConsoleSession.Listener {
+      override fun onOutput(text: String) {
+        handler.post {
+          webView.evaluateJavascript("window.__consoleAppend(" + jsString(text) + ")", null)
+        }
+      }
+
+      override fun onStatus(text: String) {
+        lastStatus = text
+        handler.post { pushStatus(text) }
+      }
+
+      override fun onExit(code: Int) {
+        handler.post {
+          webView.evaluateJavascript(
+            "window.__consoleStatus(" + jsString("bash 已退出（code $code）") + ")", null,
+          )
+        }
+      }
+    })
+  }
+
+  override fun onDestroy() {
+    session.destroy()
+    webView.destroy()
+    super.onDestroy()
+  }
+
+  /** JS 桥：命令提交 + 引擎状态查询。 */
+  inner class ConsoleBridge {
+    @JavascriptInterface
+    fun submit(command: String) {
+      session.writeCommand(command)
+    }
+
+    @JavascriptInterface
+    fun engineStatus(): String = EngineProbe.check().toString()
+  }
+}

--- a/app/src/main/java/com/dshmobile/shell/ConsoleSession.kt
+++ b/app/src/main/java/com/dshmobile/shell/ConsoleSession.kt
@@ -1,0 +1,112 @@
+package com.dshmobile.shell
+
+import android.content.Context
+import android.util.Log
+import java.io.File
+
+/**
+ * 控制台会话：spawn 快照 bash（env 与引擎一致：PATH/LD_LIBRARY_PATH/
+ * HOME/DSH_HOME/TERMUX_*），stdin 写命令、stdout/stderr 合并后台读，
+ * 输出经 Listener 回调回 UI。引擎未运行时也可用（排查引擎启动失败场景）；
+ * Activity 销毁时进程随之终止。
+ *
+ * 非 PTY 交互（bash -i）：无 job control 提示，命令逐行执行；完整 PTY
+ * （script -q -c bash）列为后续迭代。
+ */
+class ConsoleSession(private val context: Context) {
+
+  interface Listener {
+    /** 输出块（已做 \r 折叠、bell 忽略），任意线程回调。 */
+    fun onOutput(text: String)
+    /** 状态文案（启动/退出），任意线程回调。 */
+    fun onStatus(text: String)
+    /** bash 进程退出码。 */
+    fun onExit(code: Int)
+  }
+
+  private var process: Process? = null
+  private var closed = false
+
+  /** 启动 bash；失败时经 listener.onStatus 报告原因并返回 false。 */
+  fun start(listener: Listener): Boolean {
+    val engineManager = EngineManager(context, EngineManager.ensurePickToken())
+    val bash = File(engineManager.usrDir, "bin/bash")
+    if (!bash.exists()) {
+      listener.onStatus("快照缺失（usr/bin/bash 不存在），无法打开控制台")
+      return false
+    }
+    return try {
+      val pb = ProcessBuilder(bash.absolutePath, "-i")
+      pb.environment().putAll(engineManager.shellEnv())
+      pb.environment()["PS1"] = "dsh:\\w$ "
+      pb.redirectErrorStream(true)
+      val proc = pb.start()
+      process = proc
+      val reader = Thread {
+        try {
+          proc.inputStream.bufferedReader().use { r ->
+            val sb = StringBuilder()
+            while (true) {
+              val c = r.read()
+              if (c < 0) break
+              // \r 折叠为 \n（无 PTY 时输出含 CR）；bell 忽略（避免 UI 噪音）。
+              if (c == '\r'.code) {
+                sb.append('\n')
+              } else if (c != '\u0007'.code) {
+                sb.append(c.toChar())
+              }
+              // 行缓冲：小输出（echo 等）不能在 4096 阈值后才 flush——
+              // 设备实测整块缓冲会把输出卡到下一次大块/EOF。
+              if (c == '\n'.code || sb.length >= 4096) {
+                val chunk = sb.toString()
+                sb.setLength(0)
+                listener.onOutput(chunk)
+              }
+            }
+            if (sb.isNotEmpty()) listener.onOutput(sb.toString())
+          }
+        } catch (t: Throwable) {
+          if (!closed) Log.w(TAG, "console reader ended: " + (t.message ?: t.javaClass.simpleName))
+        }
+        // destroy() 竞态：bash 收到 SIGTERM 关闭 stdout 后（read 返回 EOF）
+        // 进程可能尚未完全退出——exitValue() 此时抛 IllegalThreadStateException
+        // （设备实测：App 被杀）。按已退出报告，或标记 -1。
+        val code = try {
+          proc.exitValue()
+        } catch (_: IllegalThreadStateException) {
+          -1
+        }
+        listener.onExit(code)
+      }
+      reader.isDaemon = true
+      reader.start()
+      listener.onStatus("bash 已启动（快照 Termux 环境）")
+      true
+    } catch (t: Throwable) {
+      listener.onStatus("控制台启动失败：" + (t.message ?: t.javaClass.simpleName))
+      false
+    }
+  }
+
+  /** 写一条命令（自动补 \n）。 */
+  fun writeCommand(cmd: String) {
+    val proc = process ?: return
+    try {
+      proc.outputStream.write((cmd + "\n").toByteArray(Charsets.UTF_8))
+      proc.outputStream.flush()
+    } catch (t: Throwable) {
+      Log.w(TAG, "console write failed: " + (t.message ?: t.javaClass.simpleName))
+    }
+  }
+
+  /** 终止会话（Activity 销毁）。 */
+  fun destroy() {
+    closed = true
+    process?.destroy()
+    process = null
+  }
+
+  companion object {
+    private const val TAG = "dsh-console"
+  }
+}

--- a/app/src/main/java/com/dshmobile/shell/EngineManager.kt
+++ b/app/src/main/java/com/dshmobile/shell/EngineManager.kt
@@ -352,40 +352,14 @@ class EngineManager(private val context: Context, private val pickToken: String?
       val args = arrayOf(
         nodeBin.absolutePath, "--expose-internals", dshBin.absolutePath, "web", "--port", port.toString(),
       )
-      val env = mapOf(
-        "PATH" to (usrDir.absolutePath + "/bin:/system/bin"),
-        "LD_LIBRARY_PATH" to (usrDir.absolutePath + "/lib"),
-        "HOME" to homeDir.absolutePath,
-        // DSH_HOME 始终保持在私有域（FUSE 禁 symlink，公共域无法维护
-        // profiles/node_modules flat fallback）；运行时用户数据全部在私有
-        // files/home/.dsh，公共 Documents/dshdata 仅作导出仓库。
-        "DSH_HOME" to ensurePrivateDshData().absolutePath,
-        // os.tmpdir() falls back to the baked-in Termux tmp on Android
-        // (unwritable from the app domain); keep spill inside filesDir.
-        "TMPDIR" to File(homeDir, "tmp").apply { mkdirs() }.absolutePath,
-        // Android 16 forbids exec of app-data ELF regardless of targetSdk
-        // (observed on Android 16/vivo: direct exec EACCES even at targetSdk
-        // 34). Termux's execve hook re-routes denied execs through
-        // /system/bin/linker64 (same mechanism as JNI libs); the snapshot
-        // ships libtermux-exec-*-ld-preload.so. The hook only rewrites for
-        // untrusted_app_25/27 SELinux domains, so force mode is required.
-        "LD_PRELOAD" to preload.absolutePath,
-        "TERMUX_EXEC__SYSTEM_LINKER_EXEC__MODE" to "force",
-        "TERMUX_EXEC__EXECVE_CALL__INTERCEPT" to "1",
-        "TERMUX__ROOTFS" to usrDir.parentFile.absolutePath,
-        "TERMUX__PREFIX" to usrDir.absolutePath,
-        "TERMUX_APP__DATA_DIR" to context.filesDir.parentFile.absolutePath,
-        "TERMUX_APP__LEGACY_DATA_DIR" to "/data/data/com.dshmobile.shell",
-        "TERMUX_VERSION" to "0.118.3",
-        // 目录选择桥端点鉴权 token（web-compat 插件校验 x-dsh-pick-token）。
-        "DSH_PICK_TOKEN" to (pickToken ?: ""),
-      )
-      engineProcess = startWithArgs(args, env)
+      engineProcess = startWithArgs(args, shellEnv())
       // 冷却只在真实启动后写入：失败路径不占用冷却窗口（可立即重试）。
       EngineManager.lastStartAttemptAt = now
+      LogCollector.log(TAG, "engine started")
       true
     } catch (t: Throwable) {
       Log.e(TAG, "engine start failed", t)
+      LogCollector.log(TAG, "engine start FAILED: " + (t.message ?: t.javaClass.simpleName))
       false
     } finally {
       STARTING.set(false)
@@ -419,8 +393,46 @@ class EngineManager(private val context: Context, private val pickToken: String?
   fun stopEngine() {
     engineProcess?.destroy()
     engineProcess = null
+    LogCollector.log(TAG, "engine stopped (manual)")
     // 手动停止后重置冷却：用户回前台应立即允许重新启动。
     EngineManager.lastStartAttemptAt = 0
+  }
+
+  /**
+   * 引擎/控制台/日志进程共用的快照环境（PATH/LD_LIBRARY_PATH/HOME/DSH_HOME/
+   * TERMUX_* 显式注入——快照自足，不依赖 Termux app）。幂等：可安全多次
+   * 调用（ensurePrivateDshData 与 TMPDIR mkdirs 均幂等）。
+   */
+  fun shellEnv(): Map<String, String> {
+    val preload = File(usrDir, "lib/libtermux-exec-ld-preload.so")
+    return mapOf(
+      "PATH" to (usrDir.absolutePath + "/bin:/system/bin"),
+      "LD_LIBRARY_PATH" to (usrDir.absolutePath + "/lib"),
+      "HOME" to homeDir.absolutePath,
+      // DSH_HOME 始终保持在私有域（FUSE 禁 symlink，公共域无法维护
+      // profiles/node_modules flat fallback）；运行时用户数据全部在私有
+      // files/home/.dsh，公共 Documents/dshdata 仅作导出仓库。
+      "DSH_HOME" to ensurePrivateDshData().absolutePath,
+      // os.tmpdir() falls back to the baked-in Termux tmp on Android
+      // (unwritable from the app domain); keep spill inside filesDir.
+      "TMPDIR" to File(homeDir, "tmp").apply { mkdirs() }.absolutePath,
+      // Android 16 forbids exec of app-data ELF regardless of targetSdk
+      // (observed on Android 16/vivo: direct exec EACCES even at targetSdk
+      // 34). Termux's execve hook re-routes denied execs through
+      // /system/bin/linker64 (same mechanism as JNI libs); the snapshot
+      // ships libtermux-exec-*-ld-preload.so. The hook only rewrites for
+      // untrusted_app_25/27 SELinux domains, so force mode is required.
+      "LD_PRELOAD" to preload.absolutePath,
+      "TERMUX_EXEC__SYSTEM_LINKER_EXEC__MODE" to "force",
+      "TERMUX_EXEC__EXECVE_CALL__INTERCEPT" to "1",
+      "TERMUX__ROOTFS" to usrDir.parentFile.absolutePath,
+      "TERMUX__PREFIX" to usrDir.absolutePath,
+      "TERMUX_APP__DATA_DIR" to context.filesDir.parentFile.absolutePath,
+      "TERMUX_APP__LEGACY_DATA_DIR" to "/data/data/com.dshmobile.shell",
+      "TERMUX_VERSION" to "0.118.3",
+      // 目录选择桥端点鉴权 token（web-compat 插件校验 x-dsh-pick-token）。
+      "DSH_PICK_TOKEN" to (pickToken ?: ""),
+    )
   }
 
   companion object {

--- a/app/src/main/java/com/dshmobile/shell/EngineService.kt
+++ b/app/src/main/java/com/dshmobile/shell/EngineService.kt
@@ -27,6 +27,8 @@ class EngineService : Service() {
     // C1：复用进程级 pick token（看门狗重启引擎后鉴权不失效、不空放行）。
     engineManager = EngineManager(this, EngineManager.ensurePickToken())
     startForeground(NOTIFICATION_ID, buildNotification())
+    // 开发者日志开关已开：常驻收集（logcat + engine.log → dshdata/log/ 按天）。
+    if (MainActivity.DevLogPrefs.isEnabled(this)) LogCollector.start(this)
   }
 
   override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -39,6 +41,8 @@ class EngineService : Service() {
   override fun onDestroy() {
     watchdog?.shutdownNow()
     watchdog = null
+    // 服务退出即停止日志收集（进程内幂等单例；开关关时也已停）。
+    LogCollector.stop()
     super.onDestroy()
   }
 

--- a/app/src/main/java/com/dshmobile/shell/LogCollector.kt
+++ b/app/src/main/java/com/dshmobile/shell/LogCollector.kt
@@ -1,0 +1,162 @@
+package com.dshmobile.shell
+
+import android.content.Context
+import android.os.Build
+import android.os.Environment
+import android.util.Log
+import java.io.File
+import java.io.RandomAccessFile
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+
+/**
+ * 开发者调试日志收集器（默认关，设置界面「开发者选项」开关控制）：
+ * logcat（本 uid：壳 + 引擎子进程）+ engine.log 增量 → 按天追加写入
+ * Documents/dshdata/log/dsh-<yyyy-MM-dd>.log（未授 MANAGE_EXTERNAL_STORAGE
+ * 回退 filesDir/log/，路径在设置页显示）。单文件超 5MB 轮转为
+ * dsh-<date>.1.log；跨天自动换新文件。进程级单例，start/stop 幂等。
+ *
+ * 隐私：日志含命令与模型内容，仅用于排查；不读取任何凭据文件。
+ */
+object LogCollector {
+
+  private const val TAG = "dsh-log"
+  private const val INTERVAL_MS = 5_000L
+  private const val MAX_FILE_BYTES = 5L * 1024 * 1024
+  private const val MAX_ENGINE_CHUNK = 256 * 1024
+
+  private var executor: ScheduledExecutorService? = null
+  private var appContext: Context? = null
+
+  /** engine.log 增量读取偏移（进程内跟踪；文件被截断/轮转时从头）。 */
+  private var engineLogOffset = 0L
+
+  /** 上一轮 logcat 最后一行时间戳（threadtime "MM-dd HH:mm:ss.SSS" 字典序）。 */
+  private var lastLogcatTs = ""
+
+  fun start(context: Context) {
+    if (executor != null) return
+    appContext = context.applicationContext
+    engineLogOffset = 0L
+    lastLogcatTs = ""
+    executor = Executors.newSingleThreadScheduledExecutor().also { exec ->
+      exec.scheduleWithFixedDelay({ tick() }, 0, INTERVAL_MS, TimeUnit.MILLISECONDS)
+    }
+    Log.i(TAG, "collector started")
+  }
+
+  fun stop() {
+    executor?.shutdownNow()
+    executor = null
+    appContext = null
+    Log.i(TAG, "collector stopped")
+  }
+
+  /**
+   * 壳事件直写日志（不依赖 logcat——MuMu/Android 15 实测 logd 对非特权
+   * app 屏蔽 logcat 读取，即使 --pid 匹配）。仅在收集器启动时落盘；
+   * 引擎启停/崩溃标记/重启等关键事件在发生时经此写入。
+   */
+  fun log(tag: String, message: String) {
+    val ctx = appContext ?: return
+    try {
+      val ts = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US).format(Date())
+      appendToDayFile(ctx, "$ts $tag: $message\n")
+    } catch (t: Throwable) {
+      Log.w(TAG, "event log write failed: " + (t.message ?: t.javaClass.simpleName))
+    }
+  }
+
+  /** 当前日志落盘目录（未授权公共目录时回退私有 filesDir/log）。 */
+  fun currentDir(context: Context): File {
+    val base = if (Build.VERSION.SDK_INT >= 30 && Environment.isExternalStorageManager()) {
+      val docs = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS)
+        ?: File(context.filesDir, "dshdata-fallback")
+      File(File(docs, "dshdata"), "log")
+    } else {
+      File(context.filesDir, "log")
+    }
+    base.mkdirs()
+    return base
+  }
+
+  private fun tick() {
+    val ctx = appContext ?: return
+    try {
+      val sb = StringBuilder()
+      sb.append(readLogcat())
+      sb.append(readEngineLog(ctx))
+      if (sb.isEmpty()) return
+      appendToDayFile(ctx, sb.toString())
+    } catch (t: Throwable) {
+      Log.w(TAG, "collect tick failed: " + (t.message ?: t.javaClass.simpleName))
+    }
+  }
+
+  /**
+   * logcat 增量：Android 13+/MuMu 实测 logd 只放行调用进程自身的日志
+   * （run-as 同 uid 也读不到）——显式 --pid=<壳进程>；引擎日志由
+   * engine.log 增量覆盖（引擎 stdout 重定向），两条源互补。
+   */
+  private fun readLogcat(): String {
+    return try {
+      val proc = ProcessBuilder(
+        "/system/bin/logcat", "-d", "-v", "threadtime",
+        "--pid=" + android.os.Process.myPid(),
+      ).start()
+      val out = proc.inputStream.bufferedReader().readText()
+      proc.waitFor()
+      val sb = StringBuilder()
+      var lastTs = lastLogcatTs
+      for (line in out.lineSequence()) {
+        val ts = line.take(18)
+        if (ts.length == 18 && ts[2] == '-' && ts[8] == ' ' && ts >= lastLogcatTs) {
+          sb.append(line).append('\n')
+          lastTs = ts
+        }
+      }
+      lastLogcatTs = lastTs
+      sb.toString()
+    } catch (t: Throwable) {
+      Log.w(TAG, "logcat read failed: " + (t.message ?: t.javaClass.simpleName))
+      ""
+    }
+  }
+
+  /** engine.log 增量尾部（引擎 stdout 重定向文件）。 */
+  private fun readEngineLog(ctx: Context): String {
+    val f = File(ctx.filesDir, "engine.log")
+    if (!f.exists()) return ""
+    return try {
+      RandomAccessFile(f, "r").use { raf ->
+        if (engineLogOffset > raf.length()) engineLogOffset = 0 // 文件被轮转/截断
+        raf.seek(engineLogOffset)
+        val size = (raf.length() - engineLogOffset).toInt().coerceAtMost(MAX_ENGINE_CHUNK)
+        val buf = ByteArray(size)
+        val n = raf.read(buf)
+        engineLogOffset = raf.filePointer
+        if (n <= 0) "" else String(buf, 0, n, Charsets.UTF_8)
+      }
+    } catch (t: Throwable) {
+      Log.w(TAG, "engine.log tail failed: " + (t.message ?: t.javaClass.simpleName))
+      ""
+    }
+  }
+
+  /** 按天轮转落盘：dsh-<日期>.log；超限轮转为 dsh-<日期>.1.log。 */
+  private fun appendToDayFile(ctx: Context, text: String) {
+    val day = SimpleDateFormat("yyyy-MM-dd", Locale.US).format(Date())
+    val dir = currentDir(ctx)
+    val file = File(dir, "dsh-$day.log")
+    if (file.exists() && file.length() > MAX_FILE_BYTES) {
+      val rotated = File(dir, "dsh-$day.1.log")
+      if (rotated.exists()) rotated.delete()
+      file.renameTo(rotated)
+    }
+    file.appendText(text)
+  }
+}

--- a/app/src/main/java/com/dshmobile/shell/MainActivity.kt
+++ b/app/src/main/java/com/dshmobile/shell/MainActivity.kt
@@ -25,7 +25,9 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.Button
 import android.widget.FrameLayout
+import android.widget.ImageView
 import android.widget.LinearLayout
+import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.activity.ComponentActivity
 import androidx.activity.result.contract.ActivityResultContracts
@@ -44,6 +46,34 @@ class MainActivity : ComponentActivity() {
   private val pickToken: String = EngineManager.ensurePickToken()
   private lateinit var engineStatus: TextView
   private lateinit var progressText: TextView
+  /** 启动/测试双态界面（v0.11.0）：解压进度条、崩溃横幅、engine.log 摘要。 */
+  private lateinit var progressBar: ProgressBar
+  private lateinit var crashBanner: TextView
+  private lateinit var logSummary: TextView
+  /** 崩溃标记：记录未捕获异常摘要，下次启动测试界面提示（不吞异常）。 */
+  private var crashInfo: String? = null
+  /** 重启引擎 in-flight 守卫（防连点双杀双启）。 */
+  private val engineRestarting = java.util.concurrent.atomic.AtomicBoolean(false)
+  /** 前台引擎监控：3s 轮询探测，down→测试界面、up→恢复 WebUI
+   *  （"设置里杀进程/引擎崩溃回退测试界面"的落地；watchdog 负责恢复）。 */
+  private val engineMonitorHandler = android.os.Handler(android.os.Looper.getMainLooper())
+  private val engineMonitorRunnable = object : Runnable {
+    override fun run() {
+      Thread {
+        val running = try { EngineProbe.check(500).optBoolean("running", false) } catch (_: Exception) { false }
+        runOnUiThread {
+          if (!::webView.isInitialized || !::guideView.isInitialized) return@runOnUiThread
+          if (!running && webView.visibility == View.VISIBLE) {
+            engineStatus.text = "引擎未运行，正在自动恢复…"
+            showGuide()
+          } else if (running && guideView.visibility == View.VISIBLE) {
+            showWeb()
+          }
+        }
+        engineMonitorHandler.postDelayed(this, 3000)
+      }.start()
+    }
+  }
   private val engineManager by lazy { EngineManager(this, pickToken) }
   private val engineFlowRunning = java.util.concurrent.atomic.AtomicBoolean(false)
   private var pendingPickCallback: String? = null
@@ -117,6 +147,19 @@ class MainActivity : ComponentActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    // 崩溃标记：进程级未捕获异常写入 filesDir/.crashed（下次启动测试界面
+    // 提示），随后交回默认 handler——只记录，不吞异常、不阻止崩溃。
+    installCrashMarker()
+    val crashFile = File(filesDir, ".crashed")
+    if (crashFile.exists()) {
+      crashInfo = try { crashFile.readText() } catch (_: Exception) { null }
+      crashFile.delete()
+    }
+    // 开发者日志开关已开（上次会话）：进程启动即恢复收集。
+    if (DevLogPrefs.isEnabled(this)) {
+      LogCollector.start(this)
+      LogCollector.log("dsh-shell", "app onCreate (dev log on)")
+    }
     val root = FrameLayout(this)
     webView = WebView(this).apply { id = View.generateViewId() }
     root.addView(webView, FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT))
@@ -134,6 +177,9 @@ class MainActivity : ComponentActivity() {
 
   override fun onResume() {
     super.onResume()
+    // 前台引擎监控：引擎被杀/崩溃时自动回退测试界面，恢复后回 WebUI。
+    engineMonitorHandler.removeCallbacks(engineMonitorRunnable)
+    engineMonitorHandler.post(engineMonitorRunnable)
     // Back from the directory picker / Termux: re-route if the engine came up.
     if (!EngineProbe.check().optBoolean("running", false)) startEngineFlow()
     // 主题补推：从系统设置/SAF 返回时系统主题可能已变（兜底桥时序覆盖）。
@@ -166,6 +212,7 @@ class MainActivity : ComponentActivity() {
 
   override fun onDestroy() {
     super.onDestroy()
+    engineMonitorHandler.removeCallbacks(engineMonitorRunnable)
     pickTtlHandler.removeCallbacks(pickTtlRunnable)
     if (::webView.isInitialized) {
       themeRetryRunnable?.let { webView.removeCallbacks(it) }
@@ -275,6 +322,28 @@ class MainActivity : ComponentActivity() {
             android.content.res.Configuration.UI_MODE_NIGHT_YES
         },
         pickToken = pickToken,
+        onRestartEngine = { restartEngine() },
+        onReloadWebUI = {
+          webView.reload()
+          showTestNotification("界面已刷新", "Web UI 已重新加载")
+        },
+        onOpenConsole = { startActivity(Intent(this, ConsoleActivity::class.java)) },
+        onGetDevLogEnabled = { DevLogPrefs.isEnabled(this) },
+        onSetDevLogEnabled = { enabled ->
+          DevLogPrefs.setEnabled(this, enabled)
+          if (enabled) {
+            LogCollector.start(this)
+            LogCollector.log("dsh-shell", "dev log enabled by user")
+            showTestNotification(
+              "开发者日志已开启",
+              "运行日志按天写入 " + LogCollector.currentDir(this).absolutePath,
+            )
+          } else {
+            LogCollector.log("dsh-shell", "dev log disabled by user")
+            LogCollector.stop()
+            showTestNotification("开发者日志已关闭", "日志收集已停止")
+          }
+        },
       ),
       "androidBridge",
     )
@@ -691,22 +760,65 @@ class MainActivity : ComponentActivity() {
   }
 
   private fun buildGuideView(): LinearLayout {
-    val padding = (24 * resources.displayMetrics.density).toInt()
+    val density = resources.displayMetrics.density
+    val pad = (24 * density).toInt()
     val guide = LinearLayout(this).apply {
       orientation = LinearLayout.VERTICAL
-      setPadding(padding, padding, padding, padding)
+      setPadding(pad, pad, pad, pad)
       gravity = android.view.Gravity.CENTER
       visibility = View.GONE
     }
-    engineStatus = TextView(this).apply { textSize = 16f; setPadding(0, 0, 0, padding) }
-    progressText = TextView(this).apply { textSize = 13f; setPadding(0, 0, 0, padding); visibility = View.GONE }
-    val openTermux = Button(this).apply {
-      text = "打开 Termux"
-      setOnClickListener { launchTermux() }
+    // logo + 标题：启动/测试双态界面的固定头部。
+    val icon = ImageView(this).apply {
+      setImageResource(R.mipmap.ic_launcher)
+      layoutParams = LinearLayout.LayoutParams((64 * density).toInt(), (64 * density).toInt())
+    }
+    val title = TextView(this).apply {
+      text = "DeepSeek Harness"
+      textSize = 20f
+      setPadding(0, (12 * density).toInt(), 0, (4 * density).toInt())
+      gravity = android.view.Gravity.CENTER
+    }
+    // 上次异常退出横幅（崩溃标记存在时显示）。
+    crashBanner = TextView(this).apply {
+      textSize = 12f
+      setTextColor(0xFFF85149.toInt())
+      setPadding(0, (6 * density).toInt(), 0, (10 * density).toInt())
+      gravity = android.view.Gravity.CENTER
+      visibility = View.GONE
+    }
+    engineStatus = TextView(this).apply { textSize = 16f; setPadding(0, 0, 0, pad); gravity = android.view.Gravity.CENTER }
+    // 解压/更新进度条（仅快照刷新时可见）。
+    progressBar = ProgressBar(this, null, android.R.attr.progressBarStyleHorizontal).apply {
+      visibility = View.GONE
+      layoutParams = LinearLayout.LayoutParams(
+        ViewGroup.LayoutParams.MATCH_PARENT, (6 * density).toInt(),
+      )
+    }
+    progressText = TextView(this).apply {
+      textSize = 13f
+      setPadding(0, (8 * density).toInt(), 0, pad)
+      gravity = android.view.Gravity.CENTER
+      visibility = View.GONE
+    }
+    // 失败诊断：engine.log 尾部摘要（测试界面排查用）。
+    logSummary = TextView(this).apply {
+      textSize = 11f
+      setPadding(0, 0, 0, pad)
+      gravity = android.view.Gravity.CENTER
+      visibility = View.GONE
+    }
+    val openConsole = Button(this).apply {
+      text = "打开控制台"
+      setOnClickListener { startActivity(Intent(this@MainActivity, ConsoleActivity::class.java)) }
     }
     val retry = Button(this).apply {
       text = "重试"
       setOnClickListener { startEngineFlow() }
+    }
+    val openTermux = Button(this).apply {
+      text = "打开 Termux"
+      setOnClickListener { launchTermux() }
     }
     val update = Button(this).apply {
       text = "检查运行时更新"
@@ -716,11 +828,30 @@ class MainActivity : ComponentActivity() {
         }
       }
     }
+    fun buttonRow(vararg buttons: Button): LinearLayout {
+      val row = LinearLayout(this).apply {
+        orientation = LinearLayout.HORIZONTAL
+        gravity = android.view.Gravity.CENTER
+        val lp = LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+        lp.setMargins(0, 0, 0, (10 * density).toInt())
+        layoutParams = lp
+      }
+      for (b in buttons) {
+        val blp = LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f)
+        blp.setMargins((6 * density).toInt(), 0, (6 * density).toInt(), 0)
+        row.addView(b, blp)
+      }
+      return row
+    }
+    guide.addView(icon)
+    guide.addView(title)
+    guide.addView(crashBanner)
     guide.addView(engineStatus)
+    guide.addView(progressBar)
     guide.addView(progressText)
-    guide.addView(openTermux)
-    guide.addView(retry)
-    guide.addView(update)
+    guide.addView(logSummary)
+    guide.addView(buttonRow(openConsole, retry))
+    guide.addView(buttonRow(openTermux, update))
     return guide
   }
 
@@ -744,10 +875,17 @@ class MainActivity : ComponentActivity() {
         runOnUiThread { showWeb() }
         return@Thread
       }
+      // 启动即有反馈：进入测试界面显示"正在启动引擎…"（不再白屏等 probe）。
+      runOnUiThread {
+        progressBar.visibility = View.GONE
+        progressText.visibility = View.GONE
+        engineStatus.text = "正在启动引擎…"
+        showGuide()
+      }
       if (!engineManager.snapshotFresh()) {
         runOnUiThread {
+          progressBar.visibility = View.VISIBLE
           progressText.visibility = View.VISIBLE
-          guideView.visibility = View.VISIBLE
           engineStatus.text = "正在更新运行时（约 70MB）…"
         }
         val ok = engineManager.refreshSnapshot { done, total ->
@@ -762,6 +900,11 @@ class MainActivity : ComponentActivity() {
             showGuide()
           }
           return@Thread
+        }
+        runOnUiThread {
+          progressBar.visibility = View.GONE
+          progressText.visibility = View.GONE
+          engineStatus.text = "正在启动引擎…"
         }
       }
       if (!engineManager.startEngine()) {
@@ -837,8 +980,88 @@ class MainActivity : ComponentActivity() {
     webView.reload()
   }
 
+  /** 进入测试界面（引擎失败/未就绪回退）：状态 + 崩溃横幅 + engine.log 摘要。 */
   private fun showGuide() {
     webView.visibility = View.GONE
     guideView.visibility = View.VISIBLE
+    val crash = crashInfo
+    if (crash != null) {
+      crashBanner.visibility = View.VISIBLE
+      crashBanner.text = "上次异常退出：$crash"
+    }
+    val tail = tailEngineLog(8)
+    if (tail.isNotEmpty()) {
+      logSummary.visibility = View.VISIBLE
+      logSummary.text = "engine.log 末尾：\n$tail"
+    } else {
+      logSummary.visibility = View.GONE
+    }
+  }
+
+  /** engine.log 尾部摘要（测试界面诊断用；缺失/不可读返回空）。 */
+  private fun tailEngineLog(lines: Int): String {
+    val f = File(filesDir, "engine.log")
+    if (!f.exists()) return ""
+    return try {
+      f.readLines().takeLast(lines).joinToString("\n")
+    } catch (_: Exception) {
+      ""
+    }
+  }
+
+  /** 进程级崩溃标记：记录未捕获异常摘要，交回默认 handler（不吞异常）。 */
+  private fun installCrashMarker() {
+    val default = Thread.getDefaultUncaughtExceptionHandler()
+    Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+      try {
+        val text = java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss", java.util.Locale.US)
+          .format(java.util.Date()) + " " + throwable.javaClass.name + ": " + (throwable.message ?: "")
+        File(filesDir, ".crashed").writeText(text)
+        LogCollector.log("dsh-shell", "uncaught crash: $text")
+      } catch (_: Exception) {
+      }
+      default?.uncaughtException(thread, throwable)
+    }
+  }
+
+  /**
+   * 重启引擎服务进程（设置界面「重启引擎」）：pkill 引擎 → 重置冷却与
+   * 流程守卫 → 1s 后重新走启动流程（EngineService 看门狗亦会拉起，
+   * 进程级 CAS + 冷却保证双路径幂等）。防连点：in-flight 守卫。
+   */
+  private fun restartEngine() {
+    if (!engineRestarting.compareAndSet(false, true)) return
+    Thread {
+      try {
+        try {
+          Runtime.getRuntime().exec(arrayOf("/system/bin/pkill", "-f", "bin.js")).waitFor()
+        } catch (_: Throwable) {
+        }
+        EngineManager.lastStartAttemptAt = 0
+        engineFlowRunning.set(false)
+        LogCollector.log("dsh-shell", "restart engine requested (pkill)")
+        Thread.sleep(1000)
+        runOnUiThread {
+          showTestNotification("引擎重启中", "引擎进程已结束，正在重新启动…")
+          startEngineFlow()
+        }
+      } finally {
+        engineRestarting.set(false)
+      }
+    }.start()
+  }
+
+  /** 开发者日志开关持久化（私有 SharedPreferences；默认关）。 */
+  object DevLogPrefs {
+    private const val PREFS = "dsh_prefs"
+    private const val KEY_DEV_LOG = "dev_log_enabled"
+
+    fun isEnabled(context: Context): Boolean =
+      context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).getBoolean(KEY_DEV_LOG, false)
+
+    fun setEnabled(context: Context, enabled: Boolean) {
+      context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        .edit().putBoolean(KEY_DEV_LOG, enabled).apply()
+    }
   }
 }


### PR DESCRIPTION
## 变更说明
设置页「开发者选项」（覆盖 #29 全部诉求）+ 启动/测试界面 + 按天调试日志：
- 重启引擎：pkill + 冷却重置 + 1s 后 startEngineFlow（看门狗双路径幂等，~6s 恢复）
- 刷新界面：webView.reload()
- 内置控制台 ConsoleActivity + ConsoleSession：快照 bash（env 与引擎一致），引擎未运行时也可排查
- 开发者调试日志开关（默认关）：壳事件直写 + engine.log 增量 → dshdata/log/ 按天（5MB 轮转，未授权回退私有）
- 启动/测试双态界面（进度条/engine.log 摘要/崩溃横幅/按钮组）+ 前台引擎监控（3s 轮询：down→测试界面，up→WebUI）
- 崩溃标记（setDefaultUncaughtExceptionHandler，不吞异常）
- 修复两个实测 bug：console 输出行缓冲；Process.exitValue() 竞态崩溃
- versionCode 10 / versionName 0.11.0
## 关联 issue
Closes #33
Closes #29
## 测试
- [x] build-release 门禁全链通过（双 ABI：ELF 断言/npm 层/插件注入 hash 一致/安全门禁）
- [x] MuMu 部署实测：开发者选项页/重启引擎 ~6s/刷新界面/控制台交互（echo/uname/pwd/node）/日志按天文件/kill 引擎回退测试界面（崩溃横幅+engine.log 摘要）/自动恢复/启动 UI/退出无崩溃
- [x] 最终 release 产物冒烟（引擎 200 + 开发者选项 nav）
- [ ] arm64 真机待接回复测（清单见 notes.md）
## 破坏性变更
无