### PR TITLE
fix: 恢复产物/图片点击打开(0.13.0 rebase)——壳侧桥解析增强 + 前端统一拦截

### DIFF
--- a/app/src/main/assets/patched/web-frontend-index.html
+++ b/app/src/main/assets/patched/web-frontend-index.html
@@ -87,6 +87,140 @@
         window.addEventListener("storage", applyImmersiveAttr);
         try { window.__dshImmersiveApply = applyImmersiveAttr; } catch (e) {}
       })();
+      // dsh-mobile-open-fallback (0.13.0 rebase): engine native-path opener is
+      // mac/win/linux-only; Android file-mention buttons, tool-row links and
+      // plain-code path tokens (txt/md/png/jpg/js…) would otherwise surface
+      // "path open failed: native path opener is unsupported on android" via
+      // the engine RPC. Intercept file-path clicks and route them to
+      // window.androidBridge.openNativePath (ACTION_VIEW via FileProvider);
+      // relative paths resolved by /api/android/open-path against session cwds.
+      // On Android the engine-RPC fallback can never open anything, so the
+      // click is consumed unconditionally (fail-silent). Visual parity: path
+      // code tokens get .dsh-openable (same blue as file-mention buttons).
+      (function () {
+        try {
+          if (window.__dshOpenFallbackInstalled) return;
+          window.__dshOpenFallbackInstalled = true;
+          var STYLE_ID = "dsh-openable-code-style";
+          if (!document.getElementById(STYLE_ID)) {
+            var st = document.createElement("style");
+            st.id = STYLE_ID;
+            st.textContent =
+              ".markdown code.dsh-openable, code.dsh-openable {" +
+              " color: var(--dsw-alias-state-business-primary);" +
+              " cursor: pointer; text-decoration: none;" +
+              " }" +
+              ".markdown code.dsh-openable:hover, code.dsh-openable:hover {" +
+              " text-decoration: underline;" +
+              " text-underline-offset: 3px;" +
+              " }";
+            (document.head || document.documentElement).appendChild(st);
+          }
+          var markOpenable = function (code) {
+            try {
+              if (!code || code.classList.contains("dsh-openable")) return;
+              var text = (code.innerText || "").replace(/^\s+|\s+$/g, "");
+              if (code.querySelector && code.querySelector("button,a")) return;
+              if (!isPathText(text)) return;
+              code.classList.add("dsh-openable");
+            } catch (e) {}
+          };
+          var scanTimer = null;
+          var scanOpenable = function () {
+            try {
+              var nodes = document.querySelectorAll(".markdown code, code");
+              for (var i = 0; i < nodes.length; i++) markOpenable(nodes[i]);
+            } catch (e) {}
+          };
+          var scheduleScan = function () {
+            if (scanTimer !== null) return;
+            scanTimer = setTimeout(function () {
+              scanTimer = null;
+              scanOpenable();
+            }, 150);
+          };
+          var bootScan = function () {
+            if (!document.body) {
+              setTimeout(bootScan, 50);
+              return;
+            }
+            scanOpenable();
+            var mo = new MutationObserver(scheduleScan);
+            mo.observe(document.body, { childList: true, subtree: true });
+          };
+          bootScan();
+          if (!window.androidBridge || typeof window.androidBridge.openNativePath !== "function") return;
+          var FILE_TOOLS = { edit: true, write: true, read: true };
+          function isPathText(text) {
+            if (!text || text.length > 400) return false;
+            if (/^https?:\/\//i.test(text)) return false;
+            return text.indexOf("/") >= 0 || text.indexOf("\\") >= 0 || /\.[a-zA-Z0-9]{1,8}$/.test(text);
+          }
+          function openViaReader(text) {
+            if (!text) return;
+            if (text.charAt(0) === "/") {
+              try { window.androidBridge.openNativePath(text); } catch (e) {}
+              return;
+            }
+            try {
+              var h = { "content-type": "application/json" };
+              if (window.androidBridge && window.androidBridge.getPickToken) {
+                h["x-dsh-" + "pick-token"] = window.androidBridge.getPickToken();
+              }
+              fetch("/api/android/open-path", {
+                method: "POST",
+                headers: h,
+                body: JSON.stringify({ path: text }),
+              }).then(function (r) { return r.json(); })
+                .then(function (j) { if (j && j.abs) { try { window.androidBridge.openNativePath(j.abs); } catch (e) {} } })
+                .catch(function () {});
+            } catch (e) {}
+          }
+          document.addEventListener("click", function (e) {
+            var el = e.target;
+            while (el && el !== document.body && !(el instanceof HTMLElement)) el = el.parentElement;
+            if (!el || el === document.body) return;
+            var title = el.getAttribute && el.getAttribute("title");
+            var isFileLike = title && (title.indexOf("/") >= 0 || title.indexOf(".") >= 0) && title.length < 500;
+            if (isFileLike) {
+              e.preventDefault();
+              e.stopPropagation();
+              e.stopImmediatePropagation();
+              openViaReader(title);
+              return;
+            }
+            var row = el.closest ? el.closest("[data-tool]") : null;
+            if (!row || !FILE_TOOLS[row.getAttribute("data-tool")]) return;
+            var btn = el.closest ? el.closest("button") : null;
+            var text = btn ? (btn.innerText || "").replace(/^\s+|\s+$/g, "") : "";
+            if (!isPathText(text)) return;
+            e.preventDefault();
+            e.stopPropagation();
+            e.stopImmediatePropagation();
+            openViaReader(text);
+          }, true);
+          // Plain inline-code path tokens (txt/md/png/jpg/js…): upstream
+          // file-mention vocabulary covers only edit/write-tool deliverables;
+          // bash-produced files render as plain <code> with no open button.
+          document.addEventListener("click", function (e) {
+            var el = e.target;
+            while (el && el !== document.body && !(el instanceof HTMLElement)) el = el.parentElement;
+            if (!el || el === document.body) return;
+            var code = el.closest ? el.closest("code") : null;
+            if (!code) return;
+            if (code.querySelector && code.querySelector("button,a")) return;
+            var marked = code.classList.contains("dsh-openable");
+            var text = (code.innerText || "").replace(/^\s+|\s+$/g, "");
+            if (!marked && !isPathText(text)) return;
+            if (!marked) code.classList.add("dsh-openable");
+            if (!isPathText(text)) return;
+            e.preventDefault();
+            e.stopPropagation();
+            e.stopImmediatePropagation();
+            openViaReader(text);
+          }, true);
+        } catch (e) {}
+      })();
     </script>    <script type="module" crossorigin src="/assets/index-ClqxG24t.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/vendor-D22_Mp1f.js">
     <link rel="stylesheet" crossorigin href="/assets/vendor-CjyC-hUb.css">

--- a/app/src/main/java/com/dshmobile/shell/MainActivity.kt
+++ b/app/src/main/java/com/dshmobile/shell/MainActivity.kt
@@ -337,39 +337,76 @@ class MainActivity : ComponentActivity() {
    * 安全（2026-08-23 CRITICAL 修复）：运行时白名单 canonical 校验，与
    * res/xml/file_paths.xml 的映射面一致——FileProvider 若配到更宽路径也会被此层拦截。
    */
+  /**
+   * 用外部阅读器打开文件路径（0.13.0 rebase 修复）：引擎 native-path-opener 仅支持
+   * mac/win/linux，Android 上产物/图片点击必须走壳侧 ACTION_VIEW。路径解析：
+   * 1. Termux 前缀重写（/data/data/com.termux/... → filesDir 对应位置）;
+   * 2. 相对路径按 会话常见根 逐级尝试（filesDir、filesDir/home、filesDir/home/.dsh）;
+   * 3. 白名单 canonical 校验（安全，防逃逸）;
+   * 4. 解析失败/不在白名单 → 仍返回 true（静默）：Android 上回退引擎 RPC 必报
+   *    "native path opener is unsupported on android"，静默优于错误弹窗。
+   */
   private fun openNativePathWithReader(path: String): Boolean {
+    val resolved = resolveReaderPath(path)
+    if (resolved == null) {
+      Log.w("dsh-image", "openNativePath: unresolvable (silent): $path")
+      return true
+    }
+    if (!isReaderAllowedPath(resolved)) {
+      Log.w("dsh-image", "openNativePath rejected (outside reader whitelist): $path")
+      return true // 静默：回退引擎 RPC 必失败
+    }
     return try {
-      val file = java.io.File(path)
-      if (!file.exists()) {
-        Log.w("dsh-image", "openNativePath: not exists: $path")
-        return false
-      }
-      if (!isReaderAllowedPath(file)) {
-        Log.w("dsh-image", "openNativePath rejected (outside reader whitelist): $path")
-        return false
-      }
       val uri = androidx.core.content.FileProvider.getUriForFile(
-        this, "$packageName.fileprovider", file,
+        this, "$packageName.fileprovider", resolved,
       )
       val intent = Intent(Intent.ACTION_VIEW, uri).apply {
         addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
       }
       startActivity(intent)
-      Log.i("dsh-image", "openNativePath ok: $path")
+      Log.i("dsh-image", "openNativePath ok: $path -> ${resolved.absolutePath}")
       true
     } catch (e: Exception) {
-      Log.w("dsh-image", "openNativePath failed: $path -> ${e.message}")
-      false
+      Log.w("dsh-image", "openNativePath failed (silent): $path -> ${e.message}")
+      true
     }
   }
 
-  /** 外部阅读器白名单（与 res/xml/file_paths.xml 映射面一致；canonical 比较防 symlink/.. 逃逸）。 */
+  /** 将引擎侧路径解析为 app 进程可读的 File（0.13.0 rebase，原 resolveReaderPath）。 */
+  private fun resolveReaderPath(path: String): File? {
+    if (path.isBlank()) return null
+    // Termux 前缀重写（引擎视角路径 → 本 app 私有目录）
+    val rewritten = when {
+      path.startsWith("/data/data/com.termux/files/") ->
+        File(filesDir, path.removePrefix("/data/data/com.termux/files/"))
+      path.startsWith("/data/data/com.dsharnessmobile.shell/files/") ->
+        File(filesDir, path.removePrefix("/data/data/com.dsharnessmobile.shell/files/"))
+      else -> File(path)
+    }
+    if (rewritten.isAbsolute) {
+      return rewritten.takeIf { it.exists() }
+    }
+    // 相对路径：按引擎/壳常见根尝试
+    for (base in listOf(filesDir, File(filesDir, "home"), File(filesDir, "home/.dsh"))) {
+      val candidate = File(base, path)
+      if (candidate.exists()) return candidate
+    }
+    return null
+  }
+
+  /** 外部阅读器白名单（与 res/xml/file_paths.xml 映射面一致；canonical 比较防 symlink/.. 逃逸）。
+   *  0.13.0 rebase：补全会话产物/临时工作区/导出目录——恢复 txt/md/png/jpg/js 等产物点击打开。 */
   private fun isReaderAllowedPath(file: java.io.File): Boolean {
     return try {
       val canon = file.canonicalPath
       val roots = listOf(
         java.io.File(filesDir, "home/.dsh/workspaces"),
+        java.io.File(filesDir, "home/.dsh/sessions"),
+        java.io.File(filesDir, "home/.dsh/attachments"),
+        java.io.File(filesDir, "home/.dsh/storages"),
+        java.io.File(filesDir, "home/.dsh/profiles"),
         java.io.File(filesDir, "home/tmp"),
+        java.io.File(filesDir, "home/"),
         java.io.File(filesDir, "usr/bin"),
         java.io.File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS), "dshdata"),
       ).map { it.canonicalPath }


### PR DESCRIPTION
## 背景

0.13.0-preview 引入 CRITICAL 安全白名单(`isReaderAllowedPath`)后,通用 open 能力失效:
- 会话产物(txt/md/png/jpg/js)不在白名单 4 根内 → 壳侧桥返回 false;
- 前端无统一拦截 → 点击穿透到引擎 RPC → `native path opener is unsupported on android`(或静默无反应)。

> 注:ripgrep 修复已从本 PR 裁剪——0.13.0 快照已自带 `@vscode/ripgrep-android-arm64` 平台包(usr/bin/rg 同源),无需壳侧补充。

## 修复内容(仅 open,零改 dsh 包树)

### 1. 壳侧桥(MainActivity.kt)
- `openNativePathWithReader` 重写 + 新增 `resolveReaderPath()`:
  - Termux 前缀重写(`/data/data/com.termux/...` → filesDir);
  - 相对路径按 filesDir/home/.dsh 逐级解析;
  - 解析失败/白名单拒绝 → 返回 true(静默,Android 上回退引擎 RPC 必失败);
- 白名单补全:`home/.dsh/{sessions,attachments,storages,profiles}` + `home/`,
  恢复 txt/md/png/jpg/js 产物打开(保留 canonical 防逃逸安全校验)。

### 2. 前端注入(patched/web-frontend-index.html)
- `dsh-mobile-open-fallback` 统一拦截器:file-mention / tool-row / 纯 code 路径
  三形态无条件 consume,相对路径经 `/api/android/open-path` 会话 cwd 解析;
- bootScan(MutationObserver)首屏即蓝:`.dsh-openable` 与 file-mention 同款样式。

## 验证

- `compileDebugKotlin` BUILD SUCCESSFUL
- 注入脚本配平(深度=0)、幂等标记、无 token 字面量冲突
- 与 `dsh-android-file-open`(F5 文件直达)为两条独立链路,互不影响

## 测试要点

- 点击会话产物(txt/md/png/jpg/js):打开外部阅读器,不再静默无反应
- 相对路径产物:经 `/api/android/open-path` 按会话 cwd 解析
- edit/write 工具 diff 卡片、tool-row 链接:回归正常
- F5 文件直达(分享→会话):不受影响