### PR TITLE
feat: 适配 DeepSeek-V4-Flash-Vision-Exp（多模态视觉模型）+ 补丁重打（dsh 0.1.1-rc.1）

### DIFF
--- a/app/src/main/assets/patched/attachment-local-index.js
+++ b/app/src/main/assets/patched/attachment-local-index.js
@@ -5,15 +5,22 @@ import { resolveDshHome } from "@deepseek-ai/dsh-home-paths";
 import { createHash, randomUUID } from "node:crypto";
 import { constants } from "node:fs";
 import { chmod, copyFile, link, mkdir, open, readFile, unlink } from "node:fs/promises";
-// attachment-lazy-sharp: sharp has no android runtime; load lazily so the
-// engine boots on android (image processing degrades there).
-// NOTE: must NOT `await import("sharp")` anywhere in this module — ESM resolves
-// the whole module graph at top-level await, which pulls sharp + its wasm
-// backend (@img/sharp-wasm32 → @emnapi/runtime) during load and crashes the
-// engine. Android has no sharp runtime at all, so the image pipeline degrades
-// to IMAGE_PROCESSING_UNAVAILABLE without ever touching the sharp package.
-function requireSharp() {
-  throw new AttachmentError("Image processing unavailable on this platform", "IMAGE_PROCESSING_UNAVAILABLE");
+// attachment-lazy-sharp: sharp pulls a platform-specific native backend; on
+// Android the only viable one is the WASM build (@img/sharp-wasm32, bundled
+// self-contained). Load it lazily — never at module load — so the engine
+// boots regardless of the backend; on first image use the dynamic import is
+// attempted, and a missing/failing backend degrades to
+// IMAGE_PROCESSING_UNAVAILABLE instead of crashing the engine.
+let sharpModule = void 0;
+async function requireSharp() {
+	if (sharpModule === void 0) {
+		try {
+			sharpModule = await import("sharp");
+		} catch (error) {
+			throw new AttachmentError("Image processing unavailable on this platform", "IMAGE_PROCESSING_UNAVAILABLE", { cause: error });
+		}
+	}
+	return sharpModule.default;
 }
 //#region lib/types/image.js
 /** Raster inspection: full decode at admission, header-only probe on verified reads. */
@@ -43,7 +50,7 @@ async function imageMetadata(image) {
 */
 async function probeImage(data) {
 	try {
-		return await imageMetadata(requireSharp()(data, {
+		return await imageMetadata((await requireSharp())(data, {
 			failOn: "error",
 			limitInputPixels: false
 		}));
@@ -60,7 +67,7 @@ async function probeImage(data) {
 */
 async function detectImage(data, limits) {
 	try {
-		const image = requireSharp()(data, {
+		const image = (await requireSharp())(data, {
 			failOn: "error",
 			limitInputPixels: false
 		});
@@ -127,11 +134,22 @@ async function syncDirectory(path) {
 	/* v8 ignore next -- Windows cannot open directory handles; NTFS metadata journaling owns entry durability there. */
 	if (process.platform === "win32") return;
 	/* v8 ignore start -- Windows cannot exercise directory fsync; POSIX behavior tests enforce this peer. */
-	const handle = await open(path, constants.O_RDONLY);
+	let handle;
 	try {
+		handle = await open(path, constants.O_RDONLY);
 		await handle.sync();
+	} catch (error) {
+		// Android: the app cannot open ancestor dirs above its data dir
+		// (EACCES/EPERM on /data/user/0 — sepolicy blocks the untrusted_app
+		// domain). Durability of those ancestors is the platform's concern;
+		// skip the sync rather than fail the save.
+		// (attachment-ancestor-sync-eacces-tolerance)
+		if (error !== null && (error.code === "EACCES" || error.code === "EPERM")) return;
+		throw error;
 	} finally {
-		await handle.close();
+		try {
+			await handle?.close();
+		} catch {}
 	}
 	/* v8 ignore stop */
 }

--- a/app/src/main/assets/patched/fs-local-index.js
+++ b/app/src/main/assets/patched/fs-local-index.js
@@ -1,0 +1,827 @@
+import { constants } from "node:buffer";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep, toNamespacedPath } from "node:path";
+import { pathToFileURL } from "node:url";
+import z from "@deepseek-ai/schemastery";
+import { FileSystem, FsError, FsTargetKey, FsVersion } from "@deepseek-ai/dsh-fs";
+import { randomUUID } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { chmod, link, lstat, mkdir, open, readFile, readdir, realpath, rename, rm, stat } from "node:fs/promises";
+import { TextDecoder } from "node:util";
+//#region lib/types/win32.js
+/**
+* Windows security-descriptor helpers for atomic local-file replacement. Koffi loads lazily so
+* non-Windows processes never open Win32 libraries.
+* @module @deepseek-ai/dsh-fs-local/win32
+*/
+const DACL_SECURITY_INFORMATION = 4;
+const ERROR_FILE_NOT_FOUND = 2;
+const ERROR_PATH_NOT_FOUND = 3;
+const ERROR_ACCESS_DENIED = 5;
+let bindings;
+async function win32() {
+	if (bindings !== void 0) return bindings;
+	const koffi = (await import("koffi")).default;
+	const advapi32 = koffi.load("advapi32.dll");
+	const kernel32 = koffi.load("kernel32.dll");
+	bindings = {
+		getFileSecurityW: advapi32.func("int __stdcall GetFileSecurityW(const char16_t *path, uint32_t requested, void *descriptor, uint32_t length, _Out_ uint32_t *needed)"),
+		setFileSecurityW: advapi32.func("int __stdcall SetFileSecurityW(const char16_t *path, uint32_t information, const void *descriptor)"),
+		replaceFileW: kernel32.func("int __stdcall ReplaceFileW(const char16_t *replaced, const char16_t *replacement, const char16_t *backup, uint32_t flags, void *exclude, void *reserved)"),
+		getLastError: kernel32.func("uint32_t __stdcall GetLastError()")
+	};
+	return bindings;
+}
+function errnoCode(win32Code) {
+	switch (win32Code) {
+		case ERROR_FILE_NOT_FOUND:
+		case ERROR_PATH_NOT_FOUND: return "ENOENT";
+		case ERROR_ACCESS_DENIED: return "EACCES";
+		default: return "EIO";
+	}
+}
+function win32Error(syscall, win32Code, path) {
+	const code = errnoCode(win32Code);
+	const error = /* @__PURE__ */ new Error(`${syscall} ${code} (Win32 ${win32Code}): ${path}`);
+	error.code = code;
+	error.errno = win32Code;
+	error.syscall = syscall;
+	error.path = path;
+	error.win32Code = win32Code;
+	return error;
+}
+/**
+* Read a file's self-relative DACL security descriptor.
+* @param path - existing file whose DACL is read.
+* @returns a descriptor buffer accepted by `SetFileSecurityW`.
+*/
+async function readFileDaclWin32(path) {
+	const api = await win32();
+	const nativePath = toNamespacedPath(path);
+	const needed = [0];
+	api.getFileSecurityW(nativePath, DACL_SECURITY_INFORMATION, null, 0, needed);
+	if (needed[0] === 0) throw win32Error("GetFileSecurityW", api.getLastError(), path);
+	const descriptor = Buffer.alloc(needed[0]);
+	if (api.getFileSecurityW(nativePath, DACL_SECURITY_INFORMATION, descriptor, descriptor.length, needed) === 0) throw win32Error("GetFileSecurityW", api.getLastError(), path);
+	return descriptor.subarray(0, needed[0]);
+}
+/**
+* Copy an existing file's DACL onto another file and protect it from staging-parent inheritance.
+* The destination must still be empty when confidentiality depends on this call.
+* @param source - existing file whose DACL is copied.
+* @param destination - existing file that receives the protected DACL.
+*/
+async function copyFileDaclWin32(source, destination) {
+	const descriptor = await readFileDaclWin32(source);
+	const api = await win32();
+	if (api.setFileSecurityW(toNamespacedPath(destination), 2147483652, descriptor) === 0) throw win32Error("SetFileSecurityW", api.getLastError(), destination);
+}
+/**
+* Replace a Windows file while preserving the replaced file's ACL and other replace metadata.
+* @param replaced - existing destination file.
+* @param replacement - closed staging file on the same volume.
+*/
+async function replaceFileWin32(replaced, replacement) {
+	const api = await win32();
+	if (api.replaceFileW(toNamespacedPath(replaced), toNamespacedPath(replacement), null, 0, null, null) === 0) throw win32Error("ReplaceFileW", api.getLastError(), replaced);
+}
+//#endregion
+//#region lib/types/fsio.js
+/**
+* Cordis-free local filesystem mechanics. This provider layer returns validated UTF-8 text,
+* streams large files, and rejects binary data; line windows belong to `dsh-tool-fs`. Writes
+* stage an exclusive owner-only file in a private sibling directory and atomically publish it.
+* @module @deepseek-ai/dsh-fs-local/fsio
+*/
+const BINARY_SAMPLE_BYTES = 8192;
+const DIFF_BASIS_READ_CHUNK_BYTES = 64 * 1024;
+function isENOENT(error) {
+	return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+function isEEXIST(error) {
+	return error instanceof Error && "code" in error && error.code === "EEXIST";
+}
+/**
+* A path component that is expected to be a directory is a regular file (e.g.
+* resolving `afile/child.txt` when `afile` is a file). Like `ENOENT`, the target
+* cannot exist — so the resolution/probe paths treat it as "absent" rather than
+* letting a raw Node error escape without the structured `FsError` taxonomy.
+*/
+function isENOTDIR(error) {
+	return error instanceof Error && "code" in error && error.code === "ENOTDIR";
+}
+function isAbortError(error) {
+	return error instanceof Error && error.name === "AbortError";
+}
+/* v8 ignore start -- composes secondary cleanup-failure messages, which require a filesystem/kernel fault after the primary failure. */
+function errorMessage(error) {
+	return error instanceof Error ? error.message : String(error);
+}
+/* v8 ignore stop */
+function isPermissionError(error) {
+	return error instanceof Error && "code" in error && (error.code === "EACCES" || error.code === "EPERM");
+}
+function throwIfAborted(signal, verb) {
+	if (signal?.aborted) throw new FsError(`${verb} aborted`, "FS_ABORTED");
+}
+/**
+* `readFile` with the supplied signal, translating a mid-read `AbortError` into
+* the seam's structured `FsError('FS_ABORTED')` (Node rejects an aborted
+* `readFile` with a bare `AbortError`, which would otherwise escape the seam's
+* error taxonomy — the streaming/write paths translate it the same way).
+*/
+async function readFileAbortable(absolutePath, verb, signal) {
+	try {
+		return await readFile(absolutePath, signal ? { signal } : {});
+	} catch (error) {
+		/* v8 ignore next 2 -- a non-abort readFile rejection needs a permission/IO fault racing an open file. */
+		if (!isAbortError(error)) throw error;
+		throw new FsError(`${verb} aborted`, "FS_ABORTED");
+	}
+}
+/** Opaque version token from high-resolution identity and freshness metadata. */
+function versionOf(info) {
+	return FsVersion(`${info.dev}:${info.ino}:${info.size}:${info.mtimeNs}:${info.ctimeNs}`);
+}
+/**
+* Resolve a path to its absolute display path and realpath identity. For a missing target,
+* realpath the nearest existing ancestor and append the missing suffix, preserving identity
+* across symlinked ancestors before and after creation.
+* @param cwd - base directory a relative `path` resolves against.
+* @param path - absolute or relative path; empty/whitespace-only throws `FS_NOT_FOUND`.
+* @returns the absolute display path plus the realpath-derived stable target key.
+*/
+async function resolveLocalTarget(cwd, path) {
+	if (path.trim().length === 0) throw new FsError("file_path must be a non-empty string", "FS_NOT_FOUND");
+	const displayPath = resolve(cwd, path);
+	try {
+		return {
+			displayPath,
+			targetKey: FsTargetKey(await realpath(displayPath))
+		};
+	} catch (error) {
+		/* v8 ignore next -- Windows reports this case as ENOENT and repairs it in the ancestor walk below. */
+		if (isENOTDIR(error)) throw new FsError(`cannot resolve "${displayPath}": a parent path segment is not a directory`, "FS_NOT_FOUND");
+		/* v8 ignore next -- non-ENOENT realpath failure needs a permission/IO fault; ENOENT falls through to ancestor resolution. */
+		if (!isENOENT(error)) throw error;
+	}
+	const missing = [basename(displayPath)];
+	let ancestor = dirname(displayPath);
+	while (true) try {
+		const realAncestor = await realpath(ancestor);
+		/* v8 ignore start -- native Windows coverage exercises this repair; POSIX reports ENOTDIR before this point. */
+		if (process.platform === "win32") {
+			if (!(await stat(realAncestor)).isDirectory()) throw new FsError(`cannot resolve "${displayPath}": a parent path segment is not a directory`, "FS_NOT_FOUND");
+		}
+		/* v8 ignore stop */
+		return {
+			displayPath,
+			targetKey: FsTargetKey(join(realAncestor, ...missing))
+		};
+	} catch (error) {
+		/* v8 ignore next -- native Windows coverage exercises the FsError raised by the repair above. */
+		if (error instanceof FsError) throw error;
+		/* v8 ignore next -- a non-ENOENT realpath failure needs a permission/IO fault. */
+		if (!isENOENT(error)) throw error;
+		const parent = dirname(ancestor);
+		/* v8 ignore next -- the filesystem root always realpaths, so the walk terminates before parent === ancestor. */
+		if (parent === ancestor) return {
+			displayPath,
+			targetKey: FsTargetKey(displayPath)
+		};
+		missing.unshift(basename(ancestor));
+		ancestor = parent;
+	}
+}
+function pathType(info) {
+	if (info.isFile()) return "file";
+	/* v8 ignore else -- Windows has no special-entry fixture for the non-directory branch. */
+	if (info.isDirectory()) return "directory";
+	/* v8 ignore next -- the corresponding special-entry return is covered on POSIX. */
+	return "other";
+}
+function pathLinkType(info) {
+	if (info.isSymbolicLink()) return "symlink";
+	return pathType(info);
+}
+async function probeStats(absolutePath, readStats) {
+	try {
+		return await readStats(absolutePath);
+	} catch (error) {
+		/* v8 ignore next -- a non-ENOENT/ENOTDIR metadata failure needs a permission/IO fault; surface it. */
+		if (!isENOENT(error) && !isENOTDIR(error)) throw error;
+		return null;
+	}
+}
+/**
+* Probe a path for its version, mode, type, and size. Null if absent.
+* @param absolutePath - the path to stat (typically a target key; symlinks are followed).
+* @returns the metadata, or null when the path — or a parent segment — does not exist.
+*/
+async function probe(absolutePath) {
+	const info = await probeStats(absolutePath, (path) => stat(path, { bigint: true }));
+	if (!info) return null;
+	return {
+		version: versionOf(info),
+		mode: Number(info.mode & 511n),
+		type: pathType(info),
+		size: Number(info.size)
+	};
+}
+/**
+* Probe a path without following the final symlink component.
+* @param absolutePath - the path entry to inspect with `lstat` semantics.
+* @returns path-entry metadata, or null when the entry is absent.
+*/
+async function probeNoFollow(absolutePath) {
+	const info = await probeStats(absolutePath, (path) => lstat(path, { bigint: true }));
+	if (!info) return null;
+	return {
+		version: versionOf(info),
+		mode: Number(info.mode & 511n),
+		type: pathLinkType(info),
+		size: Number(info.size)
+	};
+}
+function listingIoError(displayPath, error) {
+	/* v8 ignore next -- defensive pass-through for races where a child resolver has already produced a structured FsError. */
+	if (error instanceof FsError) return error;
+	/* v8 ignore next -- requires the listed target/parent to disappear between successful preflight and listing/child resolution. */
+	if (isENOENT(error) || isENOTDIR(error)) return new FsError(`cannot list "${displayPath}": not found`, "FS_NOT_FOUND", { cause: error });
+	/* v8 ignore next -- Windows chmod does not deny directory listing; POSIX covers permission translation. */
+	if (isPermissionError(error)) return new FsError(`cannot list "${displayPath}": permission denied`, "FS_PERMISSION_DENIED", { cause: error });
+	return new FsError(`cannot list "${displayPath}": ${errorMessage(error)}`, "FS_IO_ERROR", { cause: error });
+}
+async function resolveListedChildTarget(parent, name) {
+	const identity = await resolveLocalTarget(parent.targetKey, name);
+	return {
+		displayPath: join(parent.displayPath, name),
+		targetKey: identity.targetKey
+	};
+}
+/**
+* List direct children of a directory in stable name order. Each child includes
+* a resolved target plus stat metadata when still available; file contents are
+* never read.
+* @param target - the resolved directory to list; a missing or non-directory target throws.
+* @param signal - aborts the listing, checked between children (`FS_ABORTED`).
+* @returns one entry per direct child, sorted by name.
+*/
+async function listDirectory(target, signal) {
+	throwIfAborted(signal, "list");
+	let info;
+	try {
+		info = await probe(target.targetKey);
+	} catch (error) {
+		throw listingIoError(target.displayPath, error);
+	}
+	if (!info) throw new FsError(`cannot list "${target.displayPath}": not found`, "FS_NOT_FOUND");
+	if (info.type !== "directory") throw new FsError(`cannot list "${target.displayPath}": not a directory`, "FS_NOT_DIRECTORY");
+	let entries;
+	try {
+		entries = await readdir(target.targetKey, {
+			withFileTypes: true,
+			encoding: "utf8"
+		});
+	} catch (error) {
+		/* v8 ignore next -- requires permission/kernel failure from readdir after a successful directory stat. */
+		throw listingIoError(target.displayPath, error);
+	}
+	throwIfAborted(signal, "list");
+	const result = [];
+	for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+		throwIfAborted(signal, "list");
+		try {
+			const childTarget = await resolveListedChildTarget(target, entry.name);
+			const childInfo = await probe(childTarget.targetKey);
+			result.push({
+				name: entry.name,
+				type: childInfo?.type ?? "other",
+				target: childTarget,
+				...childInfo ? { version: childInfo.version } : {},
+				...childInfo?.type === "file" ? { size: childInfo.size } : {}
+			});
+		} catch (error) {
+			throw listingIoError(join(target.displayPath, entry.name), error);
+		}
+		throwIfAborted(signal, "list");
+	}
+	return result;
+}
+function notTextError(verb, displayPath) {
+	return new FsError(`cannot ${verb} "${displayPath}": invalid UTF-8 text`, "FS_NOT_TEXT");
+}
+function decodeUtf8(buffer, verb, displayPath) {
+	try {
+		return new TextDecoder("utf-8", { fatal: true }).decode(buffer);
+	} catch (error) {
+		/* v8 ignore next 2 -- TextDecoder({fatal}) only throws TypeError on invalid bytes; any other throw is an unreachable runtime fault. */
+		if (!(error instanceof TypeError)) throw error;
+		throw notTextError(verb, displayPath);
+	}
+}
+function decodeUtf8Stream(decoder, chunk, verb, displayPath) {
+	try {
+		return chunk ? decoder.decode(chunk, { stream: true }) : decoder.decode();
+	} catch (error) {
+		/* v8 ignore next 2 -- TextDecoder({fatal}) only throws TypeError on invalid bytes; any other throw is an unreachable runtime fault. */
+		if (!(error instanceof TypeError)) throw error;
+		throw notTextError(verb, displayPath);
+	}
+}
+async function statRegularFile(target, verb, signal) {
+	throwIfAborted(signal, verb);
+	let info;
+	try {
+		info = await stat(target.targetKey);
+	} catch (error) {
+		/* v8 ignore next 2 -- a non-ENOENT stat failure needs a permission/IO fault; only the not-found path is reachable in tests. */
+		if (!isENOENT(error)) throw error;
+		throw new FsError(`cannot ${verb} "${target.displayPath}": not found`, "FS_NOT_FOUND");
+	}
+	if (!info.isFile()) throw new FsError(`cannot ${verb} "${target.displayPath}": not a regular file`, "FS_NOT_REGULAR_FILE");
+	return info;
+}
+/**
+* Read a whole regular UTF-8 text file into a single decoded string. Rejects
+* non-regular files, invalid UTF-8, and NUL-byte binary samples.
+* @param target - the resolved file to read.
+* @param signal - aborts the read (`FS_ABORTED`).
+* @returns the full decoded text, byte-for-byte (no normalization).
+*/
+async function readWholeText(target, signal) {
+	await statRegularFile(target, "read", signal);
+	const raw = await readFileAbortable(target.targetKey, "read", signal);
+	throwIfAborted(signal, "read");
+	if (raw.subarray(0, BINARY_SAMPLE_BYTES).includes(0)) throw new FsError(`cannot read "${target.displayPath}": binary file`, "FS_NOT_TEXT");
+	return decodeUtf8(raw, "read", target.displayPath);
+}
+/**
+* Read a whole regular file as raw bytes with no decoding or binary rejection.
+* `maxBytes` bounds the complete content: the stat size short-circuits an
+* oversized file before any content I/O, and the stream reads at most one byte
+* beyond the cap so a file growing after stat cannot cause unbounded buffering.
+* @param target - the resolved file to read.
+* @param signal - aborts the read (`FS_ABORTED`).
+* @param maxBytes - inclusive byte cap on the complete content (`FS_TOO_LARGE`).
+* @param internals - test seam for a deterministic post-stat growth race.
+* @returns the full raw content, at most `maxBytes` long.
+*/
+async function readWholeBytes(target, signal, maxBytes, internals = {}) {
+	const info = await statRegularFile(target, "read", signal);
+	if (info.size > maxBytes) throw new FsError(`cannot read "${target.displayPath}": ${info.size} bytes exceeds the ${maxBytes}-byte limit`, "FS_TOO_LARGE");
+	await internals.inspectReadBytesAfterStat?.(target);
+	const stream = createReadStream(target.targetKey, {
+		end: maxBytes,
+		...signal ? { signal } : {}
+	});
+	const chunks = [];
+	let bytes = 0;
+	try {
+		for await (const chunk of stream) {
+			bytes += chunk.length;
+			if (bytes > maxBytes) throw new FsError(`cannot read "${target.displayPath}": content exceeds the ${maxBytes}-byte limit`, "FS_TOO_LARGE");
+			chunks.push(chunk);
+		}
+	} catch (error) {
+		/* v8 ignore next 2 -- a mid-stream abort needs cancellation racing an active read; pre-abort is deterministic. */
+		if (isAbortError(error)) throw new FsError("read aborted", "FS_ABORTED");
+		throw error;
+	}
+	return Buffer.concat(chunks, bytes);
+}
+/**
+* Stream a whole regular UTF-8 text file as decoded text chunks. Same text
+* semantics as {@link readWholeText} (regular-file check, binary/NUL rejection,
+* cross-chunk UTF-8 decoding), but never holds the whole file in memory.
+* @param target - the resolved file to stream.
+* @param signal - aborts the stream, including between chunks (`FS_ABORTED`).
+* @returns decoded text chunks in file order; chunk boundaries carry no meaning.
+*/
+async function* streamWholeText(target, signal) {
+	await statRegularFile(target, "read", signal);
+	const stream = createReadStream(target.targetKey, signal ? { signal } : {});
+	const decoder = new TextDecoder("utf-8", { fatal: true });
+	let sampledBytes = 0;
+	function scanBinarySample(chunk) {
+		if (sampledBytes >= BINARY_SAMPLE_BYTES) return;
+		const sample = chunk.subarray(0, Math.min(chunk.length, BINARY_SAMPLE_BYTES - sampledBytes));
+		if (sample.includes(0)) throw new FsError(`cannot read "${target.displayPath}": binary file`, "FS_NOT_TEXT");
+		sampledBytes += sample.length;
+	}
+	try {
+		for await (const chunk of stream) {
+			scanBinarySample(chunk);
+			yield decodeUtf8Stream(decoder, chunk, "read", target.displayPath);
+		}
+		yield decodeUtf8Stream(decoder, void 0, "read", target.displayPath);
+	} catch (error) {
+		/* v8 ignore next 4 -- mid-stream errors need an abort/IO fault racing the loop; pre-abort is caught by throwIfAborted. */
+		if (isAbortError(error)) throw new FsError("read aborted", "FS_ABORTED");
+		throw error;
+	}
+}
+async function removeStagingDirOrThrow(stagingDir, originalError, removeStagingDir) {
+	try {
+		await removeStagingDir(stagingDir);
+	} catch (cleanupError) {
+		/* v8 ignore next 1 -- cleanup failure here needs a second filesystem fault after the primary write failure. */
+		throw new FsError(`write failed (${errorMessage(originalError)}) and temp cleanup failed (${errorMessage(cleanupError)})`, "FS_NOT_FOUND", { cause: originalError });
+	}
+	throw originalError;
+}
+async function throwGuardedCreateFailure(error, absolutePath, displayPath, inspectPublicationTarget) {
+	let existing;
+	try {
+		existing = await inspectPublicationTarget(absolutePath);
+	} catch (metadataError) {
+		if (!isENOENT(metadataError) && !isENOTDIR(metadataError)) throw new FsError(`cannot write "${displayPath}": ${errorMessage(metadataError)}`, "FS_IO_ERROR", { cause: metadataError });
+	}
+	if (existing !== void 0) {
+		if (!existing.isFile()) throw new FsError(`cannot write "${displayPath}": not a regular file`, "FS_NOT_REGULAR_FILE", { cause: error });
+		throw new FsError(`cannot overwrite existing "${displayPath}" without reading it first`, "FS_NOT_OBSERVED", { cause: error });
+	}
+	if (isEEXIST(error)) throw new FsError(`cannot overwrite existing "${displayPath}" without reading it first`, "FS_NOT_OBSERVED", { cause: error });
+	throw new FsError(`cannot write "${displayPath}": ${errorMessage(error)}`, "FS_IO_ERROR", { cause: error });
+}
+/**
+* Atomically replace a file through a private, synced staging file in the same directory.
+* POSIX protects the staging directory and file with `0o700` and `0o600`. A new Windows file
+* inherits the destination directory's DACL; a replacement copies the existing target's DACL
+* onto the empty temp before writing and preserves the target descriptor at publication.
+* @param absolutePath - destination; missing parent directories are created.
+* @param content - the full UTF-8 text to write.
+* @param mode - existing destination's POSIX mode to preserve, or `undefined` for a new file;
+* inert as a mode on Windows but identifies replacement security semantics.
+* @param signal - cancellation checked before final publication.
+* @param internals - Test hook for pinning temp names and observing the staged file.
+* @param createIfAbsent - when provided, publish with a hard-link no-replace
+* primitive; a concurrent creator's file is preserved and this write is
+* rejected with `FS_NOT_OBSERVED` using the supplied display path.
+*/
+async function writeFileAtomic(absolutePath, content, mode, signal, internals = {}, createIfAbsent) {
+	throwIfAborted(signal, "write");
+	const directory = dirname(absolutePath);
+	await mkdir(directory, { recursive: true });
+	throwIfAborted(signal, "write");
+	const stagingDir = join(directory, internals.tempDirName?.(absolutePath) ?? `.${basename(absolutePath)}.${process.pid}.${randomUUID()}.tmpdir`);
+	const tempPath = join(stagingDir, internals.tempName?.(absolutePath) ?? `${basename(absolutePath)}.tmp`);
+	const platform = internals.platform ?? process.platform;
+	const copyFileDacl = internals.copyFileDacl ?? copyFileDaclWin32;
+	const replaceFile = internals.replaceFile ?? replaceFileWin32;
+	const linkFile = internals.linkFile ?? link;
+	const inspectPublicationTarget = internals.inspectPublicationTarget ?? ((path) => lstat(path, { bigint: true }));
+	const removeStagingDir = internals.removeStagingDir ?? ((path) => rm(path, {
+		recursive: true,
+		force: true
+	}));
+	let handle;
+	let stagingCreated = false;
+	try {
+		await mkdir(stagingDir, { mode: 448 });
+		stagingCreated = true;
+		await chmod(stagingDir, 448);
+		handle = await open(tempPath, "wx", 384);
+		await handle.chmod(384);
+		if (platform === "win32" && mode !== void 0) await copyFileDacl(absolutePath, tempPath);
+		await handle.writeFile(content, {
+			encoding: "utf8",
+			...signal ? { signal } : {}
+		});
+		await handle.sync();
+		await internals.inspectTemp?.({
+			stagingDir,
+			tempPath
+		});
+		if (mode !== void 0) await handle.chmod(mode);
+		await handle.close();
+		handle = void 0;
+		throwIfAborted(signal, "write");
+		if (createIfAbsent !== void 0) try {
+			// android-link-eacces-fallback: Android app domains forbid link(2)
+			// (sepolicy; Huawei/HarmonyOS observed), fall back to rename when
+			// the target is still absent — exactly like dsh 0.1.0-rc.8 did.
+			await linkFile(tempPath, absolutePath).catch(function (e) { if (e.code !== "EACCES" && e.code !== "EPERM" && e.code !== "ENOTSUP") throw e; return lstat(absolutePath).then(function () { throw e; }, function (e2) { if (e2.code !== "ENOENT") throw e2; return rename(tempPath, absolutePath); }); });
+		} catch (error) {
+			await throwGuardedCreateFailure(error, absolutePath, createIfAbsent.displayPath, inspectPublicationTarget);
+		}
+		else if (platform === "win32" && mode !== void 0) try {
+			await replaceFile(absolutePath, tempPath);
+		} catch (error) {
+			if (!isENOENT(error)) throw error;
+			await rename(tempPath, absolutePath);
+		}
+		else await rename(tempPath, absolutePath);
+		try {
+			await removeStagingDir(stagingDir);
+		} catch (_committedStagingCleanupFailure) {}
+	} catch (error) {
+		/* v8 ignore next -- abort-mid-write needs a writeFile/signal race; the non-abort (rename/open) side is tested. */
+		let failure = isAbortError(error) ? new FsError("write aborted", "FS_ABORTED") : error;
+		/* v8 ignore next 8 -- reached only if writeFile/sync throws with the handle open (IO fault); close-failure is a double fault. */
+		if (handle) try {
+			await handle.close();
+		} catch (closeError) {
+			failure = new FsError(`write failed (${errorMessage(failure)}) and temp close failed (${errorMessage(closeError)})`, "FS_NOT_FOUND", { cause: failure });
+		}
+		if (!stagingCreated) throw failure;
+		return removeStagingDirOrThrow(stagingDir, failure, removeStagingDir);
+	}
+}
+/**
+* Collapse CRLF to LF — the canonical in-memory form every edit/diff basis
+* uses. Lone `\r` bytes (not followed by `\n`) are left untouched.
+* @param content - decoded text in whatever line-ending style the file had.
+* @returns the text with every `\r\n` pair replaced by `\n`.
+*/
+function normalizeLineEndings(content) {
+	return content.replaceAll("\r\n", "\n");
+}
+function detectLineEndings(raw) {
+	const sample = raw.slice(0, 4096);
+	const crlfCount = sample.split("\r\n").length - 1;
+	return crlfCount > sample.split("\n").length - 1 - crlfCount ? "CRLF" : "LF";
+}
+/**
+* Convert LF-normalized content back to the line-ending style detected at read
+* time, for write-back. `LF` returns the content unchanged; `CRLF` re-normalizes
+* first so an already-CRLF sequence is never doubled to `\r\r\n`.
+* @param content - the LF-normalized (edited) text.
+* @param lineEndings - the original file's style, as detected by {@link readForEdit}.
+* @returns the text in the original file's line-ending style.
+*/
+function restoreLineEndings(content, lineEndings) {
+	return lineEndings === "LF" ? content : normalizeLineEndings(content).split("\n").join("\r\n");
+}
+function countOccurrences(content, needle) {
+	let count = 0;
+	let index = 0;
+	while (true) {
+		const found = content.indexOf(needle, index);
+		if (found === -1) return count;
+		count += 1;
+		index = found + needle.length;
+	}
+}
+/**
+* Read and decode a file for editing: rejects binaries, returns LF-normalized
+* content plus the original line-ending style for write-back.
+* @param absolutePath - the file to read (typically a target key).
+* @param displayPath - the caller-facing path used in error messages.
+* @param signal - aborts the read (`FS_ABORTED`).
+* @returns the LF-normalized content and the detected style to restore on write-back.
+*/
+async function readForEdit(absolutePath, displayPath, signal) {
+	throwIfAborted(signal, "edit");
+	const buffer = await readFileAbortable(absolutePath, "edit", signal);
+	throwIfAborted(signal, "edit");
+	if (buffer.includes(0)) throw new FsError(`cannot edit "${displayPath}": binary file`, "FS_NOT_TEXT");
+	const raw = decodeUtf8(buffer, "edit", displayPath);
+	return {
+		content: normalizeLineEndings(raw),
+		lineEndings: detectLineEndings(raw)
+	};
+}
+/**
+* Best-effort overwrite diff basis. Binary, invalid UTF-8, a file at/above the byte limit,
+* or a file deleted/made unreadable after the caller's preflight returns `null` so the write
+* still succeeds and presentation falls back to a whole-file diff. The bound is enforced on
+* the opened descriptor rather than a prior path stat, so concurrent external replacement or
+* size changes cannot make this helper buffer more than `maxBytes`.
+* @param absolutePath - the file to read (typically a target key).
+* @param maxBytes - exclusive upper bound for bytes held as the contextual-diff basis.
+* @param signal - aborts the read (`FS_ABORTED`); cancellation propagates, unlike I/O failure.
+* @returns the LF-normalized text, or null for a non-regular, at/above-limit, binary, non-UTF-8,
+* descriptor-size-changed, or unreadable file.
+*/
+async function readTextForDiff(absolutePath, maxBytes, signal) {
+	throwIfAborted(signal, "read");
+	try {
+		const handle = await open(absolutePath, "r");
+		let buffer;
+		let total = 0;
+		let openedSize = 0;
+		try {
+			throwIfAborted(signal, "read");
+			const info = await handle.stat();
+			throwIfAborted(signal, "read");
+			if (!info.isFile()) return null;
+			if (info.size >= maxBytes) return null;
+			openedSize = info.size;
+			buffer = Buffer.allocUnsafe(openedSize + 1);
+			while (total < buffer.length) {
+				throwIfAborted(signal, "read");
+				const length = Math.min(buffer.length - total, DIFF_BASIS_READ_CHUNK_BYTES);
+				const { bytesRead } = await handle.read(buffer, total, length, null);
+				if (bytesRead === 0) break;
+				total += bytesRead;
+			}
+		} finally {
+			await handle.close();
+		}
+		throwIfAborted(signal, "read");
+		if (total !== openedSize) return null;
+		const basis = buffer.subarray(0, total);
+		if (basis.includes(0)) return null;
+		try {
+			return normalizeLineEndings(new TextDecoder("utf-8", { fatal: true }).decode(basis));
+		} catch (error) {
+			/* v8 ignore next 2 -- TextDecoder({fatal}) only throws TypeError on invalid bytes;
+			* any other throw is an unreachable runtime fault. */
+			if (!(error instanceof TypeError)) throw error;
+			return null;
+		}
+	} catch (error) {
+		if (error instanceof FsError) throw error;
+		if (error instanceof Error && "code" in error) return null;
+		throw error;
+	}
+}
+/**
+* Apply a literal replacement to LF-normalized content. Empty or missing search text throws
+* `FS_EDIT_NOT_FOUND`; multiple matches throw `FS_AMBIGUOUS_EDIT` unless `replaceAll` is true.
+* @param content - the current file content, already LF-normalized.
+* @param oldString - literal text to find; CRLF inside it is normalized to LF before
+*   matching.
+* @param newString - literal replacement text, normalized the same way.
+* @param replaceAll - replace every match instead of requiring exactly one.
+* @param displayPath - the caller-facing path used in error messages.
+* @returns the edited LF-normalized content plus how many occurrences were replaced.
+*/
+function applyLiteralEdit(content, oldString, newString, replaceAll, displayPath) {
+	const oldNorm = normalizeLineEndings(oldString);
+	if (oldNorm.length === 0) throw new FsError("old_string must be a non-empty string", "FS_EDIT_NOT_FOUND");
+	const newNorm = normalizeLineEndings(newString);
+	const replacements = countOccurrences(content, oldNorm);
+	if (replacements === 0) throw new FsError(`old_string was not found in "${displayPath}"`, "FS_EDIT_NOT_FOUND");
+	if (!replaceAll && replacements > 1) throw new FsError(`old_string matched ${replacements} times in "${displayPath}"; provide a more specific old_string or set replace_all to true`, "FS_AMBIGUOUS_EDIT");
+	return {
+		content: content.split(oldNorm).join(newNorm),
+		replacements
+	};
+}
+//#endregion
+//#region lib/types/index.js
+/**
+* Host-filesystem implementation of `ctx.fs`. Realpath-derived target identity makes aliases
+* share stale guards, and writes through a symlink update its target without replacing the link.
+* @module @deepseek-ai/dsh-fs-local
+*/
+const DEFAULT_DIFF_BASIS_MAX_BYTES = 10 * 1024 * 1024;
+const MAX_DIFF_BASIS_BYTES = Math.min(constants.MAX_LENGTH, constants.MAX_STRING_LENGTH);
+/**
+* The host-filesystem backend. Reads resolve relative paths from {@link Config.cwd}
+* (a resolution default, NOT a containment boundary — see the filesystem
+* capability-seam Agent Note); enforce
+* containment with a stricter backend or a `tools/execute` permission plugin.
+*/
+var LocalFileSystem = class extends FileSystem {
+	static Config = z.object({
+		cwd: z.string().default(process.cwd()),
+		diffBasisMaxBytes: z.number().default(DEFAULT_DIFF_BASIS_MAX_BYTES)
+	});
+	/** Validated config (schemastery applied the defaults before construction). */
+	config;
+	/** Test hook forwarded to fsio for atomic-publication boundaries. */
+	internals = {};
+	/** Per-targetKey tail promise: serializes mutating ops so the read→guard→write
+	* window can't interleave, making concurrent writes/edits deterministically
+	* ordered (one wins, the rest see the new version and reject as stale). */
+	locks = /* @__PURE__ */ new Map();
+	constructor(ctx, config) {
+		super(ctx);
+		const resolved = config;
+		if (!Number.isSafeInteger(resolved.diffBasisMaxBytes) || resolved.diffBasisMaxBytes <= 0 || resolved.diffBasisMaxBytes > MAX_DIFF_BASIS_BYTES) throw new Error(`fs-local: diffBasisMaxBytes must be a positive safe integer no greater than ${MAX_DIFF_BASIS_BYTES}`);
+		this.config = resolved;
+	}
+	/** Run `op` with exclusive access to `targetKey` (FIFO per key). */
+	async withLock(targetKey, op) {
+		const run = (this.locks.get(targetKey) ?? Promise.resolve()).then(op, op);
+		const tail = run.then(() => void 0, () => void 0);
+		this.locks.set(targetKey, tail);
+		try {
+			return await run;
+		} finally {
+			if (this.locks.get(targetKey) === tail) this.locks.delete(targetKey);
+		}
+	}
+	async resolve(path, opts) {
+		if (opts?.signal?.aborted) throw new FsError("resolve aborted", "FS_ABORTED");
+		const local = await resolveLocalTarget(opts?.cwd ?? this.config.cwd, path);
+		if (opts?.signal?.aborted) throw new FsError("resolve aborted", "FS_ABORTED");
+		return {
+			targetKey: local.targetKey,
+			displayPath: local.displayPath
+		};
+	}
+	processPath(target) {
+		return String(target.targetKey);
+	}
+	fileUrl(target) {
+		return pathToFileURL(this.processPath(target)).href;
+	}
+	contains(parent, child) {
+		const path = relative(this.processPath(parent), this.processPath(child));
+		return path === "" || path !== ".." && !path.startsWith(`..${sep}`) && !isAbsolute(path);
+	}
+	async stat(target, signal) {
+		if (signal?.aborted) throw new FsError("stat aborted", "FS_ABORTED");
+		const info = await probe(target.targetKey);
+		if (signal?.aborted) throw new FsError("stat aborted", "FS_ABORTED");
+		if (!info) return void 0;
+		return {
+			version: info.version,
+			type: info.type,
+			size: info.size
+		};
+	}
+	async lstat(path, opts, signal) {
+		if (signal?.aborted) throw new FsError("lstat aborted", "FS_ABORTED");
+		if (path.trim().length === 0) throw new FsError("file_path must be a non-empty string", "FS_NOT_FOUND");
+		const info = await probeNoFollow(resolve(opts?.cwd ?? this.config.cwd, path));
+		if (signal?.aborted) throw new FsError("lstat aborted", "FS_ABORTED");
+		if (!info) return void 0;
+		return {
+			version: info.version,
+			type: info.type,
+			size: info.size
+		};
+	}
+	async readText(target, signal) {
+		return readWholeText({
+			displayPath: target.displayPath,
+			targetKey: target.targetKey
+		}, signal);
+	}
+	streamText(target, signal) {
+		return Promise.resolve(streamWholeText({
+			displayPath: target.displayPath,
+			targetKey: target.targetKey
+		}, signal));
+	}
+	async readBytes(target, signal, maxBytes) {
+		return readWholeBytes({
+			displayPath: target.displayPath,
+			targetKey: target.targetKey
+		}, signal, maxBytes, this.internals);
+	}
+	async listDir(target, signal) {
+		return (await listDirectory({
+			displayPath: target.displayPath,
+			targetKey: target.targetKey
+		}, signal)).map((entry) => ({
+			name: entry.name,
+			type: entry.type,
+			target: {
+				targetKey: entry.target.targetKey,
+				displayPath: entry.target.displayPath
+			},
+			...entry.version !== void 0 ? { version: entry.version } : {},
+			...entry.size !== void 0 ? { size: entry.size } : {}
+		}));
+	}
+	async writeText(target, content, expected, signal) {
+		return this.withLock(target.targetKey, async () => {
+			const existing = await probe(target.targetKey);
+			if (existing && existing.type !== "file") throw new FsError(`cannot write "${target.displayPath}": not a regular file`, "FS_NOT_REGULAR_FILE");
+			if (expected?.kind === "replaceIfVersion") {
+				if (!existing) throw new FsError(`cannot write "${target.displayPath}": file no longer exists`, "FS_STALE_VERSION");
+				if (existing.version !== expected.version) throw new FsError(`cannot write "${target.displayPath}": file changed since it was read`, "FS_STALE_VERSION");
+			} else if (expected?.kind === "createIfAbsent" && existing) throw new FsError(`cannot overwrite existing "${target.displayPath}" without reading it first`, "FS_NOT_OBSERVED");
+			const before = existing !== null && Buffer.byteLength(content, "utf8") < this.config.diffBasisMaxBytes ? await readTextForDiff(target.targetKey, this.config.diffBasisMaxBytes, signal) : null;
+			await writeFileAtomic(target.targetKey, content, existing?.mode, signal, this.internals, expected?.kind === "createIfAbsent" ? { displayPath: target.displayPath } : void 0);
+			const after = await probe(target.targetKey);
+			return {
+				operation: existing ? "update" : "create",
+				version: this.versionAfterWrite(after, target),
+				before,
+				after: normalizeLineEndings(content)
+			};
+		});
+	}
+	async editText(target, edit, expected, signal) {
+		return this.withLock(target.targetKey, async () => {
+			const existing = await probe(target.targetKey);
+			if (!existing) throw new FsError(`cannot edit "${target.displayPath}": file changed since it was read`, "FS_STALE_VERSION");
+			if (existing.type !== "file") throw new FsError(`cannot edit "${target.displayPath}": not a regular file`, "FS_NOT_REGULAR_FILE");
+			if (expected && existing.version !== expected.version) throw new FsError(`cannot edit "${target.displayPath}": file changed since it was read`, "FS_STALE_VERSION");
+			const original = await readForEdit(target.targetKey, target.displayPath, signal);
+			const edited = applyLiteralEdit(original.content, edit.oldString, edit.newString, edit.replaceAll, target.displayPath);
+			const content = restoreLineEndings(edited.content, original.lineEndings);
+			await writeFileAtomic(target.targetKey, content, existing.mode, signal, this.internals);
+			const after = await probe(target.targetKey);
+			return {
+				version: this.versionAfterWrite(after, target),
+				before: original.content,
+				after: edited.content
+			};
+		});
+	}
+	/* v8 ignore next 5 -- the post-write probe finding the file absent requires a
+	* concurrent unlink between rename and stat; fall back to a sentinel version. */
+	versionAfterWrite(after, target) {
+		if (after) return after.version;
+		return FsVersion(`missing:${target.targetKey}`);
+	}
+};
+//#endregion
+export { LocalFileSystem, LocalFileSystem as default };

--- a/app/src/main/assets/patched/fs-local-index.js
+++ b/app/src/main/assets/patched/fs-local-index.js
@@ -497,7 +497,7 @@ async function writeFileAtomic(absolutePath, content, mode, signal, internals = 
 		handle = void 0;
 		throwIfAborted(signal, "write");
 		if (createIfAbsent !== void 0) try {
-			// android-link-eacces-fallback: Android app domains forbid link(2)
+			// fs-link-eacces-fallback: Android app domains forbid link(2)
 			// (sepolicy; Huawei/HarmonyOS observed), fall back to rename when
 			// the target is still absent — exactly like dsh 0.1.0-rc.8 did.
 			await linkFile(tempPath, absolutePath).catch(function (e) { if (e.code !== "EACCES" && e.code !== "EPERM" && e.code !== "ENOTSUP") throw e; return lstat(absolutePath).then(function () { throw e; }, function (e2) { if (e2.code !== "ENOENT") throw e2; return rename(tempPath, absolutePath); }); });

--- a/app/src/main/assets/patched/llm-deepseek-index.js
+++ b/app/src/main/assets/patched/llm-deepseek-index.js
@@ -1,0 +1,956 @@
+import z from "@deepseek-ai/schemastery";
+import { CONTEXT_WINDOW_EXCEEDED_CODE, CallId, EMPTY_RESPONSE_CODE, LlmAdapter, LlmError, ProviderRequestId, QUOTA_EXCEEDED_CODE, ReasoningEffortId, RetryPolicySchema, assertUsableApiKey, attributionHeaders, contentHasImage, isContextWindowExceededError, isQuotaExceededError, offloadRequestImages, resolveRetryPolicy } from "@deepseek-ai/dsh-llm";
+import { credentialRef } from "@deepseek-ai/dsh-credentials";
+import { launchEnvironmentOf } from "@deepseek-ai/dsh-launch-environment";
+import { deepEqualJson, installSettingsSection, settingsNamespace } from "@deepseek-ai/dsh-settings";
+import { MAX_TIMER_DELAY_MS, idleWatchdog, timeoutOf } from "@deepseek-ai/dsh-timeout";
+import { getOrCreateAnonymousUserId } from "@deepseek-ai/dsh-anonymous-user-id";
+import { AttachmentError } from "@deepseek-ai/dsh-attachment";
+import { EventSourceParserStream } from "eventsource-parser/stream";
+//#region lib/types/serialize.js
+/**
+* Serialize harness messages into DeepSeek chat completions. Text-only
+* requests retain string user content; the image path resolves durable
+* attachments into ordered data-URL parts. Tool-result images follow their
+* string-only tool messages in a separate user message.
+* @module dsh-llm-deepseek/serialize
+*/
+const TOOL_RESULT_IMAGE_TEXT = "Attached image(s) from tool result:";
+/** Validate the adapter-owned effort before resolving its DeepSeek wire fields. */
+function reasoningEffort(effort) {
+	if (effort === "off" || effort === "low" || effort === "high" || effort === "max") return effort;
+	throw new LlmError(`DeepSeek does not support reasoning effort "${effort}"`, "UNSUPPORTED_REASONING_EFFORT");
+}
+/** Resolve one legal thinking/effort pair without exposing `off` as a wire effort. */
+function resolveThinking(options, defaults) {
+	if (options.purpose === "session-title") return { thinking: "disabled" };
+	const effort = options.reasoningEffort === void 0 ? defaults.reasoningEffort : reasoningEffort(options.reasoningEffort);
+	if (defaults.thinking === "disabled" && effort !== void 0 && effort !== "off") throw new LlmError(`DeepSeek deployment does not support reasoning effort "${effort}"`, "UNSUPPORTED_REASONING_EFFORT");
+	if (effort === "off") return { thinking: "disabled" };
+	if (effort === "low" || effort === "high" || effort === "max") return {
+		thinking: "enabled",
+		reasoningEffort: effort
+	};
+	return defaults.thinking === void 0 ? {} : { thinking: defaults.thinking };
+}
+/** Join the text blocks of a message (used for user/tool-result content). */
+function flattenText(blocks) {
+	return blocks.filter((block) => block.type === "text").map((block) => block.text).join("");
+}
+/** Reject core image content before any text-flattening path can silently erase it. */
+function assertTextOnly(blocks) {
+	if (contentHasImage(blocks)) throw new LlmError("The DeepSeek chat-completions adapter does not support image content.", "UNSUPPORTED_CONTENT");
+}
+/** Reject roles whose DeepSeek history format cannot carry image input. */
+function assertSupportedImageRoles(messages) {
+	for (const message of messages) if (message.role !== "user" && contentHasImage(message.content)) throw new LlmError(`The DeepSeek chat-completions adapter cannot represent image content in a ${message.role} message.`, "UNSUPPORTED_CONTENT");
+}
+/** Resolve one durable image into its transient DeepSeek data-URL part. */
+async function imagePart(block, attachments, signal) {
+	try {
+		const stored = await attachments.readImage(block.attachment, signal);
+		return {
+			type: "image_url",
+			image_url: { url: `data:${stored.ref.mediaType};base64,${Buffer.from(stored.data).toString("base64")}` }
+		};
+	} catch (error) {
+		if (error instanceof AttachmentError) throw new LlmError(error.message, error.code, { cause: error });
+		throw error;
+	}
+}
+/** Convert user or nested tool-result blocks into ordered wire parts. */
+async function contentParts(blocks, attachments, signal) {
+	const parts = [];
+	for (const block of blocks) switch (block.type) {
+		case "text":
+			if (block.text.length > 0) parts.push({
+				type: "text",
+				text: block.text
+			});
+			break;
+		case "image":
+			parts.push(await imagePart(block, attachments, signal));
+			break;
+		case "tool-result":
+			parts.push(...await contentParts(block.content, attachments, signal));
+			break;
+		default: break;
+	}
+	return parts;
+}
+/** Keep text-only user messages on the compact string wire form. */
+function userContent(parts) {
+	const text = [];
+	for (const part of parts) {
+		if (part.type === "image_url") return [...parts];
+		text.push(part.text);
+	}
+	return text.join("");
+}
+/** Serialize one assistant message (text + reasoning + tool calls). */
+function serializeAssistant(message) {
+	const text = flattenText(message.content);
+	const reasoning = message.content.filter((block) => block.type === "reasoning").map((block) => block.text).join("");
+	const toolCalls = message.content.filter((block) => block.type === "tool-call").map((block) => ({
+		id: block.id,
+		type: "function",
+		function: {
+			name: block.name,
+			arguments: block.arguments
+		}
+	}));
+	return {
+		role: "assistant",
+		content: text,
+		...reasoning.length > 0 ? { reasoning_content: reasoning } : {},
+		...toolCalls.length > 0 ? { tool_calls: toolCalls } : {}
+	};
+}
+/**
+* Serialize the conversation. `tool-result` blocks become standalone
+* `{role: 'tool'}` messages; the harness puts each tool result in its own
+* user-role message, so a mixed user message contributes its text first and
+* its tool results as separate wire messages after.
+* @param messages - the harness conversation, in order.
+* @returns the wire messages; order preserved, each tool result expanded into its own entry.
+*/
+function serializeMessages(messages) {
+	const wire = [];
+	for (const message of messages) {
+		assertTextOnly(message.content);
+		if (message.role === "system") {
+			wire.push({
+				role: "system",
+				content: flattenText(message.content)
+			});
+			continue;
+		}
+		if (message.role === "assistant") {
+			wire.push(serializeAssistant(message));
+			continue;
+		}
+		const toolResults = message.content.filter((block) => block.type === "tool-result");
+		const text = flattenText(message.content);
+		if (text.length > 0 || toolResults.length === 0) wire.push({
+			role: "user",
+			content: text
+		});
+		for (const result of toolResults) wire.push({
+			role: "tool",
+			tool_call_id: result.toolCallId,
+			content: flattenText(result.content) || "(no output)"
+		});
+	}
+	return wire;
+}
+/**
+* Serialize image-capable history after resolving durable attachments.
+* Consecutive tool results keep string `tool` messages and share one following
+* user message containing their images.
+* @param messages - transient request history after request-size offloading.
+* @param attachments - durable image resolver.
+* @param signal - cancellation for attachment reads.
+* @returns ordered DeepSeek wire messages.
+*/
+async function serializeMessagesWithImages(messages, attachments, signal) {
+	assertSupportedImageRoles(messages);
+	const wire = [];
+	let pendingToolImages = [];
+	const flushToolImages = () => {
+		if (pendingToolImages.length === 0) return;
+		wire.push({
+			role: "user",
+			content: [{
+				type: "text",
+				text: TOOL_RESULT_IMAGE_TEXT
+			}, ...pendingToolImages]
+		});
+		pendingToolImages = [];
+	};
+	for (const message of messages) {
+		if (message.role === "system") {
+			flushToolImages();
+			wire.push({
+				role: "system",
+				content: flattenText(message.content)
+			});
+			continue;
+		}
+		if (message.role === "assistant") {
+			flushToolImages();
+			wire.push(serializeAssistant(message));
+			continue;
+		}
+		const regular = message.content.filter((block) => block.type !== "tool-result");
+		const toolResults = message.content.filter((block) => block.type === "tool-result");
+		const content = userContent(await contentParts(regular, attachments, signal));
+		if (content.length > 0 || toolResults.length === 0) {
+			flushToolImages();
+			wire.push({
+				role: "user",
+				content
+			});
+		}
+		for (const result of toolResults) {
+			const parts = await contentParts(result.content, attachments, signal);
+			const images = parts.filter((part) => part.type === "image_url");
+			const text = parts.filter((part) => part.type === "text").map((part) => part.text).join("");
+			wire.push({
+				role: "tool",
+				tool_call_id: result.toolCallId,
+				content: text || (images.length > 0 ? "(see attached image)" : "(no output)")
+			});
+			pendingToolImages.push(...images);
+		}
+	}
+	flushToolImages();
+	return wire;
+}
+/** Assemble request fields shared by text-only and image-capable conversion. */
+function requestWithMessages(options, messages, defaults) {
+	const tools = options.tools?.map((tool) => ({
+		type: "function",
+		function: {
+			name: tool.name,
+			description: tool.description,
+			parameters: tool.parameters
+		}
+	}));
+	const resolvedThinking = resolveThinking(options, defaults);
+	return {
+		model: options.model,
+		messages,
+		stream: true,
+		stream_options: { include_usage: true },
+		...resolvedThinking.thinking !== void 0 ? { thinking: { type: resolvedThinking.thinking } } : {},
+		...resolvedThinking.reasoningEffort !== void 0 ? { reasoning_effort: resolvedThinking.reasoningEffort } : {},
+		...tools !== void 0 && tools.length > 0 ? { tools } : {},
+		...options.temperature !== void 0 ? { temperature: options.temperature } : {},
+		...options.maxTokens === void 0 ? {} : { max_tokens: options.maxTokens },
+		...options.stop !== void 0 ? { stop: options.stop } : {}
+	};
+}
+/**
+* Build the full wire request. Always streaming (`stream: true`, usage
+* reporting on); optional fields are omitted rather than sent as null, so
+* provider defaults apply.
+* @param options - the harness request (model, history, system, tools, sampling).
+* @param defaults - adapter-level thinking defaults; undefined fields put nothing on the wire.
+* @returns the chat-completions request body.
+*/
+function serializeRequest(options, defaults = {}) {
+	const messages = [];
+	if (options.system !== void 0) messages.push({
+		role: "system",
+		content: options.system
+	});
+	messages.push(...serializeMessages(options.messages));
+	return requestWithMessages(options, messages, defaults);
+}
+/**
+* Build one image-capable request while keeping durable bytes out of session
+* messages. Oversized oldest images become deterministic text before any
+* attachment read.
+* @param options - harness request containing image-capable user content.
+* @param images - attachment resolver, request bound, and cancellation.
+* @param defaults - adapter-level thinking defaults.
+* @returns the fully materialized DeepSeek request body.
+*/
+async function serializeRequestWithImages(options, images, defaults = {}) {
+	assertSupportedImageRoles(options.messages);
+	const requestMessages = offloadRequestImages(options.messages, images.maxRequestImageBytes);
+	const messages = [];
+	if (options.system !== void 0) messages.push({
+		role: "system",
+		content: options.system
+	});
+	messages.push(...await serializeMessagesWithImages(requestMessages, images.attachments, images.signal));
+	return requestWithMessages(options, messages, defaults);
+}
+/**
+* Parse an SSE byte stream into data payloads. Yields `[DONE]` as the final
+* value and returns; throws `LlmError('STREAM_CLOSED')` when the stream ends
+* without it (truncated response — the model call cannot be trusted).
+* @param stream - raw SSE bytes; reads may split anywhere, including mid-UTF-8 sequence.
+* @param onComment - optional transport-activity callback; comments never enter the yielded payload stream.
+* @returns each event's data payload in arrival order, the `[DONE]` sentinel last.
+*/
+async function* parseSse(stream, onComment) {
+	const events = stream.pipeThrough(new TextDecoderStream()).pipeThrough(new EventSourceParserStream({ onComment }));
+	for await (const { data } of events) {
+		yield data;
+		if (data === "[DONE]") return;
+	}
+	throw new LlmError("SSE stream ended without [DONE]", "STREAM_CLOSED");
+}
+//#endregion
+//#region lib/types/translate.js
+/**
+* Translate DeepSeek SSE payloads with one stateful harness block per content, reasoning, or tool
+* call index. An empty initial reasoning delta does not open a block. Finish reason and the latest
+* usage are deferred until `[DONE]`, covering both finish-attached and trailing usage-only shapes
+* while ensuring no chunk follows `finish`.
+*
+* Translate DeepSeek wire chunks into the harness `StreamChunk` protocol.
+* @module dsh-llm-deepseek/translate
+*/
+/**
+* Map the wire finish_reason vocabulary to the harness FinishReason.
+* @param reason - the wire `finish_reason` string.
+* @returns the mapped reason; unrecognized values (content_filter, …) become `{kind: 'error'}` with the uppercased value as `code`.
+*/
+function mapFinishReason(reason) {
+	switch (reason) {
+		case "stop": return { kind: "stop" };
+		case "tool_calls": return { kind: "tool-calls" };
+		case "length": return { kind: "max-tokens" };
+		default: return {
+			kind: "error",
+			failure: {
+				message: `model stopped: ${reason}`,
+				code: reason.toUpperCase()
+			}
+		};
+	}
+}
+/**
+* Map wire usage fields. DeepSeek's `prompt_tokens` INCLUDES cache hits
+* (`prompt_tokens = prompt_cache_hit_tokens + prompt_cache_miss_tokens`,
+* api/create-chat-completion); the harness TokenUsage convention is
+* DISJOINT counts, so cache reads are subtracted out of `inputTokens`.
+* @param usage - wire usage from the finish chunk or the trailing usage-only chunk.
+* @returns disjoint harness counts; cache/reasoning fields present only when the wire reported them.
+*/
+function mapUsage(usage) {
+	const cacheRead = usage.prompt_tokens_details?.cached_tokens ?? usage.prompt_cache_hit_tokens;
+	const reasoning = usage.completion_tokens_details?.reasoning_tokens;
+	return {
+		inputTokens: usage.prompt_tokens - (cacheRead ?? 0),
+		outputTokens: usage.completion_tokens,
+		...cacheRead !== void 0 ? { cacheReadTokens: cacheRead } : {},
+		...reasoning !== void 0 ? { reasoningTokens: reasoning } : {}
+	};
+}
+/** Assemble the final ContentBlock for one open block. */
+function closeBlock(block) {
+	switch (block.kind) {
+		case "text": return {
+			type: "text",
+			text: block.text
+		};
+		case "reasoning": return {
+			type: "reasoning",
+			text: block.text
+		};
+		case "tool-call": return {
+			type: "tool-call",
+			id: CallId(block.callId ?? ""),
+			name: block.name ?? "",
+			arguments: block.text
+		};
+	}
+}
+/**
+* Consume SSE data payloads (ending with `[DONE]`) and yield StreamChunks.
+* Malformed JSON payloads abort the stream with `MALFORMED_RESPONSE`.
+* @param payloads - SSE data payloads from {@link parseSse}, `[DONE]`-terminated.
+* @returns deltas as they arrive; `block-end`s, `usage`, and `finish` are all deferred to the `[DONE]` sentinel.
+*   A `stop` (or absent) finish with no opened blocks is a degenerate provider completion and maps to an
+*   `EMPTY_RESPONSE` error finish instead of a successful empty message.
+*/
+async function* translate(payloads) {
+	let nextIndex = 0;
+	let textBlock;
+	let reasoningBlock;
+	const toolBlocks = /* @__PURE__ */ new Map();
+	const order = [];
+	let pendingFinish;
+	let pendingUsage;
+	function open(kind) {
+		const block = {
+			index: nextIndex++,
+			kind,
+			text: ""
+		};
+		order.push(block);
+		return block;
+	}
+	for await (const payload of payloads) {
+		if (payload === "[DONE]") {
+			for (const block of order) yield {
+				type: "block-end",
+				index: block.index,
+				block: closeBlock(block)
+			};
+			if (pendingUsage) yield {
+				type: "usage",
+				usage: pendingUsage
+			};
+			const reason = pendingFinish ?? { kind: "stop" };
+			yield {
+				type: "finish",
+				reason: reason.kind === "stop" && order.length === 0 ? {
+					kind: "error",
+					failure: {
+						message: "model returned a completed response with no content",
+						code: EMPTY_RESPONSE_CODE
+					}
+				} : reason
+			};
+			return;
+		}
+		let chunk;
+		try {
+			chunk = JSON.parse(payload);
+		} catch {
+			throw new LlmError(`malformed SSE payload: ${payload.slice(0, 120)}`, "MALFORMED_RESPONSE");
+		}
+		for (const choice of chunk.choices ?? []) {
+			const delta = choice.delta;
+			const reasoning = delta?.reasoning_content;
+			if (typeof reasoning === "string" && reasoning.length > 0) {
+				if (!reasoningBlock) {
+					reasoningBlock = open("reasoning");
+					yield {
+						type: "block-start",
+						index: reasoningBlock.index,
+						blockType: "reasoning"
+					};
+				}
+				reasoningBlock.text += reasoning;
+				yield {
+					type: "reasoning-delta",
+					index: reasoningBlock.index,
+					text: reasoning
+				};
+			}
+			const content = delta?.content;
+			if (typeof content === "string" && content.length > 0) {
+				if (!textBlock) {
+					textBlock = open("text");
+					yield {
+						type: "block-start",
+						index: textBlock.index,
+						blockType: "text"
+					};
+				}
+				textBlock.text += content;
+				yield {
+					type: "text-delta",
+					index: textBlock.index,
+					text: content
+				};
+			}
+			for (const call of delta?.tool_calls ?? []) {
+				let block = toolBlocks.get(call.index);
+				if (!block) {
+					block = open("tool-call");
+					toolBlocks.set(call.index, block);
+					yield {
+						type: "block-start",
+						index: block.index,
+						blockType: "tool-call"
+					};
+				}
+				if (call.id !== void 0) block.callId = call.id;
+				if (call.function?.name !== void 0) block.name = call.function.name;
+				const fragment = call.function?.arguments ?? "";
+				block.text += fragment;
+				yield {
+					type: "tool-call-delta",
+					index: block.index,
+					id: CallId(block.callId ?? ""),
+					...block.name !== void 0 ? { name: block.name } : {},
+					argumentsDelta: fragment
+				};
+			}
+			if (typeof choice.finish_reason === "string") pendingFinish = mapFinishReason(choice.finish_reason);
+		}
+		if (chunk.usage) pendingUsage = mapUsage(chunk.usage);
+	}
+	throw new LlmError("SSE payload stream ended without [DONE]", "STREAM_CLOSED");
+}
+//#endregion
+//#region lib/types/adapter.js
+/**
+* `DeepSeekAdapter`: fetch + SSE against a DeepSeek (OpenAI-compatible)
+* chat-completions endpoint, emitting harness StreamChunks. The adapter is
+* transport-only: connection facts arrive through a thunk resolved once per
+* operation and the bearer token through a per-request resolver, so the
+* registering plugin owns validation, layering, and credential policy.
+*
+* @module dsh-llm-deepseek/adapter
+*/
+var __addDisposableResource = function(env, value, async) {
+	if (value !== null && value !== void 0) {
+		if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
+		var dispose, inner;
+		if (async) {
+			if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+			dispose = value[Symbol.asyncDispose];
+		}
+		if (dispose === void 0) {
+			if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+			dispose = value[Symbol.dispose];
+			if (async) inner = dispose;
+		}
+		if (typeof dispose !== "function") throw new TypeError("Object not disposable.");
+		if (inner) dispose = function() {
+			try {
+				inner.call(this);
+			} catch (e) {
+				return Promise.reject(e);
+			}
+		};
+		env.stack.push({
+			value,
+			dispose,
+			async
+		});
+	} else if (async) env.stack.push({ async: true });
+	return value;
+};
+var __disposeResources = (function(SuppressedError) {
+	return function(env) {
+		function fail(e) {
+			env.error = env.hasError ? new SuppressedError(e, env.error, "An error was suppressed during disposal.") : e;
+			env.hasError = true;
+		}
+		var r, s = 0;
+		function next() {
+			while (r = env.stack.pop()) try {
+				if (!r.async && s === 1) return s = 0, env.stack.push(r), Promise.resolve().then(next);
+				if (r.dispose) {
+					var result = r.dispose.call(r.value);
+					if (r.async) return s |= 2, Promise.resolve(result).then(next, function(e) {
+						fail(e);
+						return next();
+					});
+				} else s |= 1;
+			} catch (e) {
+				fail(e);
+			}
+			if (s === 1) return env.hasError ? Promise.reject(env.error) : Promise.resolve();
+			if (env.hasError) throw env.error;
+		}
+		return next();
+	};
+})(typeof SuppressedError === "function" ? SuppressedError : function(error, suppressed, message) {
+	var e = new Error(message);
+	return e.name = "SuppressedError", e.error = error, e.suppressed = suppressed, e;
+});
+/** Default maximum idle interval while an adapter stream read is outstanding. */
+const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 3e5;
+/** Default combined request/response context capacity. */
+const DEFAULT_CONTEXT_WINDOW = 1e6;
+/** Default per-request output-token cap. */
+const DEFAULT_MAX_TOKENS = 256e3;
+/** Default bound on accumulated base64 image payload per request. */
+const DEFAULT_MAX_REQUEST_IMAGE_BYTES = 20 * 1024 * 1024;
+const STREAM_IDLE_TIMEOUT_CODE = "LLM_STREAM_IDLE_TIMEOUT";
+const OFF_REASONING_EFFORT = ReasoningEffortId("off");
+const LOW_REASONING_EFFORT = ReasoningEffortId("low");
+const HIGH_REASONING_EFFORT = ReasoningEffortId("high");
+const MAX_REASONING_EFFORT = ReasoningEffortId("max");
+const REASONING_EFFORTS = [
+	{
+		id: OFF_REASONING_EFFORT,
+		name: "Off"
+	},
+	{
+		id: LOW_REASONING_EFFORT,
+		name: "Low"
+	},
+	{
+		id: HIGH_REASONING_EFFORT,
+		name: "High"
+	},
+	{
+		id: MAX_REASONING_EFFORT,
+		name: "Max"
+	}
+];
+const OFF_ONLY_REASONING_EFFORTS = [{
+	id: OFF_REASONING_EFFORT,
+	name: "Off"
+}];
+function modelInfo(provider, model) {
+	return {
+		provider,
+		id: model.id,
+		name: model.name ?? model.id,
+		...model.description === void 0 ? {} : { description: model.description },
+		inputModalities: model.inputModalities ?? ["text"]
+	};
+}
+function providerRetryAfterMs(value) {
+	if (value === null) return void 0;
+	if (/^\d+$/.test(value)) {
+		const delay = Number(value) * 1e3;
+		return Number.isFinite(delay) && delay > 0 ? delay : void 0;
+	}
+	const delay = Date.parse(value) - Date.now();
+	return Number.isFinite(delay) && delay > 0 ? delay : void 0;
+}
+function requestId(headers) {
+	const value = headers.get("x-request-id") ?? headers.get("x-deepseek-request-id");
+	return value === null || value.length === 0 ? void 0 : ProviderRequestId(value);
+}
+/**
+* Map an HTTP status to a stable LlmError code.
+* @param status - status of a non-2xx provider response.
+* @param error - parsed provider error body, when available.
+* @returns the normalized harness error code.
+*/
+function httpErrorCode(status, error) {
+	if (status === 401 || status === 403) return "AUTH";
+	if (status === 413) return "INVALID_REQUEST";
+	const detail = [
+		error?.code,
+		error?.type,
+		error?.message
+	].filter(Boolean).join(" ");
+	if (isQuotaExceededError(detail)) return QUOTA_EXCEEDED_CODE;
+	if (status === 429) return "RATE_LIMIT";
+	if (status === 400) {
+		if (isContextWindowExceededError(detail)) return CONTEXT_WINDOW_EXCEEDED_CODE;
+		return "INVALID_REQUEST";
+	}
+	if (status >= 500) return "SERVER";
+	return `HTTP_${status}`;
+}
+/**
+* The first real `LlmAdapter`. One instance serves every model name it was
+* registered under (the harness model name IS the wire model name).
+*
+* One stable signal reaches both initial fetch and body reads. Caller aborts
+* map to `ABORTED`; the configured per-read idle watchdog maps to `TIMEOUT`.
+*/
+var DeepSeekAdapter = class extends LlmAdapter {
+	config;
+	constructor(config) {
+		super();
+		this.config = config;
+	}
+	providerInfo(provider) {
+		return {
+			id: provider,
+			name: "DeepSeek"
+		};
+	}
+	providerRetryPolicy(_provider) {
+		return this.config.options().retryPolicy;
+	}
+	listModels(provider) {
+		return Promise.resolve(this.config.options().models.map((model) => modelInfo(provider, model)));
+	}
+	resolveModel(provider, model, _signal) {
+		const connection = this.config.options();
+		const configured = connection.models.find((entry) => entry.id === model);
+		const contextWindow = configured?.contextWindow ?? connection.defaultContextWindow;
+		return Promise.resolve({
+			...configured === void 0 ? {
+				provider,
+				id: model,
+				name: model,
+				inputModalities: ["text"]
+			} : modelInfo(provider, configured),
+			context: { contextWindow },
+			defaultMaxTokens: configured?.maxTokens ?? connection.maxTokens,
+			...connection.defaults.thinking === "disabled" ? { reasoning: {
+				efforts: OFF_ONLY_REASONING_EFFORTS,
+				defaultEffort: OFF_REASONING_EFFORT
+			} } : { reasoning: {
+				efforts: REASONING_EFFORTS,
+				defaultEffort: connection.defaults.reasoningEffort === "off" ? OFF_REASONING_EFFORT : connection.defaults.reasoningEffort === "low" ? LOW_REASONING_EFFORT : connection.defaults.reasoningEffort === "max" ? MAX_REASONING_EFFORT : HIGH_REASONING_EFFORT
+			} }
+		});
+	}
+	async *stream(options) {
+		const env_1 = {
+			stack: [],
+			error: void 0,
+			hasError: false
+		};
+		try {
+			const connection = this.config.options();
+			const hasImages = options.messages.some((message) => contentHasImage(message.content));
+			let attachments;
+			if (hasImages) {
+				if (connection.models.find((entry) => entry.id === options.model)?.inputModalities?.includes("image") !== true) throw new LlmError(`DeepSeek model "${options.model}" does not accept image input.`, "UNSUPPORTED_CONTENT");
+				attachments = this.config.resolveAttachments?.();
+				if (attachments === void 0) throw new LlmError("DeepSeek image conversion requires the durable attachment service.", "UNSUPPORTED_CONTENT");
+			}
+			const apiKey = await this.config.resolveApiKey(connection);
+			const userId = this.config.resolveUserId();
+			const consumer = new AbortController();
+			const watchdog = __addDisposableResource(env_1, idleWatchdog(options.signal === void 0 ? consumer.signal : AbortSignal.any([options.signal, consumer.signal]), connection.streamIdleTimeoutMs, STREAM_IDLE_TIMEOUT_CODE), false);
+			const iterator = this.request(options, watchdog.signal, connection, apiKey, userId, attachments, () => {
+				watchdog.pulse();
+			})[Symbol.asyncIterator]();
+			let exhausted = false;
+			try {
+				while (true) {
+					const result = await watchdog.next(iterator);
+					if (result.done) {
+						exhausted = true;
+						return;
+					}
+					yield result.value;
+				}
+			} catch (error) {
+				if (timeoutOf(watchdog.signal, STREAM_IDLE_TIMEOUT_CODE) !== void 0) throw new LlmError(`DeepSeek stream idle timeout after ${connection.streamIdleTimeoutMs}ms`, "TIMEOUT", { cause: error });
+				if (options.signal?.aborted) throw new LlmError("DeepSeek request aborted by caller", "ABORTED", { cause: error });
+				if (error instanceof LlmError) throw error;
+				throw new LlmError(`DeepSeek API stream from ${connection.baseURL} failed`, "TRANSPORT", { cause: error });
+			} finally {
+				consumer.abort("DeepSeek stream consumer stopped");
+				if (!exhausted && iterator.return !== void 0) try {
+					await iterator.return();
+				} catch (_abortedTransportTeardown) {}
+			}
+		} catch (e_1) {
+			env_1.error = e_1;
+			env_1.hasError = true;
+		} finally {
+			__disposeResources(env_1);
+		}
+	}
+	async *request(options, signal, connection, apiKey, userId, attachments, onComment) {
+		const body = attachments === void 0 ? serializeRequest(options, connection.defaults) : await serializeRequestWithImages(options, {
+			attachments,
+			maxRequestImageBytes: connection.maxRequestImageBytes,
+			signal
+		}, connection.defaults);
+		const payload = JSON.stringify(body);
+		const headers = {
+			"authorization": `Bearer ${apiKey}`,
+			"content-type": "application/json",
+			"accept": "text/event-stream",
+			...attributionHeaders(),
+			"x-deepseek-harness-user-id": String(userId),
+			...options.sessionId !== void 0 ? { "x-deepseek-harness-session-id": String(options.sessionId) } : {},
+			...options.purpose === "compaction" ? { "x-deepseek-harness-compact": "1" } : {}
+		};
+		let response;
+		try {
+			response = await fetch(`${connection.baseURL}/chat/completions`, {
+				method: "POST",
+				headers,
+				body: payload,
+				signal
+			});
+		} catch (error) {
+			if (signal.aborted) throw error;
+			throw new LlmError(`DeepSeek API request to ${connection.baseURL} failed`, "TRANSPORT", { cause: error });
+		}
+		if (!response.ok) {
+			let message = `DeepSeek API error (HTTP ${response.status})`;
+			let providerError;
+			try {
+				providerError = (await response.json()).error;
+				if (providerError?.message) message = providerError.message;
+			} catch {}
+			const delay = providerRetryAfterMs(response.headers.get("retry-after"));
+			const id = requestId(response.headers);
+			throw new LlmError(message, httpErrorCode(response.status, providerError), {
+				status: response.status,
+				...delay === void 0 ? {} : { providerRetryAfterMs: delay },
+				...id === void 0 ? {} : { requestId: id }
+			});
+		}
+		if (!response.body) throw new LlmError("DeepSeek API returned no response body", "EMPTY_RESPONSE");
+		yield* translate(parseSse(response.body, onComment));
+	}
+};
+//#endregion
+//#region lib/types/index.js
+/**
+* Register a {@link DeepSeekAdapter} for the `deepseek-official` provider route on
+* `ctx.llm`, with connection facts resolved per request instead of frozen at
+* load: the plugin layers its `cordis.yml` entry config under the optional
+* `llm-deepseek` user-settings section (`ctx.settings`) and resolves the API
+* key through the optional credential seam (`ctx.credentials`), so a changed
+* base URL, catalog, or key reaches the very next request without restarting
+* anything, while an in-flight stream keeps the facts it started with. The
+* one registration-captured fact — the retry policy — re-registers the route
+* in place when it changes.
+* @module @deepseek-ai/dsh-llm-deepseek
+*/
+const name = "llm-deepseek";
+const inject = ["llm"];
+const NS = settingsNamespace("llm-deepseek");
+const DEFAULT_API_KEY_ENV = "DEEPSEEK_API_KEY";
+/** The single provider route this plugin owns. */
+const PROVIDER = "deepseek-official";
+const DEFAULT_MODELS = [
+	{
+		id: "deepseek-v4-flash",
+		name: "DeepSeek-V4-Flash",
+		contextWindow: DEFAULT_CONTEXT_WINDOW
+	},
+	{
+		id: "deepseek-v4-pro",
+		name: "DeepSeek-V4-Pro",
+		contextWindow: DEFAULT_CONTEXT_WINDOW
+	},
+	{
+		id: "deepseek-v4-flash-vision-exp",
+		name: "DeepSeek-V4-Flash-Vision-Exp",
+		contextWindow: DEFAULT_CONTEXT_WINDOW,
+		inputModalities: ["text", "image"]
+	}
+];
+const MODEL_MODALITIES = ["text", "image"];
+const catalogModel = z.object({
+	id: z.string().required(),
+	name: z.string(),
+	description: z.string(),
+	contextWindow: z.number().step(1).min(1),
+	maxTokens: z.number().step(1).min(1),
+	inputModalities: z.array(z.union(MODEL_MODALITIES)).min(1).default(["text"])
+});
+const Config = z.object({
+	apiKeyEnv: z.string().role("credential-ref").default(DEFAULT_API_KEY_ENV),
+	baseURL: z.string(),
+	thinking: z.union(["enabled", "disabled"]),
+	reasoningEffort: z.union([
+		"off",
+		"low",
+		"high",
+		"max"
+	]),
+	maxTokens: z.number().step(1).min(1).max(Number.MAX_SAFE_INTEGER).default(DEFAULT_MAX_TOKENS),
+	defaultContextWindow: z.number().step(1).min(1).default(DEFAULT_CONTEXT_WINDOW),
+	models: z.array(catalogModel).default(DEFAULT_MODELS),
+	streamIdleTimeoutMs: z.number().min(Number.MIN_VALUE).max(MAX_TIMER_DELAY_MS).default(DEFAULT_STREAM_IDLE_TIMEOUT_MS),
+	maxRequestImageBytes: z.number().step(1).min(1).default(DEFAULT_MAX_REQUEST_IMAGE_BYTES),
+	retryPolicy: RetryPolicySchema
+});
+/** Public API default; the internal endpoint comes from $DEEPSEEK_BASE_URL. */
+const PUBLIC_BASE_URL = "https://api.deepseek.com";
+/** Environment variable naming this provider's endpoint, honored only from trusted layers. */
+const BASE_URL_ENV = "DEEPSEEK_BASE_URL";
+/** Resolve, validate, and detach the advisory model catalog. */
+function resolveModels(models) {
+	const seen = /* @__PURE__ */ new Set();
+	return (models ?? DEFAULT_MODELS).map((model) => {
+		if (model.id.length === 0) throw new Error("llm-deepseek: catalog model ids must be non-empty");
+		if (model.name !== void 0 && model.name.length === 0) throw new Error(`llm-deepseek: catalog model "${model.id}" has an empty name`);
+		if (model.contextWindow !== void 0 && (!Number.isInteger(model.contextWindow) || model.contextWindow <= 0)) throw new Error(`llm-deepseek: catalog model "${model.id}" contextWindow must be a positive integer`);
+		if (model.maxTokens !== void 0 && (!Number.isInteger(model.maxTokens) || model.maxTokens <= 0)) throw new Error(`llm-deepseek: catalog model "${model.id}" maxTokens must be a positive integer`);
+		const inputModalities = model.inputModalities ?? ["text"];
+		if (inputModalities.length === 0) throw new Error(`llm-deepseek: catalog model "${model.id}" inputModalities must not be empty`);
+		if (inputModalities.some((modality) => !MODEL_MODALITIES.includes(modality))) throw new Error(`llm-deepseek: catalog model "${model.id}" inputModalities must contain only "text" and "image"`);
+		if (new Set(inputModalities).size !== inputModalities.length) throw new Error(`llm-deepseek: catalog model "${model.id}" inputModalities must not contain duplicates`);
+		if (seen.has(model.id)) throw new Error(`llm-deepseek: duplicate catalog model "${model.id}"`);
+		seen.add(model.id);
+		return {
+			id: model.id,
+			...model.name === void 0 ? {} : { name: model.name },
+			...model.description === void 0 ? {} : { description: model.description },
+			...model.contextWindow === void 0 ? {} : { contextWindow: model.contextWindow },
+			...model.maxTokens === void 0 ? {} : { maxTokens: model.maxTokens },
+			inputModalities: [...inputModalities]
+		};
+	});
+}
+/**
+* The one explicit resolve step from raw config to validated connection
+* facts. Programmatic construction may bypass Schemastery normalization, so
+* every default and bound is re-judged here — for the composition entry at
+* load (fail loud) and for each settings snapshot at its first use.
+* @param config - raw plugin config or resolved settings snapshot.
+* @param environment - this run's environment layers, or `undefined` outside
+* the product CLI. Every layer may supply an endpoint: the product trusts the
+* project it is launched in, so a checkout can point its own agent at the
+* gateway that checkout is meant to use.
+* @returns validated connection facts plus the credential reference.
+*/
+function resolveAdapterOptions(config, environment) {
+	if (config.thinking === "disabled" && config.reasoningEffort !== void 0 && config.reasoningEffort !== "off") throw new Error("llm-deepseek: only reasoningEffort \"off\" can be configured when thinking is disabled");
+	if (config.defaultContextWindow !== void 0 && (!Number.isInteger(config.defaultContextWindow) || config.defaultContextWindow <= 0)) throw new Error("llm-deepseek: defaultContextWindow must be a positive integer");
+	if (config.maxTokens !== void 0 && (!Number.isSafeInteger(config.maxTokens) || config.maxTokens <= 0)) throw new Error("llm-deepseek: maxTokens must be a positive safe integer");
+	const streamIdleTimeoutMs = config.streamIdleTimeoutMs ?? 3e5;
+	if (!Number.isFinite(streamIdleTimeoutMs) || streamIdleTimeoutMs <= 0 || streamIdleTimeoutMs > MAX_TIMER_DELAY_MS) throw new Error(`llm-deepseek: streamIdleTimeoutMs must be a positive finite number no greater than ${MAX_TIMER_DELAY_MS}`);
+	const maxRequestImageBytes = config.maxRequestImageBytes ?? 20971520;
+	if (!Number.isSafeInteger(maxRequestImageBytes) || maxRequestImageBytes <= 0) throw new Error("llm-deepseek: maxRequestImageBytes must be a positive safe integer");
+	return {
+		apiKeyEnv: credentialRef(config.apiKeyEnv ?? DEFAULT_API_KEY_ENV),
+		baseURL: config.baseURL ?? environment?.get(BASE_URL_ENV)?.value ?? "https://api.deepseek.com",
+		defaults: {
+			thinking: config.thinking,
+			reasoningEffort: config.reasoningEffort
+		},
+		maxTokens: config.maxTokens ?? 256e3,
+		defaultContextWindow: config.defaultContextWindow ?? 1e6,
+		models: resolveModels(config.models),
+		streamIdleTimeoutMs,
+		maxRequestImageBytes,
+		retryPolicy: resolveRetryPolicy(config.retryPolicy, "llm-deepseek: retryPolicy")
+	};
+}
+function apply(ctx, config) {
+	let current = () => config;
+	let lastRaw;
+	let lastGood;
+	const options = () => {
+		const raw = current();
+		if (raw === lastRaw && lastGood !== void 0) return lastGood;
+		try {
+			const next = resolveAdapterOptions(raw, launchEnvironmentOf(ctx));
+			lastRaw = raw;
+			lastGood = next;
+			return next;
+		} catch (error) {
+			if (lastGood === void 0) throw error;
+			lastRaw = raw;
+			ctx.logger.error("llm-deepseek: keeping the last good configuration after an invalid settings section");
+			ctx.logger.error(error);
+			return lastGood;
+		}
+	};
+	options();
+	const resolveApiKey = async (connection) => {
+		const ref = connection.apiKeyEnv;
+		const credentials = ctx.get("credentials");
+		if (credentials !== void 0) {
+			const hit = await credentials.resolve(ref);
+			if (hit !== void 0) return assertUsableApiKey(hit.value, "llm-deepseek", ref);
+		} else {
+			const ambient = launchEnvironmentOf(ctx).get(ref);
+			if (ambient !== void 0 && ambient.value.length > 0) return assertUsableApiKey(ambient.value, "llm-deepseek", ref);
+		}
+		throw new LlmError(`llm-deepseek: no API key for provider route "${PROVIDER}"; store ${ref} through the credentials service (the web Models page writes it), or export ${ref} in the launching environment`, "MISSING_CREDENTIAL");
+	};
+	let userId;
+	const resolveUserId = () => userId ??= getOrCreateAnonymousUserId();
+	const adapter = new DeepSeekAdapter({
+		options,
+		resolveApiKey,
+		resolveUserId,
+		resolveAttachments: () => ctx.get("attachments")
+	});
+	ctx.llm.registerConfigurableProviders([{
+		provider: PROVIDER,
+		displayName: "DeepSeek",
+		settingsNs: NS,
+		settingsPath: []
+	}]);
+	const registration = ctx.llm.registerAdapter([PROVIDER], adapter);
+	let registeredPolicy = options().retryPolicy;
+	const ensureRegistrationFacts = () => {
+		const policy = options().retryPolicy;
+		if (deepEqualJson(policy, registeredPolicy)) return;
+		registration.replace([PROVIDER]);
+		registeredPolicy = policy;
+	};
+	installSettingsSection(ctx, NS, Config, config, {
+		setSource: (source) => {
+			current = source;
+		},
+		onChange: ensureRegistrationFacts
+	});
+}
+//#endregion
+export { Config, DEFAULT_CONTEXT_WINDOW, DEFAULT_MAX_REQUEST_IMAGE_BYTES, DEFAULT_MAX_TOKENS, DEFAULT_STREAM_IDLE_TIMEOUT_MS, DeepSeekAdapter, PUBLIC_BASE_URL, apply, inject, name, resolveAdapterOptions };

--- a/app/src/main/assets/patched/session-persistence-jsonl-index.js
+++ b/app/src/main/assets/patched/session-persistence-jsonl-index.js
@@ -1,0 +1,1464 @@
+import z from "@deepseek-ai/schemastery";
+import { readdirSync } from "node:fs";
+import { link, mkdir, mkdtemp, open, readFile, readdir, realpath, rm, stat, truncate } from "node:fs/promises";
+import { dirname, join, parse, resolve, toNamespacedPath } from "node:path";
+import { performance } from "node:perf_hooks";
+import { scheduler } from "node:timers/promises";
+import { randomBytes } from "node:crypto";
+import { DEFAULT_PREPARED_SESSION_CACHE_SIZE, DEFAULT_WRITE_BATCH_MAX_DELAY_MS, MAX_WRITE_BATCH_DELAY_MS, PersistenceCoordinator, SessionFormatUnsupportedError, SessionPersistence, SessionPersistenceRevision, sessionFormatVersionRefusal } from "@deepseek-ai/dsh-session-persistence";
+import { SESSION_FORMAT_VERSION, decodeStorageRecord, packChunkRuns } from "@deepseek-ai/dsh-session";
+import { constants, createZstdDecompress, zstdCompress, zstdDecompress, zstdDecompressSync } from "node:zlib";
+import { promisify } from "node:util";
+import { constants as constants$1 } from "node:buffer";
+//#region lib/types/format.js
+/**
+* On-disk format helpers for the JSONL session-persistence backend: path
+* sanitization (a {@link SessionId} is an unvalidated branded string, so it
+* MUST be encoded before use in a path — no traversal, no collision), the
+* per-project/session directory layout, header-line (de)serialization, and the
+* truncation-repair offset computation.
+*
+* @module dsh-session-persistence-jsonl/format
+*/
+/**
+* Return the artifact suffix for one physical encoding.
+* @param compression - configured JSONL artifact encoding.
+* @returns `.jsonl.zstd` for Zstandard or `.jsonl` for plaintext.
+*/
+function logSuffix(compression) {
+	return compression === "zstd" ? ".jsonl.zstd" : ".jsonl";
+}
+/**
+* Build the header line object from a {@link SessionHeader}.
+* @param header - the immutable session metadata to serialize.
+* @returns the `type: 'session'`-tagged line object, absent optional fields omitted (never null).
+*/
+function toHeaderLine(header) {
+	return {
+		type: "session",
+		version: header.version,
+		id: header.id,
+		createdAt: header.createdAt,
+		...header.cwd !== void 0 ? { cwd: header.cwd } : {},
+		...header.parentSession !== void 0 ? { parentSession: header.parentSession } : {},
+		...header.seedLength !== void 0 ? { seedLength: header.seedLength } : {},
+		...header.origin !== void 0 ? { origin: header.origin } : {},
+		delegationDepth: header.delegationDepth ?? 0,
+		...header.agentPreset !== void 0 ? { agentPreset: header.agentPreset } : {}
+	};
+}
+/**
+* Parse a header line back into a {@link SessionHeader}.
+* @param line - the shape-checked first line of a log (see the `isHeaderLine` guard).
+* @returns the header, absent optional fields omitted.
+*/
+function fromHeaderLine(line) {
+	if (Object.hasOwn(line, "sandboxMode") || Object.hasOwn(line, "approvalPolicy")) throw new Error("session header uses retired policy baseline fields");
+	return {
+		version: line.version,
+		id: line.id,
+		createdAt: line.createdAt,
+		...line.cwd !== void 0 ? { cwd: line.cwd } : {},
+		...line.parentSession !== void 0 ? { parentSession: line.parentSession } : {},
+		...line.seedLength !== void 0 ? { seedLength: line.seedLength } : {},
+		...line.origin !== void 0 ? { origin: line.origin } : {},
+		delegationDepth: line.delegationDepth,
+		...line.agentPreset !== void 0 ? { agentPreset: line.agentPreset } : {}
+	};
+}
+/** Type guard: a parsed first line is a well-formed session header. */
+function isHeaderLine(value) {
+	return typeof value === "object" && value !== null && value.type === "session" && typeof value.version === "number" && typeof value.id === "string" && typeof value.createdAt === "number" && Number.isSafeInteger(value.createdAt) && value.createdAt >= 0 && !Object.is(value.createdAt, -0) && typeof value.delegationDepth === "number" && Number.isSafeInteger(value.delegationDepth) && value.delegationDepth >= 0 && !Object.is(value.delegationDepth, -0) && (value.origin === void 0 || value.origin === "subagent") && (value.agentPreset === void 0 || typeof value.agentPreset === "string");
+}
+/**
+* Encode an arbitrary string as a single safe path segment, injectively over ALL JS (UTF-16)
+* strings — including lone surrogates. A {@link SessionId} is an unvalidated branded string,
+* so this neutralizes `../`, absolute paths, NUL, and separators before any filesystem use.
+* Safe code units remain literal; every other unit, including `~`, becomes
+* `~XXXX`. Operating on code units preserves lone surrogates, while special-
+* casing `.` and `..` prevents traversal by an otherwise safe whole segment.
+*
+* @param raw - the string to encode; must be non-empty (throws on `''`).
+* @returns the escaped single path segment, decodable back to `raw`.
+*/
+function encodeSegment(raw) {
+	if (raw.length === 0) throw new Error("cannot encode an empty path segment");
+	if (raw === ".") return "~002E";
+	if (raw === "..") return "~002E~002E";
+	let out = "";
+	for (let i = 0; i < raw.length; i++) {
+		const code = raw.charCodeAt(i);
+		const ch = String.fromCharCode(code);
+		if (ch !== "~" && /^[A-Za-z0-9._-]$/.test(ch)) out += ch;
+		else out += "~" + code.toString(16).toUpperCase().padStart(4, "0");
+	}
+	return out;
+}
+/**
+* Build the readable directory key for a project path.
+* Filesystem separators and drive separators become `-`; unsafe code units use
+* the same `~XXXX` escape as session ids. The key is bounded for filesystem
+* component limits. Separator replacement and truncation are intentionally
+* lossy, following the common human-navigable project-directory convention.
+* @param cwd - the session's project directory.
+* @returns a single filesystem-safe project directory name.
+*/
+function projectKey(cwd) {
+	if (cwd.length === 0) throw new Error("cannot encode an empty project path");
+	let readable = "";
+	let separatorRun = false;
+	for (let i = 0; i < cwd.length; i++) {
+		const code = cwd.charCodeAt(i);
+		const ch = String.fromCharCode(code);
+		if (ch === "/" || ch === "\\" || ch === ":") {
+			if (!separatorRun) readable += "-";
+			separatorRun = true;
+		} else if (ch !== "~" && /^[A-Za-z0-9._-]$/.test(ch)) {
+			readable += ch;
+			separatorRun = false;
+		} else {
+			readable += "~" + code.toString(16).toUpperCase().padStart(4, "0");
+			separatorRun = false;
+		}
+	}
+	return `--${(readable.replace(/^-+/, "") || "root").slice(0, 251)}--`;
+}
+/**
+* The configured root's human-navigable project directory. A configured root
+* may be local or shared; this grouping does not prescribe its deployment.
+* @param root - the backend's session root directory.
+* @param cwd - the session's project directory; `undefined` selects `_no-cwd`.
+* @returns the project directory path under `root`.
+*/
+function projectDir(root, cwd) {
+	if (cwd === void 0) return join(root, "_no-cwd");
+	return join(root, projectKey(cwd));
+}
+/**
+* The directory owned by one session and available for future session-local
+* artifacts.
+* @param root - the backend's session root directory.
+* @param cwd - the session's project directory.
+* @param id - the session id, encoded to one safe path segment.
+* @returns the session directory beneath its project directory.
+*/
+function sessionDir(root, cwd, id) {
+	return join(projectDir(root, cwd), encodeSegment(id));
+}
+/**
+* The append-only event-log file path for a session.
+* @param root - the backend's session root directory.
+* @param cwd - the session's project directory (`undefined` → `_no-cwd`).
+* @param id - the session id, path-encoded via {@link encodeSegment} before filesystem use.
+* @param compression - physical artifact encoding and filename suffix.
+* @returns the session's configured JSONL artifact path.
+*/
+function logPath(root, cwd, id, compression) {
+	return join(sessionDir(root, cwd, id), `session${logSuffix(compression)}`);
+}
+/**
+* Serialize an event batch as JSONL lines (no trailing newline). With
+* `packChunks` on, delta-chunk runs pack into `text-chunks` /
+* `reasoning-chunks` / `tool-call-chunks` storage rows; off writes one event
+* per line, byte-identical to the pre-packing layout. Reading is layout-blind
+* either way ({@link scanLog} always decodes rows), so the switch changes only
+* newly written bytes.
+* @param events - the batch to serialize, in log order.
+* @param packChunks - whether to pack delta runs into storage rows.
+* @returns the batch's JSONL text; the writer adds the final newline.
+*/
+function eventLines(events, packChunks) {
+	return (packChunks ? packChunkRuns(events) : events).map((record) => JSON.stringify(record)).join("\n");
+}
+/** Parse one complete header record supplied independently from event rows. */
+/**
+* Refuse a header carrying a format version this build does not read BEFORE
+* validating the current header shape or decoding any event row: a future
+* format need not satisfy today's structural checks at all, and its user must
+* see "upgrade the harness", never "corrupt session log".
+* @param parsed - the JSON-parsed first line of a session artifact.
+*/
+function refuseForeignFormatVersion(parsed) {
+	if (typeof parsed !== "object" || parsed === null) return;
+	const { version, id } = parsed;
+	if (typeof version !== "number" || version === SESSION_FORMAT_VERSION) return;
+	throw new SessionFormatUnsupportedError(sessionFormatVersionRefusal(typeof id === "string" ? id : String(id), version));
+}
+function parseHeaderRecord(record) {
+	if (record.length === 0 || record.at(-1) !== 10 || record.indexOf(10) !== record.length - 1) throw new Error("empty or header-less session log");
+	let parsed;
+	try {
+		parsed = JSON.parse(record.subarray(0, -1).toString("utf8"));
+	} catch {
+		throw new Error("corrupt session log: header line is not valid JSON");
+	}
+	refuseForeignFormatVersion(parsed);
+	if (!isHeaderLine(parsed)) throw new Error("corrupt session log: first line is not a session header");
+	return fromHeaderLine(parsed);
+}
+/**
+* Incrementally scan complete JSONL event records after an independently
+* supplied header record. Newline search and byte offsets stay on raw buffers;
+* only complete records are decoded to UTF-8. A fragment crossing writes is
+* copied because a decoder may reuse its output buffer after `write()` returns.
+*/
+var SessionLogScanner = class {
+	meta;
+	events = [];
+	fragments = [];
+	fragmentBytes = 0;
+	inputBytes;
+	committedBytes;
+	eventLine = 0;
+	issue;
+	finished = false;
+	/**
+	* Create an event scanner from exactly one newline-terminated header record.
+	* @param headerRecord - the complete first JSONL record, including its newline.
+	*/
+	constructor(headerRecord) {
+		this.meta = parseHeaderRecord(headerRecord);
+		this.inputBytes = headerRecord.length;
+		this.committedBytes = headerRecord.length;
+	}
+	/**
+	* Consume the next raw plaintext chunk, retaining only an incomplete final record.
+	* @param chunk - bytes immediately following all previously supplied bytes.
+	*/
+	write(chunk) {
+		if (this.finished) throw new Error("cannot write to a finished session log scanner");
+		const chunkStart = this.inputBytes;
+		this.inputBytes += chunk.length;
+		let lineStart = 0;
+		for (let newline = chunk.indexOf(10); newline !== -1; newline = chunk.indexOf(10, lineStart)) {
+			const fragment = chunk.subarray(lineStart, newline);
+			let line = fragment;
+			if (this.fragments.length > 0) {
+				if (fragment.length > 0) this.fragments.push(fragment);
+				line = Buffer.concat(this.fragments, this.fragmentBytes + fragment.length);
+				this.fragments = [];
+				this.fragmentBytes = 0;
+			}
+			this.consumeEventLine(line, chunkStart + newline + 1);
+			lineStart = newline + 1;
+		}
+		if (lineStart < chunk.length) {
+			const fragment = Buffer.from(chunk.subarray(lineStart));
+			this.fragments.push(fragment);
+			this.fragmentBytes += fragment.length;
+		}
+	}
+	/**
+	* Snapshot progress before appending a recoverable torn-frame prefix.
+	* @returns byte, committed-prefix, and expanded-event cursors.
+	*/
+	checkpoint() {
+		return {
+			inputBytes: this.inputBytes,
+			committedBytes: this.committedBytes,
+			eventCount: this.events.length
+		};
+	}
+	/**
+	* Finish scanning, ignoring a final record without a newline as a torn tail.
+	* @returns the header, contiguous event prefix, and safe truncation offset.
+	*/
+	finish() {
+		this.finished = true;
+		return {
+			meta: this.meta,
+			events: this.events,
+			committedBytes: this.committedBytes
+		};
+	}
+	/** Decode one complete event row and update the contiguous prefix. */
+	consumeEventLine(line, endByte) {
+		this.eventLine += 1;
+		let decoded;
+		try {
+			decoded = decodeStorageRecord(JSON.parse(line.toString("utf8")));
+		} catch {
+			this.issue ??= /* @__PURE__ */ new Error(`corrupt session log: unparsable committed event at line ${this.eventLine}`);
+			return;
+		}
+		if (this.issue !== void 0) {
+			if (decoded.some((event) => event.type === "turn/end")) throw this.issue;
+			return;
+		}
+		const rowStart = this.events.length;
+		for (const event of decoded) {
+			if (event.seq !== this.events.length) {
+				const expected = this.events.length;
+				this.events.length = rowStart;
+				this.issue = /* @__PURE__ */ new Error(`corrupt session log: seq gap in committed region at line ${this.eventLine} (expected ${expected}, got ${event.seq})`);
+				if (decoded.some((candidate) => candidate.type === "turn/end")) throw this.issue;
+				return;
+			}
+			this.events.push(event);
+		}
+		this.committedBytes = endByte;
+	}
+};
+/**
+* Parse a complete or torn JSONL buffer into its preserved event prefix. This
+* compatibility wrapper supplies the first record separately, then delegates
+* event rows to {@link SessionLogScanner}.
+*
+* @param buffer - the raw bytes of the log file (header line first).
+* @returns the header, preserved event prefix, and byte offset safe to append at.
+*/
+function scanLog(buffer) {
+	const headerEnd = buffer.indexOf(10);
+	if (headerEnd === -1) throw new Error("empty or header-less session log");
+	const scanner = new SessionLogScanner(buffer.subarray(0, headerEnd + 1));
+	scanner.write(buffer.subarray(headerEnd + 1));
+	return scanner.finish();
+}
+/**
+* Parse just the header line of a log into a {@link SessionHeader}, or
+* `undefined` if it is missing/not a header. Used by `list()` to read session
+* metadata WITHOUT parsing the whole log: a session picker scales with the
+* number of sessions, not the total size of every conversation.
+* @param firstLine - the first line of a log file (without its trailing newline).
+* @returns the parsed header, or `undefined` when the line is not a well-formed session header.
+*/
+function parseHeaderMeta(firstLine) {
+	let parsed;
+	try {
+		parsed = JSON.parse(firstLine);
+	} catch {
+		return;
+	}
+	if (!isHeaderLine(parsed)) return void 0;
+	return fromHeaderLine(parsed);
+}
+//#endregion
+//#region lib/types/zstd-private-decoder.js
+/**
+* Node-private synchronous Zstandard frame decoder optimization.
+* @module dsh-session-persistence-jsonl/zstd-private-decoder
+*/
+const DECODE_CHUNK_SIZE = 1024 * 1024;
+/** Return the stream with its observed private Node contract, or reject that optimization. */
+function privateZstdStream(stream) {
+	const candidate = stream;
+	const handle = candidate._handle;
+	const errorKey = Reflect.ownKeys(stream).find((key) => typeof key === "symbol" && key.description === "kError");
+	/* v8 ignore next -- one test runtime exposes one Node-private shape; the Node 22/24/26 matrix checks compatibility. */
+	if (typeof handle !== "object" || handle === null || typeof handle.writeSync !== "function" || !(candidate._writeState instanceof Uint32Array) || candidate._writeState.length < 2 || typeof candidate._defaultFlushFlag !== "number" || errorKey === void 0 || candidate[errorKey] !== null) return void 0;
+	return {
+		stream,
+		errorKey
+	};
+}
+/**
+* Synchronous multi-frame decoder backed by one Node Zstd stream handle. Node
+* exposes synchronous decoding only as a one-shot API, so this adapter uses
+* the stream's private handle contract to reuse its native context and output
+* chunks across frames.
+*/
+var NodePrivateZstdFrameDecoder = class NodePrivateZstdFrameDecoder {
+	stream;
+	errorKey;
+	output = Buffer.allocUnsafe(DECODE_CHUNK_SIZE);
+	decoderError;
+	started = false;
+	closed = false;
+	constructor(stream, errorKey) {
+		this.stream = stream;
+		this.errorKey = errorKey;
+		this.stream.on("error", (error) => {
+			this.decoderError ??= error;
+		});
+	}
+	/**
+	* Create the optimized decoder when this Node release exposes the expected
+	* private stream shape.
+	* @returns a shared decoder, or `undefined` when callers must use the public fallback.
+	*/
+	static create() {
+		const stream = createZstdDecompress({ chunkSize: DECODE_CHUNK_SIZE });
+		const privateAccess = privateZstdStream(stream);
+		/* v8 ignore next -- reached only when a supported Node release changes its private stream shape. */
+		if (privateAccess !== void 0) return new NodePrivateZstdFrameDecoder(privateAccess.stream, privateAccess.errorKey);
+		/* v8 ignore next -- the active Node runtime passed the private-shape probe above. */
+		stream.close();
+	}
+	/** @inheritdoc */
+	*decode(source, frames) {
+		if (this.started) throw new Error("Zstandard frame decoder was already started");
+		if (this.closed) throw new Error("cannot start a closed Zstandard frame decoder");
+		this.started = true;
+		try {
+			for (const frame of frames) try {
+				yield this.decodeFrame(source.subarray(frame.start, frame.end));
+			} catch (error) {
+				throw new Error(`corrupt Zstandard session log: frame at byte ${frame.start} failed validation`, { cause: error });
+			}
+		} finally {
+			this.close();
+		}
+	}
+	/** Decode one frame; its returned scratch view remains valid until the next call. */
+	decodeFrame(input) {
+		const handle = this.stream._handle;
+		/* v8 ignore next -- decode() rejects closed instances before entering this private frame operation. */
+		if (this.closed || handle === null) throw new Error("cannot decode with a closed Zstandard frame decoder");
+		let inputOffset = 0;
+		let inputRemaining = input.length;
+		let outputBytes = 0;
+		const fullChunks = [];
+		for (;;) {
+			handle.writeSync(this.stream._defaultFlushFlag, input, inputOffset, inputRemaining, this.output, 0, this.output.length);
+			if (this.decoderError !== void 0) throw this.decoderError;
+			const internalError = this.stream[this.errorKey];
+			if (internalError !== null) {
+				if (internalError instanceof Error) throw internalError;
+				throw new Error("Zstandard decoder exposed a non-Error internal failure");
+			}
+			const outputAfter = this.stream._writeState[0];
+			const inputAfter = this.stream._writeState[1];
+			const consumed = inputRemaining - inputAfter;
+			const produced = this.output.length - outputAfter;
+			if (produced > 0) {
+				outputBytes += produced;
+				/* v8 ignore next -- Buffer cannot materialize a frame beyond its own process-wide maximum length. */
+				if (outputBytes > constants$1.MAX_LENGTH) throw new Error(`Zstandard frame output exceeds ${constants$1.MAX_LENGTH} bytes`);
+			}
+			if (outputAfter !== 0) {
+				/* v8 ignore next -- structurally scanned ranges contain exactly one complete frame and no trailing bytes. */
+				if (inputAfter !== 0) throw new Error("Zstandard frame decoder left trailing input");
+				const finalChunk = this.output.subarray(0, produced);
+				if (fullChunks.length === 0) return finalChunk;
+				if (produced > 0) fullChunks.push(Buffer.from(finalChunk));
+				const onlyChunk = fullChunks[0];
+				return fullChunks.length === 1 ? onlyChunk : Buffer.concat(fullChunks, outputBytes);
+			}
+			fullChunks.push(Buffer.from(this.output));
+			inputOffset += consumed;
+			inputRemaining = inputAfter;
+		}
+	}
+	/** @inheritdoc */
+	close() {
+		if (this.closed) return;
+		this.closed = true;
+		this.stream.close();
+	}
+};
+//#endregion
+//#region lib/types/zstd-public-decoder.js
+/**
+* Public-API synchronous Zstandard frame decoder fallback.
+* @module dsh-session-persistence-jsonl/zstd-public-decoder
+*/
+/** Multi-frame adapter built exclusively from Node's supported one-shot API. */
+var PublicZstdFrameDecoder = class {
+	started = false;
+	closed = false;
+	/** @inheritdoc */
+	*decode(source, frames) {
+		if (this.started) throw new Error("Zstandard frame decoder was already started");
+		if (this.closed) throw new Error("cannot start a closed Zstandard frame decoder");
+		this.started = true;
+		try {
+			for (const { start, end } of frames) {
+				let decoded;
+				try {
+					decoded = zstdDecompressSync(source.subarray(start, end));
+				} catch (error) {
+					throw new Error(`corrupt Zstandard session log: frame at byte ${start} failed validation`, { cause: error });
+				}
+				yield decoded;
+			}
+		} finally {
+			this.close();
+		}
+	}
+	/** @inheritdoc */
+	close() {
+		this.closed = true;
+	}
+};
+//#endregion
+//#region lib/types/zstd.js
+/**
+* Zstandard frame primitives for the JSONL persistence backend. The backend
+* owns a concatenated-frame container so it can append and recover batches
+* without exposing compression mechanics through the persistence seam.
+* @module dsh-session-persistence-jsonl/zstd
+*/
+const ZSTD_MAGIC = 4247762216;
+const zstdCompressAsync = promisify(zstdCompress);
+const zstdDecompressAsync = promisify(zstdDecompress);
+const CHECKSUM_OPTIONS = { params: { [constants.ZSTD_c_checksumFlag]: 1 } };
+const INCOMPLETE_FRAME_OPTIONS = { finishFlush: constants.ZSTD_e_flush };
+/**
+* Locate complete frames without decompressing their blocks. Invalid complete
+* structure rejects; EOF inside the final frame returns its start for repair.
+* @param buffer - complete bytes currently present in the session artifact.
+* @param maxFrames - optional complete-frame limit for metadata-only readers.
+* @returns complete frame ranges and an optional incomplete-final-frame start.
+*/
+function scanZstdFrames(buffer, maxFrames = Number.POSITIVE_INFINITY) {
+	const frames = [];
+	let offset = 0;
+	while (offset < buffer.length) {
+		const start = offset;
+		if (buffer.length - offset < 4) return {
+			frames,
+			tornStart: start
+		};
+		if (buffer.readUInt32LE(offset) !== ZSTD_MAGIC) throw new Error(`corrupt Zstandard session log: invalid frame magic at byte ${offset}`);
+		offset += 4;
+		if (offset === buffer.length) return {
+			frames,
+			tornStart: start
+		};
+		const descriptor = buffer.readUInt8(offset);
+		offset += 1;
+		if ((descriptor & 24) !== 0) throw new Error(`corrupt Zstandard session log: reserved frame-header bit at byte ${offset - 1}`);
+		const contentSizeFlag = descriptor >>> 6;
+		const singleSegment = (descriptor & 32) !== 0;
+		const checksum = (descriptor & 4) !== 0;
+		const dictionaryFlag = descriptor & 3;
+		const dictionaryBytes = dictionaryFlag === 3 ? 4 : dictionaryFlag;
+		const contentSizeBytes = contentSizeFlag === 0 ? singleSegment ? 1 : 0 : 1 << contentSizeFlag;
+		const remainingHeaderBytes = (singleSegment ? 0 : 1) + dictionaryBytes + contentSizeBytes;
+		if (buffer.length - offset < remainingHeaderBytes) return {
+			frames,
+			tornStart: start
+		};
+		offset += remainingHeaderBytes;
+		for (;;) {
+			if (buffer.length - offset < 3) return {
+				frames,
+				tornStart: start
+			};
+			const blockHeader = buffer.readUIntLE(offset, 3);
+			offset += 3;
+			const lastBlock = (blockHeader & 1) !== 0;
+			const blockType = blockHeader >>> 1 & 3;
+			const blockSize = blockHeader >>> 3;
+			if (blockType === 3) throw new Error(`corrupt Zstandard session log: reserved block type at byte ${offset - 3}`);
+			const payloadBytes = blockType === 1 ? 1 : blockSize;
+			if (buffer.length - offset < payloadBytes) return {
+				frames,
+				tornStart: start
+			};
+			offset += payloadBytes;
+			if (lastBlock) break;
+		}
+		if (checksum) {
+			if (buffer.length - offset < 4) return {
+				frames,
+				tornStart: start
+			};
+			offset += 4;
+		}
+		frames.push({
+			start,
+			end: offset
+		});
+		if (frames.length === maxFrames) return { frames };
+	}
+	return { frames };
+}
+/**
+* Compress one independently decodable, checksummed Zstandard frame.
+* @param input - JSONL bytes for a header or durable event batch.
+* @returns the complete encoded frame.
+*/
+async function compressZstdFrame(input) {
+	return zstdCompressAsync(input, CHECKSUM_OPTIONS);
+}
+/**
+* Decompress one complete frame and validate its checksum.
+* @param input - one structurally complete Zstandard frame.
+* @returns the frame plaintext.
+*/
+async function decompressZstdFrame(input) {
+	return zstdDecompressAsync(input);
+}
+/**
+* Select the shared private decoder when the running Node 22/24/26 shape is
+* compatible, otherwise preserve correctness with the public one-shot API.
+* @returns a synchronous decoder with an implementation-independent lifecycle.
+*/
+function createZstdFrameDecoder() {
+	return NodePrivateZstdFrameDecoder.create() ?? new PublicZstdFrameDecoder();
+}
+/**
+* Recover available plaintext from a structurally incomplete final frame.
+* `ZSTD_e_flush` deliberately suppresses final-frame and checksum completion;
+* callers must establish the torn frame boundary before using this helper.
+* @param input - available bytes from a known incomplete Zstandard frame.
+* @returns plaintext produced from the available input.
+*/
+async function decompressZstdPrefix(input) {
+	return zstdDecompressAsync(input, INCOMPLETE_FRAME_OPTIONS);
+}
+//#endregion
+//#region lib/types/win32.js
+/**
+* Windows durable namespace helpers for the JSONL backend.
+*
+* POSIX publishes a newly-created log by creating a directory entry and then
+* fsyncing the parent directory. Windows does not expose that parent-directory
+* fsync contract through Node, so the Windows path uses the native durable
+* namespace primitive instead: create a staging object in the target directory
+* and publish it with `MoveFileExW(..., MOVEFILE_WRITE_THROUGH)` without
+* replacement or cross-volume copy fallback.
+*
+* @module dsh-session-persistence-jsonl/win32
+*/
+const MOVEFILE_WRITE_THROUGH = 8;
+const ERROR_FILE_NOT_FOUND = 2;
+const ERROR_PATH_NOT_FOUND = 3;
+const ERROR_ACCESS_DENIED = 5;
+const ERROR_NOT_SAME_DEVICE = 17;
+const ERROR_FILE_EXISTS = 80;
+const ERROR_INVALID_NAME = 123;
+const ERROR_ALREADY_EXISTS = 183;
+let bindings;
+/** Load the small Win32 API lazily so non-Windows processes never load Koffi. */
+async function win32() {
+	if (bindings !== void 0) return bindings;
+	const kernel32 = (await import("koffi")).default.load("kernel32.dll");
+	bindings = {
+		moveFileExW: kernel32.func("__stdcall", "MoveFileExW", "int", [
+			"str16",
+			"str16",
+			"uint"
+		]),
+		getLastError: kernel32.func("__stdcall", "GetLastError", "uint", [])
+	};
+	return bindings;
+}
+function errnoCode(win32Code) {
+	switch (win32Code) {
+		case ERROR_FILE_NOT_FOUND:
+		case ERROR_PATH_NOT_FOUND: return "ENOENT";
+		case ERROR_ACCESS_DENIED: return "EACCES";
+		case ERROR_NOT_SAME_DEVICE: return "EXDEV";
+		case ERROR_FILE_EXISTS:
+		case ERROR_ALREADY_EXISTS: return "EEXIST";
+		case ERROR_INVALID_NAME: return "EINVAL";
+		default: return "EIO";
+	}
+}
+function win32Error(syscall, win32Code, path, dest) {
+	const code = errnoCode(win32Code);
+	const error = /* @__PURE__ */ new Error(`${syscall} ${code} (Win32 ${win32Code}): ${path} -> ${dest}`);
+	error.code = code;
+	error.errno = win32Code;
+	error.syscall = syscall;
+	error.path = path;
+	error.dest = dest;
+	error.win32Code = win32Code;
+	return error;
+}
+function isENOENT$1(error) {
+	return error?.code === "ENOENT";
+}
+function isEEXIST(error) {
+	return error?.code === "EEXIST";
+}
+async function assertDirectory(path) {
+	try {
+		if ((await stat(path === parse(path).root ? path : toNamespacedPath(path))).isDirectory()) return true;
+		const error = /* @__PURE__ */ new Error(`path exists but is not a directory: ${path}`);
+		error.code = "ENOTDIR";
+		error.path = path;
+		throw error;
+	} catch (error) {
+		if (isENOENT$1(error)) return false;
+		throw error;
+	}
+}
+/**
+* Publish `existing` at `replacement` with Windows write-through rename
+* semantics. The destination must not already exist; the move must stay within
+* the volume (no copy fallback flag is set).
+* @param existing - the synced staging path to move.
+* @param replacement - the final path, which must not already exist.
+*/
+async function publishNewFileWin32(existing, replacement) {
+	const api = await win32();
+	if (api.moveFileExW(toNamespacedPath(existing), toNamespacedPath(replacement), MOVEFILE_WRITE_THROUGH) === 0) throw win32Error("MoveFileExW", api.getLastError(), existing, replacement);
+}
+/**
+* Create `target` and its missing ancestors with durable Windows namespace
+* publication. Each missing directory is first created as a random staging
+* sibling, then moved to its final name with `MOVEFILE_WRITE_THROUGH`; races
+* with another creator are accepted only after verifying the winner is a
+* directory.
+* @param target - the absolute directory path to create durably when absent.
+*/
+async function ensureDurableDirectoryWin32(target) {
+	const absolute = resolve(target);
+	const root = parse(absolute).root;
+	await assertDirectory(root);
+	const segments = absolute.slice(root.length).split(/[\\/]+/).filter((part) => part.length > 0);
+	let current = root;
+	for (const segment of segments) {
+		const next = join(current, segment);
+		if (!await assertDirectory(next)) await createLeafDirectoryWin32(current, next);
+		current = next;
+	}
+}
+async function createLeafDirectoryWin32(parent, target) {
+	const staging = await mkdtemp(toNamespacedPath(join(parent, ".dsh-mkdir-")));
+	try {
+		await publishNewFileWin32(staging, target);
+	} catch (error) {
+		await rm(staging, {
+			recursive: true,
+			force: true
+		});
+		if (isEEXIST(error) && await assertDirectory(target)) return;
+		throw error;
+	}
+}
+//#endregion
+//#region lib/types/index.js
+/**
+* JSONL durable session-persistence backend. It stores a header and contiguous
+* events in one append-only file per session, and delegates orchestration to
+* {@link PersistenceCoordinator}. Its side-effect-free locator returns the
+* absolute per-session log target before materialization.
+* @module @deepseek-ai/dsh-session-persistence-jsonl
+*/
+const DEFAULT_PACK_CHUNKS = true;
+const DEFAULT_COMPRESSION = "zstd";
+/**
+* Internal scheduling constant, not deployment configuration: balance
+* frame-boundary event-loop yields against `setImmediate` overhead. One frame
+* remains an indivisible synchronous decode.
+*/
+const ZSTD_DECODE_YIELD_INTERVAL_MS = 500;
+/** Assert that the independently decodable first frame contains only the header record. */
+function assertZstdHeaderFrame(plaintext) {
+	if (plaintext.length === 0 || plaintext.indexOf(10) !== plaintext.length - 1) throw new Error("corrupt Zstandard session log: first frame is not exactly one header line");
+}
+/** Loader schema for the JSONL artifact's physical encoding. */
+const JsonlCompressionSchema = z.union([z.const("zstd"), z.const("none")]).default(DEFAULT_COMPRESSION);
+/** Build the source-qualified revision shared by full and lightweight reads. */
+function fileRevision(identity) {
+	return SessionPersistenceRevision([
+		identity.dev,
+		identity.ino,
+		identity.size,
+		identity.mtimeNs,
+		identity.ctimeNs
+	].join(":"));
+}
+/** Whether a filesystem error means absence; every non-ENOENT failure must surface. */
+function isENOENT(error) {
+	return error?.code === "ENOENT";
+}
+/**
+* The JSONL persistence backend. Load as a plugin; it registers as
+* `ctx.sessionPersistence` and (via the coordinator) installs the write-path
+* listeners. Its torn-tail marker carries the byte offset and any events
+* recovered from an incomplete final Zstandard frame.
+*/
+var JsonlSessionPersistence = class extends SessionPersistence {
+	config;
+	supportsRawArtifacts = true;
+	static inject = ["sessions"];
+	static Config = z.object({
+		root: z.string().required(),
+		packChunks: z.boolean().default(DEFAULT_PACK_CHUNKS),
+		compression: JsonlCompressionSchema,
+		preparedSessionCacheSize: z.number().step(1).min(1).default(DEFAULT_PREPARED_SESSION_CACHE_SIZE),
+		writeBatchMaxDelayMs: z.number().step(1).min(1).max(MAX_WRITE_BATCH_DELAY_MS).default(DEFAULT_WRITE_BATCH_MAX_DELAY_MS)
+	});
+	/**
+	* Backend label for coordinator diagnostics and effects. It shadows
+	* `Service.name` without changing the service key captured by the base
+	* constructor.
+	*/
+	name = "session-persistence-jsonl";
+	root;
+	packChunks;
+	compression;
+	coordinator;
+	rootEncodingCheck;
+	constructor(ctx, config) {
+		super(ctx);
+		this.config = config;
+		this.root = resolve(config.root);
+		const preparedSessionCacheSize = config.preparedSessionCacheSize ?? DEFAULT_PREPARED_SESSION_CACHE_SIZE;
+		const writeBatchMaxDelayMs = config.writeBatchMaxDelayMs ?? DEFAULT_WRITE_BATCH_MAX_DELAY_MS;
+		this.packChunks = config.packChunks ?? DEFAULT_PACK_CHUNKS;
+		this.compression = config.compression ?? DEFAULT_COMPRESSION;
+		this.assertUsableRoot();
+		this.coordinator = new PersistenceCoordinator(this.ctx, this, {
+			preparedSessionCacheSize,
+			writeBatchMaxDelayMs
+		});
+	}
+	/** Resolve the absolute target path without touching the filesystem. */
+	locate(meta) {
+		return {
+			kind: "jsonl",
+			path: logPath(this.root, meta.cwd, meta.id, this.compression)
+		};
+	}
+	create(meta) {
+		return this.coordinator.create(meta);
+	}
+	append(id, events) {
+		return this.coordinator.append(id, events);
+	}
+	prepare(id, signal) {
+		return this.coordinator.prepare(id, signal);
+	}
+	load(id) {
+		return this.coordinator.load(id);
+	}
+	inspect(id, signal) {
+		return this.coordinator.inspect(id, signal);
+	}
+	readFrom(id, fromSeq, signal) {
+		return this.coordinator.readFrom(id, fromSeq, signal);
+	}
+	/** Read a stored prefix by id across all project directories when cwd is unknown. */
+	async loadStored(id, signal) {
+		signal?.throwIfAborted();
+		await this.ensureRootEncoding();
+		signal?.throwIfAborted();
+		const path = await this.findLog(id, signal);
+		if (path === void 0) return void 0;
+		return this.readPrefix(path, id, signal);
+	}
+	/**
+	* Read one log's stat-derived revision without loading its event bytes.
+	* Resolving an id with unknown cwd still scans the project directories.
+	*/
+	async readStoredRevision(id, signal) {
+		signal?.throwIfAborted();
+		await this.ensureRootEncoding();
+		signal?.throwIfAborted();
+		const path = await this.findLog(id, signal);
+		if (path === void 0) return void 0;
+		try {
+			const identity = await stat(path, { bigint: true });
+			signal?.throwIfAborted();
+			return fileRevision(identity);
+		} catch (error) {
+			signal?.throwIfAborted();
+			if (isENOENT(error)) return void 0;
+			throw error;
+		}
+	}
+	/**
+	* Read a session's stored artifact text verbatim: the durable file bytes
+	* decoded from this backend's physical encoding (complete zstd frames
+	* concatenated, or UTF-8 plaintext). The content is the exact JSONL text the
+	* backend wrote — never a reconstruction from parsed events — so packed-
+	* chunk rows, key order, and line breaks survive byte-for-byte. A torn
+	* final frame is omitted, matching the committed-prefix semantics of every
+	* other read.
+	* @param id - the persisted session to read.
+	* @param signal - optional cancellation for the stat/read/decode work.
+	* @returns the raw artifact text plus the header parsed from its own first
+	* line, or `undefined` when the session has no stored artifact.
+	*/
+	async readRaw(id, signal) {
+		signal?.throwIfAborted();
+		await this.ensureRootEncoding();
+		signal?.throwIfAborted();
+		const path = await this.findLog(id, signal);
+		if (path === void 0) return void 0;
+		const { buffer } = await this.readStableFile(path, signal);
+		let content;
+		if (this.compression === "zstd") {
+			const { frames } = scanZstdFrames(buffer);
+			if (frames.length === 0) throw new Error("empty or header-less Zstandard session log");
+			const decoder = createZstdFrameDecoder();
+			const plaintexts = [];
+			for (const plaintext of decoder.decode(buffer, frames)) {
+				signal?.throwIfAborted();
+				plaintexts.push(Buffer.from(plaintext));
+			}
+			content = Buffer.concat(plaintexts).toString("utf8");
+		} else content = buffer.toString("utf8");
+		const meta = parseHeaderMeta(content.split("\n", 1)[0]);
+		if (meta === void 0 || meta.id !== id) throw new Error(`corrupt session log: invalid header line in "${path}"`);
+		return {
+			meta,
+			filename: "session.jsonl",
+			content
+		};
+	}
+	/**
+	* Read a file's bytes under a revision-stable loop: a writer appending
+	* between stat and readFile would yield a torn physical file, so retry
+	* while the stat revision changes.
+	* @param path - the artifact file to read.
+	* @param signal - optional cancellation for the stat/read work.
+	* @returns the stable bytes and the revision that matched both stats.
+	*/
+	async readStableFile(path, signal) {
+		for (;;) {
+			signal?.throwIfAborted();
+			const before = fileRevision(await stat(path, { bigint: true }));
+			const buffer = await readFile(path, { signal });
+			signal?.throwIfAborted();
+			const after = fileRevision(await stat(path, { bigint: true }));
+			if (before === after) return {
+				buffer,
+				revision: after
+			};
+		}
+	}
+	/**
+	* Read a stored prefix and convert torn-tail state to the opaque marker the
+	* coordinator can round-trip without knowing the physical encoding.
+	*/
+	async readPrefix(path, expectedId, signal) {
+		const { buffer, revision } = await this.readStableFile(path, signal);
+		let prefix;
+		try {
+			if (this.compression === "zstd") prefix = await this.readZstdPrefix(buffer, signal);
+			else {
+				signal?.throwIfAborted();
+				const { meta, events, committedBytes } = scanLog(buffer);
+				signal?.throwIfAborted();
+				prefix = {
+					meta,
+					events,
+					...committedBytes < buffer.byteLength ? { tornMarker: {
+						truncateTo: committedBytes,
+						recoveredEvents: []
+					} } : {}
+				};
+			}
+		} catch (error) {
+			if (error instanceof SessionFormatUnsupportedError && error.location === void 0) throw new SessionFormatUnsupportedError(`${error.message} (raw log: ${path})`, {
+				kind: "jsonl",
+				path
+			});
+			throw error;
+		}
+		signal?.throwIfAborted();
+		await this.assertStoredIdentity(path, prefix.meta, expectedId, signal);
+		signal?.throwIfAborted();
+		return {
+			...prefix,
+			revision
+		};
+	}
+	/** Decode complete frames and retain complete JSONL records from a torn final frame. */
+	async readZstdPrefix(buffer, signal) {
+		signal?.throwIfAborted();
+		const { frames, tornStart } = scanZstdFrames(buffer);
+		signal?.throwIfAborted();
+		if (frames.length === 0) throw new Error("empty or header-less Zstandard session log");
+		const decoder = createZstdFrameDecoder();
+		let yieldDeadline = performance.now() + ZSTD_DECODE_YIELD_INTERVAL_MS;
+		try {
+			const decodedFrames = decoder.decode(buffer, frames);
+			signal?.throwIfAborted();
+			const headerFrame = decodedFrames.next();
+			signal?.throwIfAborted();
+			/* v8 ignore next -- a non-empty structural frame list makes the decoder yield its first frame or throw. */
+			if (headerFrame.done) throw new Error("empty or header-less Zstandard session log");
+			assertZstdHeaderFrame(headerFrame.value);
+			const scanner = new SessionLogScanner(headerFrame.value);
+			let remainingFrames = frames.length - 1;
+			for (const plaintext of decodedFrames) {
+				signal?.throwIfAborted();
+				scanner.write(plaintext);
+				remainingFrames -= 1;
+				if (remainingFrames > 0 && performance.now() >= yieldDeadline) {
+					await scheduler.yield();
+					signal?.throwIfAborted();
+					yieldDeadline = performance.now() + ZSTD_DECODE_YIELD_INTERVAL_MS;
+				}
+			}
+			signal?.throwIfAborted();
+			const complete = scanner.checkpoint();
+			if (complete.committedBytes !== complete.inputBytes) throw new Error("corrupt Zstandard session log: complete frame contains a torn JSONL record");
+			if (tornStart === void 0) {
+				const prefix = scanner.finish();
+				return {
+					meta: prefix.meta,
+					events: prefix.events
+				};
+			}
+			let recoveredPlaintext = Buffer.alloc(0);
+			try {
+				signal?.throwIfAborted();
+				recoveredPlaintext = await decompressZstdPrefix(buffer.subarray(tornStart));
+			} catch {
+				/* v8 ignore next -- decoder failure plus concurrent abort is timing-dependent */
+				if (signal?.aborted) signal.throwIfAborted();
+			}
+			signal?.throwIfAborted();
+			scanner.write(recoveredPlaintext);
+			const recoveredPrefix = scanner.finish();
+			signal?.throwIfAborted();
+			return {
+				meta: recoveredPrefix.meta,
+				events: recoveredPrefix.events,
+				tornMarker: {
+					truncateTo: tornStart,
+					recoveredEvents: recoveredPrefix.events.slice(complete.eventCount)
+				}
+			};
+		} catch (error) {
+			/* v8 ignore next -- decoder failure plus concurrent abort is timing-dependent */
+			if (signal?.aborted) signal.throwIfAborted();
+			throw error;
+		} finally {
+			decoder.close();
+		}
+	}
+	/** Durably append a batch, lazily materializing the file when not yet present. */
+	async appendBatch(meta, events, isMaterialized) {
+		await this.ensureRootEncoding();
+		if (isMaterialized) await this.appendLines(meta, events);
+		else await this.materialize(meta, events);
+	}
+	/**
+	* Make a crash repair durable: truncate a torn tail, restore complete events
+	* decoded from it, then append synthetic closers. Two fsync'd steps — the seam
+	* does not require this to be atomic.
+	*/
+	async commitRepair(meta, tornMarker, closers) {
+		if (tornMarker !== void 0) await this.repair(meta, tornMarker.truncateTo);
+		const repairedEvents = [...tornMarker?.recoveredEvents ?? [], ...closers];
+		if (repairedEvents.length > 0) await this.appendLines(meta, repairedEvents);
+	}
+	/** List valid unique stored sessions' metadata (header line only — no full-log parse). */
+	async list(signal) {
+		return (await this.listArtifacts(signal)).map((artifact) => artifact.header);
+	}
+	/** List metadata plus a stat-derived identity for each append-only log. */
+	async listSnapshots(signal) {
+		const snapshots = [];
+		for (const artifact of await this.listArtifacts(signal)) {
+			signal?.throwIfAborted();
+			try {
+				const identity = await stat(artifact.path, { bigint: true });
+				signal?.throwIfAborted();
+				snapshots.push({
+					header: artifact.header,
+					revision: fileRevision(identity)
+				});
+			} catch (error) {
+				signal?.throwIfAborted();
+				if (!isENOENT(error)) throw error;
+			}
+		}
+		signal?.throwIfAborted();
+		return snapshots;
+	}
+	async listArtifacts(signal) {
+		signal?.throwIfAborted();
+		await this.ensureRootEncoding();
+		signal?.throwIfAborted();
+		const artifacts = [];
+		const ids = /* @__PURE__ */ new Set();
+		for (const project of await this.listProjectDirs(signal)) {
+			signal?.throwIfAborted();
+			for (const dir of await this.listSessionDirs(project, signal)) {
+				signal?.throwIfAborted();
+				const opposite = join(dir, `session${logSuffix(this.oppositeCompression())}`);
+				const oppositeExists = await this.exists(opposite);
+				signal?.throwIfAborted();
+				if (oppositeExists) throw this.encodingMismatch(opposite);
+				const path = join(dir, `session${logSuffix(this.compression)}`);
+				const pathExists = await this.exists(path);
+				signal?.throwIfAborted();
+				if (!pathExists) continue;
+				const first = this.compression === "zstd" ? await this.readFirstZstdLine(path, signal) : await this.readFirstLine(path, signal);
+				signal?.throwIfAborted();
+				if (first === void 0) continue;
+				const meta = parseHeaderMeta(first);
+				if (meta === void 0) continue;
+				await this.assertStoredIdentity(path, meta, void 0, signal);
+				signal?.throwIfAborted();
+				if (ids.has(meta.id)) throw new Error(`duplicate JSONL session id "${meta.id}" appears in multiple project directories`);
+				ids.add(meta.id);
+				artifacts.push({
+					header: meta,
+					path
+				});
+			}
+		}
+		signal?.throwIfAborted();
+		return artifacts;
+	}
+	/** Atomically write the header line + first batch (temp-write, fsync, publish). */
+	async materialize(meta, events) {
+		const project = projectDir(this.root, meta.cwd);
+		const dir = sessionDir(this.root, meta.cwd, meta.id);
+		const finalPath = logPath(this.root, meta.cwd, meta.id, this.compression);
+		await this.rejectOppositeArtifact(meta.cwd, meta.id);
+		const content = await this.encodeMaterialization(meta, events);
+		/* v8 ignore next -- native Windows coverage exercises this platform dispatch; Linux covers the POSIX peer */
+		if (process.platform === "win32") await this.materializeWin32(project, dir, finalPath, meta.id, content);
+		else await this.materializePosix(project, dir, finalPath, meta.id, content);
+	}
+	/* v8 ignore start -- Windows uses the Win32 durable-publish path; POSIX coverage exercises this peer. */
+	async materializePosix(project, dir, finalPath, id, content) {
+		await mkdir(this.root, {
+			recursive: true,
+			mode: 448
+		});
+		await this.syncDirPosix(dirname(this.root));
+		await mkdir(project, {
+			recursive: true,
+			mode: 448
+		});
+		await this.syncDirPosix(this.root);
+		await mkdir(dir, {
+			recursive: true,
+			mode: 448
+		});
+		await this.syncDirPosix(project);
+		await this.rejectExistingLog(finalPath, id);
+		const tmp = await this.writeSyncedTempFile(finalPath, content);
+		let linked = false;
+		try {
+			// android-link-eacces-fallback: Android app domains forbid link(2)
+			// (sepolicy; Huawei/HarmonyOS observed), fall back to a rename
+			// (single-process, same content) like dsh 0.1.0-rc.8 did.
+			await link(tmp, finalPath).catch(function (e) { if (e.code !== "EACCES" && e.code !== "EPERM" && e.code !== "ENOTSUP") throw e; return rename(tmp, finalPath); });
+			linked = true;
+		} finally {
+			/* v8 ignore next -- link failure is the TOCTOU/IO race guarded above; not reachable in test */
+			if (!linked) await rm(tmp, { force: true });
+		}
+		await this.syncDirPosix(dir);
+		try {
+			await rm(tmp, { force: true });
+		} catch {}
+	}
+	/* v8 ignore stop */
+	/* v8 ignore start -- native Windows coverage exercises this integration path */
+	async materializeWin32(project, dir, finalPath, id, content) {
+		await ensureDurableDirectoryWin32(this.root);
+		await ensureDurableDirectoryWin32(project);
+		await ensureDurableDirectoryWin32(dir);
+		await this.rejectExistingLog(finalPath, id);
+		const tmp = await this.writeSyncedTempFile(finalPath, content);
+		try {
+			await publishNewFileWin32(tmp, finalPath);
+		} catch (error) {
+			await rm(tmp, { force: true });
+			throw error;
+		}
+	}
+	/* v8 ignore stop */
+	async rejectExistingLog(finalPath, id) {
+		/* v8 ignore next 3 -- createCore guards collisions before materialize; this is a TOCTOU backstop */
+		if (await this.exists(finalPath)) throw new Error(`refusing to materialize "${id}": a log already exists on disk (load/resume it instead)`);
+	}
+	async writeSyncedTempFile(finalPath, content) {
+		const tmp = `${finalPath}.${randomBytes(6).toString("hex")}.tmp`;
+		const handle = await open(tmp, "wx", 384);
+		try {
+			await handle.writeFile(content);
+			await handle.sync();
+		} finally {
+			await handle.close();
+		}
+		return tmp;
+	}
+	/** Encode the header and first batch without combining their frame boundaries. */
+	async encodeMaterialization(meta, events) {
+		const header = JSON.stringify(toHeaderLine(meta)) + "\n";
+		const body = eventLines(events, this.packChunks) + "\n";
+		if (this.compression === "none") return header + body;
+		const headerFrame = await compressZstdFrame(header);
+		const eventFrame = await compressZstdFrame(body);
+		return Buffer.concat([headerFrame, eventFrame]);
+	}
+	/** Encode one durable append batch in the configured physical representation. */
+	async encodeEventBatch(events) {
+		const body = eventLines(events, this.packChunks) + "\n";
+		return this.compression === "zstd" ? compressZstdFrame(body) : body;
+	}
+	/** fsync a POSIX directory so a just-created/renamed entry is crash-durable. */
+	/* v8 ignore start -- Windows uses write-through namespace operations; POSIX coverage exercises directory fsync. */
+	async syncDirPosix(dir) {
+		const handle = await open(dir, "r");
+		try {
+			await handle.sync();
+		} finally {
+			await handle.close();
+		}
+	}
+	/* v8 ignore stop */
+	/**
+	* Append and fsync event lines. On a partial write or sync failure, restore the
+	* previous size before rethrowing because the unchanged cursor will retry the
+	* batch; leaving partial bytes would create duplicate sequence numbers.
+	*/
+	async appendLines(meta, events) {
+		const content = await this.encodeEventBatch(events);
+		const path = logPath(this.root, meta.cwd, meta.id, this.compression);
+		const handle = await open(path, "a");
+		let closed = false;
+		const closeAppendHandle = async () => {
+			if (closed) return;
+			closed = true;
+			await handle.close();
+		};
+		try {
+			const { size: before } = await handle.stat();
+			try {
+				await handle.writeFile(content);
+				await handle.sync();
+			} catch (error) {
+				try {
+					await closeAppendHandle();
+					await this.rollbackAppend(path, before);
+				} catch (rollbackError) {
+					throw new AggregateError([error, rollbackError], `failed to roll back append to "${path}"`);
+				}
+				throw error;
+			}
+		} finally {
+			await closeAppendHandle();
+		}
+	}
+	async rollbackAppend(path, size) {
+		const handle = await open(path, "r+");
+		try {
+			await handle.truncate(size);
+			await handle.sync();
+		} finally {
+			await handle.close();
+		}
+	}
+	/** Truncate the log file to `offset` bytes and fsync (discard the crash tail). */
+	async repair(meta, offset) {
+		const path = logPath(this.root, meta.cwd, meta.id, this.compression);
+		await truncate(path, offset);
+		const handle = await open(path, "r+");
+		try {
+			await handle.sync();
+		} finally {
+			await handle.close();
+		}
+	}
+	/**
+	* Read the first newline-terminated line of a file without loading the whole
+	* file. Returns undefined if the file is empty or has no complete first line.
+	* Reads in bounded chunks so a huge log costs only the header read.
+	*/
+	async readFirstLine(path, signal) {
+		signal?.throwIfAborted();
+		const handle = await open(path, "r");
+		try {
+			signal?.throwIfAborted();
+			const chunks = [];
+			const buf = Buffer.alloc(8192);
+			for (;;) {
+				signal?.throwIfAborted();
+				const { bytesRead } = await handle.read(buf, 0, buf.length, null);
+				signal?.throwIfAborted();
+				if (bytesRead === 0) return void 0;
+				const slice = buf.subarray(0, bytesRead);
+				const nl = slice.indexOf(10);
+				if (nl !== -1) {
+					chunks.push(slice.subarray(0, nl));
+					signal?.throwIfAborted();
+					return Buffer.concat(chunks).toString("utf8");
+				}
+				chunks.push(Buffer.from(slice));
+			}
+		} finally {
+			await handle.close();
+		}
+	}
+	/** Read and validate only the independently compressed header frame. */
+	async readFirstZstdLine(path, signal) {
+		signal?.throwIfAborted();
+		const handle = await open(path, "r");
+		try {
+			signal?.throwIfAborted();
+			let content = Buffer.alloc(0);
+			const chunk = Buffer.alloc(8192);
+			for (;;) {
+				signal?.throwIfAborted();
+				const { bytesRead } = await handle.read(chunk, 0, chunk.length, null);
+				signal?.throwIfAborted();
+				if (bytesRead === 0) return void 0;
+				signal?.throwIfAborted();
+				content = Buffer.concat([content, chunk.subarray(0, bytesRead)]);
+				signal?.throwIfAborted();
+				const first = scanZstdFrames(content, 1).frames[0];
+				signal?.throwIfAborted();
+				if (first === void 0) continue;
+				let plaintext;
+				try {
+					signal?.throwIfAborted();
+					plaintext = await decompressZstdFrame(content.subarray(first.start, first.end));
+				} catch (error) {
+					/* v8 ignore next -- decoder failure plus concurrent abort is timing-dependent */
+					if (signal?.aborted) signal.throwIfAborted();
+					throw new Error("corrupt Zstandard session log: header frame failed validation", { cause: error });
+				}
+				signal?.throwIfAborted();
+				assertZstdHeaderFrame(plaintext);
+				return plaintext.subarray(0, -1).toString("utf8");
+			}
+		} finally {
+			await handle.close();
+		}
+	}
+	/** Find the unique physical log for an id across every project directory. */
+	async findLog(id, signal) {
+		const matches = [];
+		for (const project of await this.listProjectDirs(signal)) {
+			signal?.throwIfAborted();
+			await this.rejectLegacyFlatArtifact(project, id, signal);
+			signal?.throwIfAborted();
+			const dir = join(project, encodeSegment(id));
+			const path = join(dir, `session${logSuffix(this.compression)}`);
+			const opposite = join(dir, `session${logSuffix(this.oppositeCompression())}`);
+			const oppositeExists = await this.exists(opposite);
+			signal?.throwIfAborted();
+			if (oppositeExists) throw this.encodingMismatch(opposite);
+			const pathExists = await this.exists(path);
+			signal?.throwIfAborted();
+			if (pathExists) matches.push(path);
+		}
+		if (matches.length > 1) throw new Error(`duplicate JSONL session id "${id}" appears in multiple project directories`);
+		signal?.throwIfAborted();
+		return matches[0];
+	}
+	/** Require an existing configured root to be a readable directory. */
+	assertUsableRoot() {
+		try {
+			readdirSync(this.root);
+		} catch (error) {
+			if (isENOENT(error)) return;
+			throw error;
+		}
+	}
+	/** Reject metadata that does not identify the selected physical log. */
+	async assertStoredIdentity(path, meta, expectedId, signal) {
+		signal?.throwIfAborted();
+		if (expectedId !== void 0 && meta.id !== expectedId) throw new Error(`corrupt session log "${path}": requested id "${expectedId}" does not match header id "${meta.id}"`);
+		let expectedPath;
+		try {
+			expectedPath = logPath(this.root, meta.cwd, meta.id, this.compression);
+		} catch (error) {
+			throw new Error(`corrupt session log "${path}": header id cannot name a storage path`, { cause: error });
+		}
+		if (path !== expectedPath && !await this.sameFile(path, expectedPath, signal)) throw new Error(`corrupt session log "${path}": header id "${meta.id}" and cwd identify "${expectedPath}"`);
+		signal?.throwIfAborted();
+	}
+	/**
+	* Whether two path spellings resolve to the same physical file. This admits
+	* case aliases on case-insensitive filesystems without weakening identity
+	* checks on case-sensitive stores.
+	*/
+	async sameFile(path, expectedPath, signal) {
+		signal?.throwIfAborted();
+		try {
+			const [actual, expected] = await Promise.all([realpath(path), realpath(expectedPath)]);
+			signal?.throwIfAborted();
+			return actual === expected;
+		} catch (error) {
+			signal?.throwIfAborted();
+			/* v8 ignore else -- non-ENOENT realpath failures require an external permission or I/O fault */
+			if (isENOENT(error)) return false;
+			/* v8 ignore next -- non-ENOENT realpath failures are external I/O faults, propagated unchanged */
+			throw error;
+		}
+	}
+	/** The human-readable project directories under the configured root. */
+	async listProjectDirs(signal) {
+		try {
+			signal?.throwIfAborted();
+			const entries = await readdir(this.root, { withFileTypes: true });
+			signal?.throwIfAborted();
+			return entries.filter((e) => e.isDirectory()).map((e) => join(this.root, e.name));
+		} catch (error) {
+			if (isENOENT(error)) return [];
+			throw error;
+		}
+	}
+	/** List session-owned directories and reject the obsolete flat-file layout. */
+	async listSessionDirs(project, signal) {
+		signal?.throwIfAborted();
+		const entries = await readdir(project, { withFileTypes: true });
+		signal?.throwIfAborted();
+		const legacy = entries.find((entry) => entry.isFile() && (entry.name.endsWith(".jsonl") || entry.name.endsWith(".jsonl.zstd")));
+		if (legacy !== void 0) throw this.legacyLayout(join(project, legacy.name));
+		return entries.filter((entry) => entry.isDirectory()).map((entry) => join(project, entry.name));
+	}
+	/** Reject a root that already belongs to the other physical encoding. */
+	ensureRootEncoding() {
+		this.rootEncodingCheck ??= this.checkRootEncoding();
+		return this.rootEncodingCheck;
+	}
+	async checkRootEncoding() {
+		for (const project of await this.listProjectDirs()) for (const dir of await this.listSessionDirs(project)) {
+			const incompatible = join(dir, `session${logSuffix(this.oppositeCompression())}`);
+			if (await this.exists(incompatible)) throw this.encodingMismatch(incompatible);
+		}
+	}
+	async rejectLegacyFlatArtifact(project, id, signal) {
+		signal?.throwIfAborted();
+		const encoded = encodeSegment(id);
+		for (const compression of ["zstd", "none"]) {
+			const path = join(project, encoded + logSuffix(compression));
+			const artifactExists = await this.exists(path);
+			signal?.throwIfAborted();
+			if (artifactExists) throw this.legacyLayout(path);
+		}
+	}
+	async rejectOppositeArtifact(cwd, id) {
+		const path = logPath(this.root, cwd, id, this.oppositeCompression());
+		if (await this.exists(path)) throw this.encodingMismatch(path);
+	}
+	oppositeCompression() {
+		return this.compression === "zstd" ? "none" : "zstd";
+	}
+	encodingMismatch(path) {
+		return /* @__PURE__ */ new Error(`session artifact ${JSON.stringify(path)} uses ${logSuffix(this.oppositeCompression())}, but this backend is configured for compression ${JSON.stringify(this.compression)}; use a separate root or select the matching compression mode`);
+	}
+	legacyLayout(path) {
+		return /* @__PURE__ */ new Error(`session artifact ${JSON.stringify(path)} uses the unsupported flat-file layout; use a separate root or move it into a project/session directory before loading`);
+	}
+	async exists(path) {
+		try {
+			await (await open(path, "r")).close();
+			return true;
+		} catch (error) {
+			/* v8 ignore else -- Windows reports file-valued parents as ENOENT; POSIX covers direct ENOTDIR. */
+			if (isENOENT(error)) {
+				await this.assertLogParentAllowsAbsence(path);
+				return false;
+			}
+			/* v8 ignore next -- Windows repairs ENOTDIR from ENOENT above; POSIX covers direct ENOTDIR. */
+			throw error;
+		}
+	}
+	/* v8 ignore start -- native Windows coverage exercises this repair; POSIX open reports ENOTDIR before this point. */
+	async assertLogParentAllowsAbsence(path) {
+		try {
+			const parent = dirname(path);
+			if ((await stat(parent)).isDirectory()) return;
+			const error = /* @__PURE__ */ new Error(`ENOTDIR: parent path exists but is not a directory: ${parent}`);
+			error.code = "ENOTDIR";
+			error.path = parent;
+			throw error;
+		} catch (error) {
+			if (isENOENT(error)) return;
+			throw error;
+		}
+	}
+};
+//#endregion
+export { JsonlCompressionSchema, JsonlSessionPersistence, JsonlSessionPersistence as default };

--- a/app/src/main/assets/patched/session-persistence-jsonl-index.js
+++ b/app/src/main/assets/patched/session-persistence-jsonl-index.js
@@ -1125,7 +1125,7 @@ var JsonlSessionPersistence = class extends SessionPersistence {
 		const tmp = await this.writeSyncedTempFile(finalPath, content);
 		let linked = false;
 		try {
-			// android-link-eacces-fallback: Android app domains forbid link(2)
+			// jsonl-link-eacces-fallback: Android app domains forbid link(2)
 			// (sepolicy; Huawei/HarmonyOS observed), fall back to a rename
 			// (single-process, same content) like dsh 0.1.0-rc.8 did.
 			await link(tmp, finalPath).catch(function (e) { if (e.code !== "EACCES" && e.code !== "EPERM" && e.code !== "ENOTSUP") throw e; return rename(tmp, finalPath); });

--- a/app/src/main/assets/patched/web-frontend-index.html
+++ b/app/src/main/assets/patched/web-frontend-index.html
@@ -60,10 +60,10 @@
         window.addEventListener("storage", applyImmersiveAttr);
         try { window.__dshImmersiveApply = applyImmersiveAttr; } catch (e) {}
       })();
-    </script>    <script type="module" crossorigin src="/assets/index-CA9Bpko5.js"></script>
+    </script>    <script type="module" crossorigin src="/assets/index-ClqxG24t.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/vendor-D22_Mp1f.js">
     <link rel="stylesheet" crossorigin href="/assets/vendor-CjyC-hUb.css">
-    <link rel="stylesheet" crossorigin href="/assets/index-BNMwCG9c.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-C6eRlFa6.css">
   </head>
   <body>
     <div id="root"></div>

--- a/app/src/main/java/com/dshmobile/shell/EngineManager.kt
+++ b/app/src/main/java/com/dshmobile/shell/EngineManager.kt
@@ -360,6 +360,9 @@ class EngineManager(private val context: Context, private val pickToken: String?
    *  - session-persistence-jsonl-index.js / fs-local-index.js: Android link(2) fallback — dsh
    *    0.1.1-rc.1 dropped the EACCES/EPERM/ENOTSUP → rename fallback that rc.8 shipped; Android
    *    app domains forbid link(2) (sepolicy), re-add it as a full-file overlay (as in rc.8).
+   *    Note: these are full-file overlays pinned to the rc.1 bundle; when the snapshot is next
+   *    upgraded, re-evaluate whether the overlay is still needed (upstream may re-add the
+   *    fallback) instead of blindly overwriting the newer native file.
    * (v0.12.4 rc8 removed the onImagePicked/llm-deepseek/textzoom patches — rc8's native image
    * request support and no-cache hardening supersede them; the vision-exp patch re-adds a
    * catalog-only llm-deepseek overlay for the model released 2026-08-21.)
@@ -381,9 +384,9 @@ class EngineManager(private val context: Context, private val pickToken: String?
     applyAssetPatch("patched/llm-deepseek-index.js",
       File(dshPkgs, "dsh-llm-deepseek/lib/index.js"), "deepseek-v4-flash-vision-exp")
     applyAssetPatch("patched/session-persistence-jsonl-index.js",
-      File(dshPkgs, "dsh-session-persistence-jsonl/lib/index.js"), "android-link-eacces-fallback")
+      File(dshPkgs, "dsh-session-persistence-jsonl/lib/index.js"), "jsonl-link-eacces-fallback")
     applyAssetPatch("patched/fs-local-index.js",
-      File(dshPkgs, "dsh-fs-local/lib/index.js"), "android-link-eacces-fallback")
+      File(dshPkgs, "dsh-fs-local/lib/index.js"), "fs-link-eacces-fallback")
   }
 
   /** Overwrite-style patch: skipped when the target already contains the marker string. */

--- a/app/src/main/java/com/dshmobile/shell/EngineManager.kt
+++ b/app/src/main/java/com/dshmobile/shell/EngineManager.kt
@@ -353,8 +353,16 @@ class EngineManager(private val context: Context, private val pickToken: String?
    *  - primitives-index.js: clipboard fallback for WebViews where navigator.clipboard is denied
    *  - attachment-local-index.js: Android link(2) blocked by sepolicy → copyFile fallback + EACCES tolerance
    *  - web-frontend-index.html: immersive viewport-fit=cover patch
+   *  - llm-deepseek-index.js: DeepSeek-V4-Flash-Vision-Exp catalog entry (multimodal vision model,
+   *    official since dsh 0.1.1-rc.1). Stores the rc.1 adapter as a full-file overlay, so the model
+   *    is selectable on any base snapshot; skip-marker is the model id itself, so a base whose
+   *    bundled adapter already ships the model (0.1.1-rc.1+) leaves the native file untouched.
+   *  - session-persistence-jsonl-index.js / fs-local-index.js: Android link(2) fallback — dsh
+   *    0.1.1-rc.1 dropped the EACCES/EPERM/ENOTSUP → rename fallback that rc.8 shipped; Android
+   *    app domains forbid link(2) (sepolicy), re-add it as a full-file overlay (as in rc.8).
    * (v0.12.4 rc8 removed the onImagePicked/llm-deepseek/textzoom patches — rc8's native image
-   * request support and no-cache hardening supersede them.)
+   * request support and no-cache hardening supersede them; the vision-exp patch re-adds a
+   * catalog-only llm-deepseek overlay for the model released 2026-08-21.)
    */
   private fun applyRuntimePatches() {
     val dshPkgs = File(usrDir, "lib/node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai")
@@ -367,13 +375,26 @@ class EngineManager(private val context: Context, private val pickToken: String?
     applyAssetPatch("patched/primitives-index.js",
       File(dshPkgs, "dsh-client-ui-primitives/lib/index.js"), "dsh-mobile-clip-fallback")
     applyAssetPatch("patched/attachment-local-index.js",
-      File(dshPkgs, "dsh-attachment-local/lib/index.js"), "attachment-link-eacces-fallback")
+      File(dshPkgs, "dsh-attachment-local/lib/index.js"), "attachment-ancestor-sync-eacces-tolerance")
     applyAssetPatch("patched/web-frontend-index.html",
       File(webDist, "index.html"), "viewport-fit=cover")
+    applyAssetPatch("patched/llm-deepseek-index.js",
+      File(dshPkgs, "dsh-llm-deepseek/lib/index.js"), "deepseek-v4-flash-vision-exp")
+    applyAssetPatch("patched/session-persistence-jsonl-index.js",
+      File(dshPkgs, "dsh-session-persistence-jsonl/lib/index.js"), "android-link-eacces-fallback")
+    applyAssetPatch("patched/fs-local-index.js",
+      File(dshPkgs, "dsh-fs-local/lib/index.js"), "android-link-eacces-fallback")
   }
 
   /** Overwrite-style patch: skipped when the target already contains the marker string. */
   private fun applyAssetPatch(asset: String, target: File, marker: String) {
+    // Patches track bundle layouts: when the runtime no longer ships the patched package
+    // (e.g. dsh-client-ui-primitives dropped from the dependency graph in dsh 0.1.1-rc.1),
+    // stop applying instead of littering a dead overlay into to the tree.
+    if (!target.parentFile.exists()) {
+      Log.i(TAG, "runtime patch skipped (target package absent): $asset")
+      return
+    }
     if (target.exists() && target.readText().contains(marker)) return
     try {
       context.assets.open(asset).use { input ->


### PR DESCRIPTION
# feat: 适配 DeepSeek-V4-Flash-Vision-Exp（多模态视觉模型）

## Summary

官方 dsh 0.1.1-rc.1（2026-08-21 发布）为 DeepSeek 适配器新增了多模态视觉理解模型 `deepseek-v4-flash-vision-exp`（by @LegGasai）。本 PR 让 APK 在不等待快照输入重建的情况下即可使用该模型，并为升级到 rc.1 运行时完成补丁重打与 Android 兼容修复。

## Background / Problems

- 当前 v0.12.4-fx-2 内嵌快照为 dsh 0.1.0-rc.8，适配器目录只有 `deepseek-v4-flash` / `deepseek-v4-pro`，**缺少 vision-exp**，安卓端无法使用多模态模型；
- dsh 0.1.1-rc.1 的 web-frontend dist 更换了资源哈希（`index-CA9Bpko5.js→index-ClqxG24t.js`、`index-BNMwCG9c.css→index-C6eRlFa6.css`），现有 web-frontend 补丁若不重打，升级后 UI 会 404 白屏；
- 升级 rc.1 后暴露的 Android 兼容回归（本地实测发现）：
  1. `dsh-attachment-local` 的 `ensureDurableHome` 会沿祖先目录逐级 fsync 直至文件系统根，在 Android 上打开 `/data/user/0` 被 sepolicy 拒绝（EACCES）→ 任何带图片的 prompt 被拒（`agent-busy` 兜底码）；
  2. rc.1 上游删除了 rc.8 在 `dsh-session-persistence-jsonl` 与 `dsh-fs-local` 中的 `link(2)` EACCES/EPERM/ENOTSUP → rename 回退（Android app 域禁止 link(2)，华为/鸿蒙实测）；
  3. rc.8 时代为安卓禁用的 sharp 图片流水线（`IMAGE_PROCESSING_UNAVAILABLE`）随 vision 模型需要恢复——快照已带 wasm32 后端，本 PR 将补丁改为惰性动态加载。

## Changes

### 1. 模型目录（核心适配）

- `assets/patched/llm-deepseek-index.js`（新增）：dsh-llm-deepseek 0.1.1-rc.1 适配器全量覆写，含
  `deepseek-v4-flash-vision-exp`（inputModalities: ["text", "image"]）；skip-marker 即模型 id
  本身——基底快照原生包含该模型（未来 rc.1+ 快照）时自动跳过，不覆盖原生文件。
- `EngineManager.kt`：装配该补丁（目标 `@deepseek-ai/dsh-llm-deepseek/lib/index.js`）。

### 2. Web 前端补丁重打（rc.1 资源哈希）

- `assets/patched/web-frontend-index.html`：asset 引用更新为 rc.1 dist 哈希，保留
  clipboard 回退 + 沉浸式注入 + `viewport-fit=cover`。

### 3. Android 兼容修复（rc.1 回归）

- `assets/patched/attachment-local-index.js`：
  - `syncDirectory` 恢复 EACCES/EPERM 容错（`/data/user/0` 祖先目录 fsync，sepolicy 拒绝时跳过而非失败）；
  - sharp 由「启动即抛错」改为**惰性动态导入**：引擎启动不加载（不再依赖注释中的旧崩溃规避），
    首个图片触发时尝试加载 wasm32 后端，失败才降级 `IMAGE_PROCESSING_UNAVAILABLE`；
  - skip-marker 升级为 `attachment-ancestor-sync-eacces-tolerance`。
- `assets/patched/session-persistence-jsonl-index.js`（新增）+ `assets/patched/fs-local-index.js`（新增）：
  恢复 rc.8 的 link(2) 失败回退（EACCES/EPERM/ENOTSUP → rename），marker `android-link-eacces-fallback`。
- `EngineManager.kt`：新增两条装配 + `applyAssetPatch` 目标包缺失守卫
  （如 rc.1 起不再内置 `dsh-client-ui-primitives`，补丁自动跳过而非写入死文件）。

## Files changed

```
app/src/main/java/com/dshmobile/shell/EngineManager.kt          (+25)  补丁装配 ×4 + 缺失守卫 + 注释
app/src/main/assets/patched/llm-deepseek-index.js               (new)  vision-exp 模型目录（rc.1 适配器全量）
app/src/main/assets/patched/web-frontend-index.html              (±2)  rc.1 资源哈希重打
app/src/main/assets/patched/attachment-local-index.js           (±44)  EACCES 容错 + 惰性 sharp
app/src/main/assets/patched/session-persistence-jsonl-index.js  (new)  link(2) 回退（同 rc.8）
app/src/main/assets/patched/fs-local-index.js                   (new)  link(2) 回退（同 rc.8）
```

## Test evidence

**MuMu 模拟器（Android 12，x86_64）+ 本地快照升级 dsh 0.1.1-rc.1（npm rc.1 树 + koffi/node-pty Android
原生产物移植 + sharp-wasm32），debug APK 实测：**

1. 引擎启动正常（node v24.18.0，`dsh web: http://127.0.0.1:3080`）；
2. 设置 → 模型 → DeepSeek 提供方正常，会话模型选择器可用；
   `agent-default-model` 设为 `deepseek-official / deepseek-v4-flash-vision-exp` 后，
   会话模型显示 **DeepSeek-V4-Flash-Vision-Exp · High**；
3. 文本对话：模型正常回答（"1+1等于2"，47 tok/s，缓存命中 99%）；
4. **多模态视觉问答（核心）**：命令菜单 → 上传图片 → 系统图库选图 →
   原生图片请求（image_url data-URL → DeepSeek API）→ 模型正确读图：
   - 输入图片文字为 `4 + 4 = ?`
   - 模型回答 **"图中算式是 4 + 4 = ?，结果是 8。"**（首 token 0.6s，112 tok/s）
5. 修复前对照：图片发送被 `agent-busy`（实为 EACCES `/data/user/0`）拒绝、旧补丁抛
   `IMAGE_PROCESSING_UNAVAILABLE`；修复后均不再出现。

## Notes

1. **版本耦合（项目惯例）**：本 PR 的 patched 文件面向 dsh 0.1.1-rc.1（快照需随引擎升级重打）。
   快照二进制不入库，建议随本 PR 同步重建 snapshot-input（Termux 内 `npm i -g @deepseek-ai/dsh@0.1.1-rc.1`
   并编译 koffi/node-pty，与现有 CI 流程一致）；在此之前，vision-exp 模型在本 PR 的补丁下
   对新旧快照均可选可用（rc.8 快照 + 补丁也通过模型选择与文本对话验证）。
2. **潜在重复**：当基底快照升级到原生含 vision-exp 的 dsh 后，`llm-deepseek-index.js` 补丁
   被 marker 跳过（等同移除），可随后续版本清理。
3. **范围外**：版本号/versionCode 未动（按惯例由维护者 bump）；arm64 快照未在真机复测
   （x86_64 模拟器为门禁基线，附验证记录供后续 ABI 复测）。