### PR TITLE
refactor: 版本号集中到 build.gradle.kts（BuildConfig 单一来源）

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,11 @@ android {
     targetSdk = 34
     versionCode = 17
     versionName = "0.12.3-FX-1"
+    buildConfigField("String", "TERMUX_VERSION", "\"0.118.3\"")
+  }
+
+  buildFeatures {
+    buildConfig = true
   }
 
   androidResources {

--- a/app/src/main/java/com/dshmobile/shell/AndroidBridge.kt
+++ b/app/src/main/java/com/dshmobile/shell/AndroidBridge.kt
@@ -32,7 +32,7 @@ class AndroidBridge(
 ) {
 
   @JavascriptInterface
-  fun version(): String = "1.0"
+  fun version(): String = BuildConfig.VERSION_NAME
 
   /** 系统深色状态同步查询（H1：首帧主题桥启动时拉取真实 uiMode，
    *  绕过厂商 WebView matchMedia 卡 light 的问题）。 */

--- a/app/src/main/java/com/dshmobile/shell/EngineManager.kt
+++ b/app/src/main/java/com/dshmobile/shell/EngineManager.kt
@@ -499,7 +499,7 @@ class EngineManager(private val context: Context, private val pickToken: String?
       "TERMUX__PREFIX" to usrDir.absolutePath,
       "TERMUX_APP__DATA_DIR" to context.filesDir.parentFile.absolutePath,
       "TERMUX_APP__LEGACY_DATA_DIR" to "/data/data/com.dsharnessmobile.shell",
-      "TERMUX_VERSION" to "0.118.3",
+      "TERMUX_VERSION" to BuildConfig.TERMUX_VERSION,
       // 目录选择桥端点鉴权 token（web-compat 插件校验 x-dsh-pick-token）。
       "DSH_PICK_TOKEN" to (pickToken ?: ""),
       // 视觉后端（Qwen-VL）API key：从私有文件读取，避免硬编码进源码。


### PR DESCRIPTION
## 改动内容
版本号此前分散硬编码于多处，现全部收编到 `app/build.gradle.kts` 作为唯一来源：

- 开启 `buildFeatures { buildConfig = true }`（AGP 8 默认关闭）
- `AndroidBridge.version()` 由硬编码 `"1.0"` 改为 `BuildConfig.VERSION_NAME`
- `EngineManager` 的 `TERMUX_VERSION` 改为 `buildConfigField` 注入的 `BuildConfig.TERMUX_VERSION`

以后发版只需改 `versionCode` / `versionName` 一处。

## 提交
- `d440127` refactor: 版本号集中到 build.gradle.kts（BuildConfig 单一来源，桥/TERMUX 版本不再硬编码）