### PR TITLE
chore: 版本号 0.12.5（versionCode 19）

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,10 +14,10 @@ android {
     // (the embedded engine, bash, and every child command would need linker64
     // wrappers); 34 keeps native exec working on Android 15/16 devices.
     targetSdk = 34
-    versionCode = 18
+    versionCode = 19
     // Snapshot builds append a suffix (e.g. -SN-1-RC8) via -PversionNameSuffix; release builds pass none.
     val snapshotSuffix = providers.gradleProperty("versionNameSuffix").getOrElse("")
-    versionName = "0.12.4" + snapshotSuffix
+    versionName = "0.12.5" + snapshotSuffix
     buildConfigField("String", "TERMUX_VERSION", "\"0.118.3\"")
   }
 


### PR DESCRIPTION
## 变更说明
- versionName 0.12.4 → 0.12.5，versionCode 18 → 19
- 集成 #65/#66/#67 修复：插件 client-ui-responsive 0.1.7 / host-web-compat 0.1.6 已合并到 main，CI 构建时按 main 拉取注入

## 关联 issue
Closes #65
Closes #66
Closes #67

## 测试
- [ ] 云端 CI 构建后真机回归（#65/#66/#67）

## 破坏性变更
无