### PR TITLE
fix: 版本号 0.12.4-fx-1（纯修复版）

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,7 +17,7 @@ android {
     versionCode = 19
     // Snapshot builds append a suffix (e.g. -SN-1-RC8) via -PversionNameSuffix; release builds pass none.
     val snapshotSuffix = providers.gradleProperty("versionNameSuffix").getOrElse("")
-    versionName = "0.12.5" + snapshotSuffix
+    versionName = "0.12.4" + snapshotSuffix
     buildConfigField("String", "TERMUX_VERSION", "\"0.118.3\"")
   }
 


### PR DESCRIPTION
## 变更说明
- versionName 基础值改回 0.12.4，CI 以 -PversionNameSuffix=-fx-1 构建 → 0.12.4-fx-1（纯修复版，非正式 0.12.5）
- versionCode 保持 19（可覆盖 vc18）
- 集成插件修复：client-ui-responsive 0.1.7（#65/#67）+ host-web-compat 0.1.6（#66 + 模板转义回归修复）

## 关联 issue
Closes #65
Closes #66
Closes #67

## 测试
- [ ] 云端 CI 构建后真机回归（#65/#66/#67 + 附件隐藏/菜单项回归）

## 破坏性变更
无