### PR TITLE
fix: versionCode 21（0.12.4-fx-2 修订）

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,7 +14,7 @@ android {
     // (the embedded engine, bash, and every child command would need linker64
     // wrappers); 34 keeps native exec working on Android 15/16 devices.
     targetSdk = 34
-    versionCode = 20
+    versionCode = 21
     // Snapshot builds append a suffix (e.g. -SN-1-RC8) via -PversionNameSuffix; release builds pass none.
     val snapshotSuffix = providers.gradleProperty("versionNameSuffix").getOrElse("")
     versionName = "0.12.4" + snapshotSuffix


### PR DESCRIPTION
## 变更说明
- versionCode 20 → 21（versionName 保持 0.12.4-fx-2，覆盖已装测试版）
- 集成 ui-responsive 0.1.9：轨迹详情面板覆盖规则限定 aside（修复关闭键失效 + 选项卡/标题重叠挤压）

## 关联 issue
Closes #67（补充修复）

## 测试
- [ ] 云端 CI 构建后真机手动回归

## 破坏性变更
无