### PR TITLE
fix: 版本号 0.12.4-fx-2（versionCode 20）

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,7 +17,7 @@ android {
     versionCode = 20
     // Snapshot builds append a suffix (e.g. -SN-1-RC8) via -PversionNameSuffix; release builds pass none.
     val snapshotSuffix = providers.gradleProperty("versionNameSuffix").getOrElse("")
-    versionName = "0.12.5" + snapshotSuffix
+    versionName = "0.12.4" + snapshotSuffix
     buildConfigField("String", "TERMUX_VERSION", "\"0.118.3\"")
   }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,7 +14,7 @@ android {
     // (the embedded engine, bash, and every child command would need linker64
     // wrappers); 34 keeps native exec working on Android 15/16 devices.
     targetSdk = 34
-    versionCode = 19
+    versionCode = 20
     // Snapshot builds append a suffix (e.g. -SN-1-RC8) via -PversionNameSuffix; release builds pass none.
     val snapshotSuffix = providers.gradleProperty("versionNameSuffix").getOrElse("")
     versionName = "0.12.5" + snapshotSuffix


### PR DESCRIPTION
## 变更说明
- versionCode 19 → 20；versionName 基础 0.12.4（CI -PversionNameSuffix=-fx-2 → 0.12.4-fx-2）
- 集成 ui-responsive 0.1.8：轨迹详情面板展开时提升 ledger stacking context（修复顶部 banner 遮挡 + 对话/轨迹标签与轨迹条未隐藏）

## 关联 issue
Closes #67（补充修复）

## 测试
- [ ] 云端 CI 构建后真机手动回归

## 破坏性变更
无