### PR TITLE
fix: 一次性清理旧无障碍截图目录 files/control-shots（#127 收尾）

### DIFF
--- a/app/src/main/java/com/dsharnessmobile/shell/DeviceControlService.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/DeviceControlService.kt
@@ -115,7 +115,8 @@ class DeviceControlService : AccessibilityService() {
   private val lock = Any()
   private var snapshot: Snapshot? = null
   private val generation = AtomicInteger(0)
-
+  /** issue #127 一次性迁移标记：旧截图目录 files/control-shots 只清一次。 */
+  private val legacyShotDirCleaned = java.util.concurrent.atomic.AtomicBoolean(false)
   @Volatile
   private var invalidated = true
 
@@ -268,6 +269,11 @@ class DeviceControlService : AccessibilityService() {
   private fun handleScreenshot(args: JSONObject): JSONObject {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
       return error("无障碍截屏需要 Android 11（API 30）及以上；本机 API ${Build.VERSION.SDK_INT}——请改用 ADB 通道（screencap）")
+    }
+    // 一次性迁移（issue #127）：≤0.13.5 把截图落在 files/control-shots（引擎读不到），
+    // 升级后清掉旧目录，避免历史残留长期占位。
+    if (legacyShotDirCleaned.compareAndSet(false, true)) {
+      try { java.io.File(filesDir, "control-shots").deleteRecursively() } catch (_: Throwable) { /* 忽略 */ }
     }
     val displayId = args.optInt("displayId", android.view.Display.DEFAULT_DISPLAY)
     val latch = java.util.concurrent.CountDownLatch(1)


### PR DESCRIPTION
## 变更说明

#127 收尾：≤0.13.5 的无障碍截图落在 `files/control-shots`（引擎读不到），升级到本批后新图走 `files/home/tmp/dsh-tmp`，但**旧目录里的历史 PNG 会长期残留**。新增 `legacyShotDirCleaned` 一次性标记：首次调用无障碍截屏时 `deleteRecursively()` 清掉旧目录（仅一次，失败忽略）。

## 关联 issue

Refs #127

## 测试

- [x] Kotlin 编译通过（CI `compileDebugKotlin`）
- [x] 设备侧确认残留位置：`files/control-shots` 4 个历史 PNG（2026-09-08/09 产生），新目录 `files/home/tmp/dsh-tmp` 为空

## 破坏性变更

无。