### PR TITLE
fix: seed 模板 llm-deepseek 改空对象(裸键 null 致命名空间注册崩,模型页全灭)

### DIFF
--- a/scripts/build-snapshot-013.mjs
+++ b/scripts/build-snapshot-013.mjs
@@ -76,7 +76,8 @@ for (const leaf of ['.credentials.yaml', '.anonymous-user-id']) {
 const seedSettings = [
   '# dsh-mobile 0.13.0 开箱默认（非机密模板；用户配置请在设置界面操作，UI 保存会覆盖本文件）',
   '# DeepSeek 官方 provider：key 由壳侧私有文件注入（DEEPSEEK_API_KEY 环境变量），此处不落任何凭据。',
-  'llm-deepseek:',
+  # 必须给空对象而非裸键：settings-file 的 section() 对 null 抛 TypeError（llm-deepseek 插件 apply 中途死亡，模型页全灭——2026-08-28 模拟器首启实验实锤）。
+  'llm-deepseek: {}',
   '  # apiKeyEnv: DEEPSEEK_API_KEY  # 壳体注入，无需手写；无 key 时错误信息引导去设置界面填写',
   '',
   '# 第三方/自定义 provider（OpenRouter、OpenCode Zen Go 等）请在「设置 → 添加自定义供应商」添加：',


### PR DESCRIPTION
2026-08-28 模拟器首启实验实锤：settings-file section() 对 null 抛 TypeError，llm-deepseek 插件 apply 中途死亡（provider 行在、命名空间缺席）→ 模型页空白/视觉模型不可选/思考强度不可调/填 key 无门。seed 改 llm-deepseek: {} 后命名空间与完整模型目录（含 vision-exp）复活（设备端验证 11→12 命名空间）。