### PR TITLE
fix: 修复 Android 新增图片提交 ATTACHMENT_WRITE_FAILED——link(2) 被 sepolicy 拒绝 → rename 回退

### DIFF
--- a/app/src/main/assets/patched/attachment-local-index.js
+++ b/app/src/main/assets/patched/attachment-local-index.js
@@ -4,7 +4,7 @@ import { AttachmentError, AttachmentId, AttachmentStore, ImageVariantId } from "
 import { resolveDshHome } from "@deepseek-ai/dsh-home-paths";
 import { createHash, randomUUID } from "node:crypto";
 import { constants } from "node:fs";
-import { chmod, link, mkdir, open, readFile, rename, rm, unlink, writeFile } from "node:fs/promises";
+import { chmod, link, lstat, mkdir, open, readFile, rename, rm, unlink, writeFile } from "node:fs/promises";
 let sharpModule = void 0;
 async function requireSharp() {
 	if (sharpModule === void 0) {
@@ -469,13 +469,23 @@ async function commitPreparedImageFile(root, prepared) {
 		try {
 			await link(temporary, target);
 		} catch (error) {
-			/* v8 ignore next -- Private same-filesystem directories make EEXIST the only recoverable link race. */
-			if (!(error instanceof Error && "code" in error && error.code === "EEXIST")) throw error;
-			if (digest$1(new Uint8Array(await readFile(target))) !== sha256) throw new AttachmentError("Stored attachment failed integrity verification.", "ATTACHMENT_CORRUPT");
+			/* Android app domains forbid link(2) (sepolicy /data/user/0): fall back to an atomic
+			   rename of the same-filesystem staging file (same mechanism as fs-local /
+			   session-persistence-jsonl). EEXIST remains the only recoverable link race. */
+			if (error instanceof Error && "code" in error && (error.code === "EACCES" || error.code === "EPERM" || error.code === "ENOTSUP" || error.code === "EXDEV")) {
+				let exists;
+				try { await lstat(target); exists = true; } catch (e2) { if (e2.code === "ENOENT") exists = false; else throw e2; }
+				if (exists) throw error;
+				await rename(temporary, target);
+			} else if (!(error instanceof Error && "code" in error && error.code === "EEXIST")) {
+				throw error;
+			} else {
+				if (digest$1(new Uint8Array(await readFile(target))) !== sha256) throw new AttachmentError("Stored attachment failed integrity verification.", "ATTACHMENT_CORRUPT");
+			}
 		}
 		await syncDirectory(bucket);
 		await syncDirectory(join(root, "objects"));
-		await unlink(temporary);
+		await unlink(temporary).catch(() => {});
 	} catch (error) {
 		/* v8 ignore next -- A descriptor can remain open only when the underlying write/sync/close operation fails. */
 		if (handle !== void 0) await handle.close().catch(


### PR DESCRIPTION
## 变更说明
- `dsh-attachment-local` 补丁的 `commitPreparedImageFile` 用 `link(2)` 把同文件系统的暂存文件硬链到 `objects/`，但 **Android app 私有数据目录被 sepolicy 拒绝 link(2)** → `EACCES: permission denied, link tmp/... -> objects/...`。
- 结果：凡需**新建对象**的图片（真机新照片、重编码后的新图）一律失败；只有对象**已缓存**（命中 `EEXIST` 分支）的图能过——这正是“第一次（小图缓存命中）能发、第二次（新照片）报 `ATTACHMENT_WRITE_FAILED`” 的根因。
- 修复：`link` 遇到 `EACCES / EPERM / ENOTSUP / EXDEV` 时，`lstat` 确认目标不存在后改用原子 `rename`（与 fs-local / session-persistence-jsonl 补丁一致），并吞掉 rename 后暂存文件已不存在导致的 `ENOENT` unlink。
- 生成脚本 `gen-attachment-rc2-v3.py` 同步该回退，保证重打一致。

## 关联 issue
（无 —— 真机回归发现）

## 测试
- [x] 本地验证通过：arm64 真机强制重编码图全链路（normalize → commit → read → requestImage）通过；修复前新增图必报 `EACCES` commit 失败
- [x] 单元/其它：生成脚本产出与手工修复逐字一致
- [ ] CI 通过（推 branch 后跑）

## 破坏性变更
无（仅修 Android 提交路径，其余行为不变）
