### PR TITLE
fix: workflow suffix 输入默认值改空串(空输入不被 -ci 吞掉)

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -21,9 +21,9 @@ on:
         options: [arm64, x86_64, 'both']
         default: 'both'
       suffix:
-        description: 'APK 版本后缀（默认 ci）'
+        description: 'APK 版本后缀（默认空=正式版纯净版本号；测试构建显式传 -fix 等）'
         type: string
-        default: '-ci'
+        default: ''
 
 jobs:
   build:


### PR DESCRIPTION
GitHub workflow_dispatch 行为：显式空串输入会被输入默认值顶替——默认 -ci 导致正式版 versionName 恒 0.13.0-ci。默认值改空串后，正式版构建传空 suffix 得纯净 0.13.0；测试构建显式传 -fix。