### PR TITLE
feat: #128 自有 WebView DOM 通道 + 光环提亮 + 运行时补丁守卫

### DIFF
--- a/app/src/main/assets/patched/attachment-local-index.js
+++ b/app/src/main/assets/patched/attachment-local-index.js
@@ -372,7 +372,11 @@ async function ensureDurableDirectory(path, boundary) {
 	let level = target;
 	while (level !== stop) {
 		const parent = dirname(level);
-		await syncDirectory(parent);
+		try { await syncDirectory(parent); } catch (error) {
+			// dsh-mobile durable-walk guard: Android app-private ancestors (/data/user/0) are not readable by the app.
+			if (error && (error.code === 'EACCES' || error.code === 'EPERM')) return;
+			throw error;
+		}
 		/* v8 ignore next -- filesystem-root guard: callers pass a boundary that is an ancestor of path, so the walk reaches it first. */
 		if (parent === level) return;
 		level = parent;

--- a/app/src/main/java/com/dsharnessmobile/shell/DeviceControlService.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/DeviceControlService.kt
@@ -49,6 +49,160 @@ class DeviceControlService : AccessibilityService() {
     private const val MAX_DEPTH = 40
     private const val TOKEN_BYTES = 18
 
+    /**
+     * #128 L1：自有 WebView 的紧凑 DOM 语义快照（在页面上下文里跑，毫秒级）。
+     * 只收集「可交互」元素（链接/按钮/输入/role/contenteditable/tabindex），
+     * 每个节点回 `ref`（window.__dshWebRefs 里的句柄，动作优先用它）+ `sel`（CSS 路径兜底）
+     * + role/text/bounds/editable/disabled/inView。视口内的排前面，上限 120 条。
+     */
+    private const val WEB_SNAPSHOT_JS = """
+(function(){
+  var rootSel = __ROOT__;
+  var root = rootSel ? document.querySelector(rootSel) : document.body;
+  if (!root) return JSON.stringify({ok:false,error:'根选择器无匹配：' + rootSel});
+  var reg = window.__dshWebRefs || (window.__dshWebRefs = {n:0,map:{}});
+  reg.map = {}; reg.n = 0;
+  var SEL = 'a,button,input,textarea,select,[role],[contenteditable="true"],[onclick],[tabindex]';
+  var all = root.querySelectorAll(SEL);
+  function textOf(el){
+    var t = el.getAttribute('aria-label') || el.getAttribute('title') || el.innerText || el.textContent || '';
+    return String(t).replace(/\s+/g,' ').trim().slice(0,80);
+  }
+  function cssPath(el){
+    var parts = [], node = el, guard = 0;
+    while (node && node.nodeType === 1 && guard++ < 6){
+      var tag = node.tagName.toLowerCase();
+      if (node.id){ parts.unshift('#' + node.id); break; }
+      var parent = node.parentElement;
+      if (parent){ var idx = Array.prototype.indexOf.call(parent.children, node) + 1; tag += ':nth-child(' + idx + ')'; }
+      parts.unshift(tag);
+      node = parent;
+    }
+    return parts.join(' > ');
+  }
+  var picked = [];
+  for (var i = 0; i < all.length; i++){
+    var el = all[i];
+    var style = getComputedStyle(el);
+    if (style.display === 'none' || style.visibility === 'hidden') continue;
+    var r = el.getBoundingClientRect();
+    if (r.width < 2 || r.height < 2) continue;
+    var tag = el.tagName.toLowerCase();
+    var type = (el.getAttribute('type') || '').toLowerCase();
+    var editable = !!el.isContentEditable || tag === 'textarea' ||
+      (tag === 'input' && ['text','search','email','password','number','url','tel',''].indexOf(type) >= 0);
+    var role = el.getAttribute('role') || (tag === 'a' ? 'link' : tag === 'button' ? 'button'
+      : tag === 'select' ? 'combobox' : editable ? 'textbox' : tag === 'input' ? (type || 'input') : '');
+    picked.push({
+      el: el, tag: tag, role: role, editable: editable,
+      disabled: !!el.disabled || el.getAttribute('aria-disabled') === 'true',
+      text: textOf(el),
+      bounds: [Math.round(r.left), Math.round(r.top), Math.round(r.width), Math.round(r.height)],
+      inView: r.bottom > 0 && r.top < innerHeight && r.right > 0 && r.left < innerWidth
+    });
+  }
+  picked.sort(function(a, b){ return a.inView === b.inView ? 0 : (a.inView ? -1 : 1); });
+  var nodes = [], cap = 120;
+  for (var j = 0; j < picked.length && nodes.length < cap; j++){
+    var item = picked[j];
+    var id = ++reg.n;
+    reg.map[id] = item.el;
+    nodes.push({
+      ref: 'w' + id, sel: cssPath(item.el), tag: item.tag, role: item.role,
+      text: item.text, editable: item.editable, disabled: item.disabled,
+      bounds: item.bounds, inView: item.inView
+    });
+  }
+  return JSON.stringify({
+    ok: true, url: location.href, title: document.title,
+    vw: innerWidth, vh: innerHeight, scrollY: Math.round(window.scrollY),
+    total: picked.length, count: nodes.length, nodes: nodes
+  });
+})()
+"""
+
+    /**
+     * #128 L1：按 ref / CSS 选择器 / 文本 / role 定位并执行 click|setText|scroll。
+     * ref 是上一次 webSnapshot 的句柄（同一页面上下文内有效，元素被 React 换掉则退回 sel）；
+     * setText 走原生 value setter + input/change 事件，兼容 React 受控组件。
+     */
+    private const val WEB_ACTION_JS = """
+(function(){
+  var a = __ARGS__;
+  var reg = window.__dshWebRefs;
+  function textOf(el){
+    var t = el.getAttribute('aria-label') || el.getAttribute('title') || el.innerText || el.textContent || '';
+    return String(t).replace(/\s+/g,' ').trim();
+  }
+  function candidates(){
+    var sel = 'a,button,input,textarea,select,[role],[contenteditable="true"],[onclick],[tabindex]';
+    return Array.prototype.slice.call(document.querySelectorAll(sel)).filter(function(el){
+      var s = getComputedStyle(el);
+      if (s.display === 'none' || s.visibility === 'hidden') return false;
+      var r = el.getBoundingClientRect();
+      return r.width >= 2 && r.height >= 2;
+    });
+  }
+  var el = null;
+  var key = String(a.ref || '').replace(/^w/, '');
+  if (key && reg && reg.map[key]) { el = reg.map[key]; if (el && !el.isConnected) el = null; }
+  if (!el && a.sel) { try { el = document.querySelector(a.sel); } catch (e) { el = null; } }
+  if (!el && a.text){
+    var want = String(a.text).replace(/\s+/g,' ').trim().toLowerCase();
+    var list = candidates(), exact = null, partial = null;
+    for (var i = 0; i < list.length; i++){
+      var t = textOf(list[i]).toLowerCase();
+      if (!exact && t === want) exact = list[i];
+      if (!partial && t.indexOf(want) >= 0) partial = list[i];
+    }
+    el = exact || partial;
+  }
+  if (!el && a.role){
+    var role = String(a.role).toLowerCase();
+    var list2 = candidates();
+    for (var k = 0; k < list2.length; k++){
+      var r2 = list2[k].getAttribute('role');
+      if (r2 && r2.toLowerCase() === role){ el = list2[k]; break; }
+    }
+    if (!el){
+      var tagMap = {link:'a', button:'button', textbox:'input', combobox:'select'};
+      var tag = tagMap[role];
+      if (tag){ for (var m = 0; m < list2.length; m++){ if (list2[m].tagName.toLowerCase() === tag){ el = list2[m]; break; } } }
+    }
+  }
+  if (!el) return JSON.stringify({ok:false,error:'未找到目标元素（ref/sel/text/role 均无匹配）'});
+  try { el.scrollIntoView({block:'center', inline:'center'}); } catch (e) {}
+  var info = {tag: el.tagName.toLowerCase(), text: textOf(el).slice(0,60)};
+  var via = key ? 'ref' : (a.sel ? 'selector' : (a.text ? 'text' : 'role'));
+  if (a.op === 'click'){
+    el.click();
+    return JSON.stringify({ok:true, op:'click', via:via, target:info});
+  }
+  if (a.op === 'setText'){
+    var value = String(a.value || '');
+    if (el.isContentEditable){
+      el.focus();
+      el.textContent = value;
+    } else {
+      var isArea = el.tagName.toLowerCase() === 'textarea';
+      var proto = isArea ? window.HTMLTextAreaElement.prototype : window.HTMLInputElement.prototype;
+      var setter = Object.getOwnPropertyDescriptor(proto, 'value');
+      el.focus();
+      if (setter && setter.set) setter.set.call(el, value); else el.value = value;
+    }
+    el.dispatchEvent(new Event('input', {bubbles:true}));
+    el.dispatchEvent(new Event('change', {bubbles:true}));
+    return JSON.stringify({ok:true, op:'setText', via:via, target:info, value:value.slice(0,60)});
+  }
+  if (a.op === 'scroll'){
+    var dy = Number(a.dy) || 300;
+    window.scrollBy(0, dy);
+    return JSON.stringify({ok:true, op:'scroll', dy:dy, scrollY:Math.round(window.scrollY)});
+  }
+  return JSON.stringify({ok:false,error:'未知 op：' + a.op});
+})()
+"""
+
     @Volatile
     private var instance: DeviceControlService? = null
 
@@ -257,6 +411,9 @@ class DeviceControlService : AccessibilityService() {
       "global" -> handleGlobal(args)
       "screenshot" -> handleScreenshot(args)
       "state" -> handleState()
+      "nodeText" -> handleNodeText(args)
+      "webSnapshot" -> handleWebSnapshot(args)
+      "webAction" -> handleWebAction(args)
       else -> error("未知操作 $op")
     }
   }
@@ -323,6 +480,81 @@ class DeviceControlService : AccessibilityService() {
     })
     latch.await(12, java.util.concurrent.TimeUnit.SECONDS)
     return payload ?: error("截屏超时")
+  }
+
+  /**
+   * 读节点当前文本（输入落地校验用；不给 path 时读聚焦的可编辑节点）。
+   * 比整树快照便宜得多——现场实测「注入后回读断言」是输入链路唯一可靠的闭环。
+   */
+  private fun handleNodeText(args: JSONObject): JSONObject {
+    val path = args.optString("path", "")
+    val node: AccessibilityNodeInfo = if (path.isNotEmpty()) {
+      nodeAtPath(path) ?: return error("路径 $path 已不存在（页面已变化）")
+    } else {
+      findFocusedEditable() ?: return error("没有聚焦的输入框——请先点击目标输入框，或用 path 指定")
+    }
+    return JSONObject()
+      .put("text", node.text?.toString() ?: "")
+      .put("desc", node.contentDescription?.toString() ?: "")
+      .put("editable", node.isEditable)
+      .put("path", path)
+  }
+
+  /**
+   * #128 L1：自有 WebView 的 DOM 语义快照（毫秒级，不依赖无障碍虚拟树）。
+   * 只对 DSH 自己的 Web UI 生效；页面不在场（Activity 已销毁/未加载）时明确报错。
+   */
+  private fun handleWebSnapshot(args: JSONObject): JSONObject {
+    val rootSel = args.optString("root", "")
+    val script = WEB_SNAPSHOT_JS.replace("__ROOT__", if (rootSel.isEmpty()) "null" else JSONObject.quote(rootSel))
+    return evalWebScript(script)
+  }
+
+  /** #128 L1：按 ref / 选择器 / 文本 / role 在自有 WebView 上执行 click|setText|scroll。 */
+  private fun handleWebAction(args: JSONObject): JSONObject {
+    val payload = JSONObject()
+      .put("op", args.optString("op", "click"))
+      .put("ref", args.optString("ref", ""))
+      .put("sel", args.optString("sel", ""))
+      .put("text", args.optString("text", ""))
+      .put("role", args.optString("role", ""))
+      .put("value", args.optString("value", ""))
+      .put("dy", args.optInt("dy", 300))
+    return evalWebScript(WEB_ACTION_JS.replace("__ARGS__", payload.toString()))
+  }
+
+  /**
+   * 在自有 WebView 上求值一段返回 JSON 字符串的脚本（主线程 evaluateJavascript + 同步等待）。
+   * `evaluateJavascript` 的回包是 JSON 字面量：脚本返回字符串时会被再转义一层，这里解回。
+   */
+  private fun evalWebScript(script: String, timeoutMs: Long = 6000): JSONObject {
+    val web = MainActivity.webViewRef
+      ?: return error("自有 WebView 不在场（页面未加载或 Activity 已销毁）——网页内容请改用 android_ui_tree / android_ui_dump")
+    val latch = java.util.concurrent.CountDownLatch(1)
+    val holder = arrayOfNulls<String>(1)
+    val posted = mainHandler.post {
+      try {
+        web.evaluateJavascript(script) { value ->
+          holder[0] = value
+          latch.countDown()
+        }
+      } catch (t: Throwable) {
+        holder[0] = null
+        latch.countDown()
+      }
+    }
+    if (!posted) return error("WebView 求值无法派发（主线程不可用）")
+    if (!latch.await(timeoutMs, java.util.concurrent.TimeUnit.MILLISECONDS)) {
+      return error("WebView DOM 求值超时（${timeoutMs}ms）")
+    }
+    val raw = holder[0] ?: return error("WebView DOM 求值失败（页面可能正在跳转）")
+    val json = if (raw.startsWith("\"")) {
+      try { org.json.JSONTokener(raw).nextValue() as? String } catch (_: Throwable) { null }
+    } else {
+      raw
+    }
+    if (json.isNullOrBlank()) return error("WebView DOM 求值返回空")
+    return try { JSONObject(json) } catch (t: Throwable) { error("WebView DOM 结果解析失败：" + (t.message ?: "?")) }
   }
 
   private fun error(message: String): JSONObject = JSONObject().put("__error", message)

--- a/app/src/main/java/com/dsharnessmobile/shell/EngineManager.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/EngineManager.kt
@@ -342,10 +342,42 @@ class EngineManager(private val context: Context, private val pickToken: String?
    * mechanism depends on the app-private domain (public FUSE forbids symlinks), so DSH_HOME must
    * never be migrated wholesale.
    */
+  /**
+   * #130-2：播种「手机操控」Agent 预设（`$DSH_HOME/.agent-presets/phone-control/`）。
+   * 组成文件直接复制当前引擎自带的 `standard` 预设（避免随引擎升级漂移），另附 SKILL.md
+   * 固定「dump → 按 ref 动作 → 校验 → 再 dump」的流程与纪律。已存在则不覆盖（用户可自改）。
+   */
+  private fun seedPhoneControlPreset(privateDsh: File) {
+    try {
+      val dir = File(File(privateDsh, ".agent-presets"), "phone-control")
+      if (File(dir, "preset.yml").exists()) return
+      val shipped = File(
+        context.filesDir,
+        "usr/lib/node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-agent-presets/presets/standard/agent.cordis.yml",
+      )
+      if (!shipped.isFile) {
+        Log.w(TAG, "phone-control preset skipped: shipped standard composition absent at " + shipped.absolutePath)
+        return
+      }
+      val skillDir = File(dir, "skills/phone-control").apply { mkdirs() }
+      File(dir, "agent.cordis.yml").writeText(shipped.readText())
+      File(dir, "preset.yml").writeText(
+        "name: 手机操控\n" +
+          "description: 以无障碍语义树 / DOM 快照驱动的手机操控预设：dump → 按 ref 点击或输入 → 校验 → 再 dump；禁止盲点坐标。\n" +
+          "order: 50\n",
+      )
+      File(skillDir, "SKILL.md").writeText(PHONE_CONTROL_SKILL)
+      Log.i(TAG, "phone-control preset seeded -> " + dir.absolutePath)
+    } catch (t: Throwable) {
+      Log.w(TAG, "phone-control preset seeding failed", t)
+    }
+  }
+
   fun ensurePrivateDshData(): File {
     val dshData = dshDataDir
     val privateDsh = File(homeDir, ".dsh")
     privateDsh.mkdirs()
+    seedPhoneControlPreset(privateDsh)
     val privateMarker = File(privateDsh, ".private-layout")
     if (privateMarker.exists()) {
       ensurePublicExportRepo(dshData)
@@ -1061,6 +1093,29 @@ class EngineManager(private val context: Context, private val pickToken: String?
 
   companion object {
     private const val TAG = "dsh-engine"
+
+    /**
+     * #130-2：手机操控预设自带的 skill——把 0.13.5 现场实测的流程与纪律固定下来
+     * （无障碍/DOM 优先、先验前台、按 ref 而非盲点坐标、动作后必校验、输入单次注入并回读）。
+     */
+    private val PHONE_CONTROL_SKILL = """
+# 手机操控流程（DSH 设备控制）
+
+## 固定顺序
+1. 会话档位必须是 danger-full-access，否则设备工具一律拒绝。
+2. 长流程开始前跑一次 android_env_prepare（关动画 + 启用内嵌 ADB 键盘），之后 dump/tap 更稳。
+3. 感知：android_ui_dump（无障碍语义树，首选）→ 若结果是 WebView 容器或目标是 DSH 自己的 Web UI，改用 android_web_dump（DOM 快照）。
+4. 动作：android_ui_click / android_ui_input，引用用 ref（id:nN / text:精确文本#k / desc: / rid: / wN / css: / text: / role:）。
+5. 校验：工具自带回执（点击回报「已生效 / 未观察到界面变化」；输入回报「回读一致 / 未落地」）——不要假设动作成功。
+6. 需要看画面时用 android_screenshot（图像直接随结果返回，不需要再 read_image）。
+
+## 纪律
+- 禁止盲点坐标点击；nx/ny 仅作兜底，且必须说明理由。
+- 同名节点必须消歧：用 dump 里的 #k 序号（text:设置#2）。
+- 抓到的包名与前台不一致时以 dumpsys 为准（uiautomator/无障碍可能抓到覆盖层）。
+- 输入只走单次注入 + 回读断言；不要用 keyevent 打字母（中文 IME 会汉字化），不要拆成多段输入。
+- 连续两次动作未产生预期变化时停下来重新 dump，并如实汇报当前界面状态，不要继续猜测。
+"""
 
     /** Healthy ticks (each 5s watchdog poll) required before the update-v2 finalize deletes usr-old. */
     const val UPDATE_CONFIRM_TICKS = 3

--- a/app/src/main/java/com/dsharnessmobile/shell/MainActivity.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/MainActivity.kt
@@ -96,6 +96,13 @@ class MainActivity : ComponentActivity() {
     /** #120：显式拒绝哨兵路径前缀（引擎侧识别为拒绝而非取消，见 host-web-compat）。
      *  协议：`__dsh_pick_refused__:<reason>`，reason = permission-denied | android-10。 */
     const val PICK_REFUSED_PREFIX = "__dsh_pick_refused__:"
+
+    /**
+     * #128 L1：控制面（无障碍服务）读取/操作**自有 WebView** 的 DOM 需要拿到实例。
+     * 只在 Activity 存活期间非空；控制服务拿到 null 即回「页面不在场」。
+     */
+    @Volatile
+    internal var webViewRef: WebView? = null
   }
 
   // —— 引擎流 / 引导页委托（原位一行委托到协作类；引擎启动与引导页状态渲染
@@ -145,6 +152,7 @@ class MainActivity : ComponentActivity() {
       id = View.generateViewId()
       visibility = View.GONE
     }
+    webViewRef = webView
     root.addView(webView, FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT))
     guideView = guideRenderer.buildGuideView()
     root.addView(guideView, FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT))
@@ -293,6 +301,8 @@ class MainActivity : ComponentActivity() {
 
   override fun onDestroy() {
     super.onDestroy()
+    // #128 L1：控制面不再持有已销毁 Activity 的 WebView。
+    webViewRef = null
     // 悬浮球避让帧消费者清除（Service 侧持有引用，避免 Activity 泄漏）
     OverlayService.frameConsumer = null
     engineFlow.stopMonitoring()

--- a/app/src/main/java/com/dsharnessmobile/shell/OverlayHalo.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/OverlayHalo.kt
@@ -37,11 +37,17 @@ class OverlayHalo(private val svc: OverlayService) {
 
   /** setColors 二参形态（自定义渐变 stop 位置）仅 API 29+；26-28 退三等分 stop。 */
   private fun setHaloColors(g: GradientDrawable, halo: Halo) {
-    val colors = intArrayOf(Color.argb(0, 255, 255, 255), halo.color, Color.argb(0, 255, 255, 255))
+    val transparent = Color.argb(0, 255, 255, 255)
     if (android.os.Build.VERSION.SDK_INT >= 29) {
-      g.setColors(colors, floatArrayOf(0f, 0.7f, 1f))
+      // 2026-09-10 用户反馈「光晕不够可见」：峰值内移到 0.45、再加一段 0.74 的过渡，
+      // 可见环更宽更亮。半径保持 24dp 不变——超过球心到屏幕边的 25dp 会在贴边时被裁
+      // （旧「吸边后光环偏心」根因，见 haloGlowPx 注释）。
+      g.setColors(
+        intArrayOf(transparent, halo.color, halo.fade, transparent),
+        floatArrayOf(0f, 0.45f, 0.74f, 1f),
+      )
     } else {
-      g.setColors(colors)
+      g.setColors(intArrayOf(transparent, halo.color, transparent))
     }
   }
 
@@ -69,11 +75,12 @@ class OverlayHalo(private val svc: OverlayService) {
   }
 }
 
-// ── 光环四态（低饱和：融合优先） ────────────────────────────────
+// ── 光环四态（低饱和：融合优先；2026-09-10 按用户反馈整体提亮一档） ──────────
 // PENDING = 待用户处理（AI 提问 / 权限审批等待应答）——低饱和琥珀黄（用户拍板新增）。
-enum class Halo(val color: Int) {
-  IDLE(Color.argb(70, 255, 255, 255)),
-  WORKING(Color.argb(128, 92, 132, 255)),
-  PENDING(Color.argb(160, 235, 190, 60)),
-  ERROR(Color.argb(115, 224, 72, 72)),
+// fade = 同一色相的次强档，用于让可见环更宽（见 setHaloColors 的四段 stop）。
+enum class Halo(val color: Int, val fade: Int) {
+  IDLE(Color.argb(96, 255, 255, 255), Color.argb(58, 255, 255, 255)),
+  WORKING(Color.argb(170, 92, 132, 255), Color.argb(102, 92, 132, 255)),
+  PENDING(Color.argb(205, 235, 190, 60), Color.argb(123, 235, 190, 60)),
+  ERROR(Color.argb(160, 224, 72, 72), Color.argb(96, 224, 72, 72)),
 }

--- a/plugins/dsh-android-bridge/package.json
+++ b/plugins/dsh-android-bridge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dsh-android/dsh-android-bridge",
   "description": "Android privilege bridge: ADB authorization state machine, fail-closed execution, audit — the only controlled privilege-extension channel (PRD F1.7)",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "main": "lib/index.js",
   "exports": {

--- a/plugins/dsh-android-bridge/src/control-policy.ts
+++ b/plugins/dsh-android-bridge/src/control-policy.ts
@@ -14,6 +14,7 @@
  */
 
 export type ControlOp = 'snapshot' | 'click' | 'setText' | 'scroll' | 'global' | 'screenshot' | 'state'
+  | 'nodeText' | 'webSnapshot' | 'webAction'
 
 export interface ControlPolicyInput {
   op: ControlOp
@@ -37,8 +38,12 @@ export interface ControlDecision {
 export const REQUIRED_SESSION_MODE = 'danger-full-access'
 
 /** a11y 通道能覆盖的操作：五个语义操作 + 截屏（API 30+，见 A11Y-CONTROL-DESIGN.md §2.2）
- *  + `state`（便宜的状态读数：快照代次/失效标记，供点击生效校验，issue #129）。 */
-export const A11Y_OPS: readonly ControlOp[] = ['snapshot', 'click', 'setText', 'scroll', 'global', 'screenshot', 'state']
+ *  + `state`（便宜的状态读数：快照代次/失效标记，供点击生效校验，issue #129）
+ *  + `webSnapshot`/`webAction`（issue #128 L1：自有 WebView 的 DOM 语义快照与动作——
+ *  与 a11y 共用同一队列/心跳，壳侧在页面不在场时明确报错）。 */
+export const A11Y_OPS: readonly ControlOp[] = [
+  'snapshot', 'click', 'setText', 'scroll', 'global', 'screenshot', 'state', 'nodeText', 'webSnapshot', 'webAction',
+]
 
 export function decideControl(input: ControlPolicyInput): ControlDecision {
   if (input.sessionMode !== REQUIRED_SESSION_MODE) {

--- a/plugins/dsh-android-manage/package.json
+++ b/plugins/dsh-android-manage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dsh-android/dsh-android-manage",
   "description": "Android phone management tools (ADB-first observe/act/wait loop, PRD F1.6): screenshot, UI tree, app/device info — all fail-closed on the privilege bridge",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "main": "lib/index.js",
   "exports": {

--- a/plugins/dsh-android-manage/src/index.ts
+++ b/plugins/dsh-android-manage/src/index.ts
@@ -528,6 +528,20 @@ function tools(ctx: Context, priv: PrivilegeFace) {
   /** 公开 id → 原始路径 id（无障碍动作按路径回指壳侧节点）。 */
   const origPathOf = (publicId: string): string | undefined => uiCache?.byId.get(publicId)?.origPath
 
+  /**
+   * 前台真值（现场实测教训 2026-09-10：uiautomator/a11y 可能抓到 DSH shell 覆盖层或错误的窗口，
+   * `dumpsys` 的 mCurrentFocus / ResumedActivity 才是权威）。
+   */
+  async function foregroundInfo(): Promise<{ pkg: string; activity: string } | null> {
+    if (!priv.execAdbLine) return null
+    const r = await priv.execAdbLine(`adb shell dumpsys window | grep -m1 mCurrentFocus`)
+    const m = /u0\s+([\w.]+)\/([\w.$]+)/.exec(r.ok ? r.stdout : '')
+    if (m) return { pkg: m[1], activity: m[2] }
+    const r2 = await priv.execAdbLine(`adb shell dumpsys activity activities | grep -m1 ResumedActivity`)
+    const m2 = /([\w.]+)\/([\w.$]+)/.exec(r2.ok ? r2.stdout : '')
+    return m2 ? { pkg: m2[1], activity: m2[2] } : null
+  }
+
   /** F2 统一坐标系锚点：屏幕物理尺寸（wm size）。uiDump 缓存优先，否则现场查。 */
   async function screenSize(): Promise<{ w: number; h: number }> {
     if (uiCache && Date.now() - uiCache.ts <= UI_CACHE_TTL && uiCache.screen.w > 0) return uiCache.screen
@@ -653,6 +667,16 @@ function tools(ctx: Context, priv: PrivilegeFace) {
           ts: Date.now(),
           gen: data.gen,
         }
+        const fg = await foregroundInfo()
+        const dumpPkg = pruned.nodes.find((n) => String(n.pkg || '') !== '')?.pkg ?? ''
+        const mismatch = fg !== null && dumpPkg !== '' && fg.pkg !== dumpPkg
+        const webNode = pruned.nodes.find((n) => /WebView/i.test(String(n.type || '')))
+        const warn = mismatch
+          ? `\n注意：dump 包名 ${dumpPkg} 与前台 ${fg!.pkg} 不一致——可能抓到覆盖层/错误窗口，以 dumpsys 为准。`
+          : ''
+        const webHint = webNode
+          ? `\n检测到 WebView 容器 ${webNode.id}：其内部控件在本通道不可见。若目标是 DSH 自有 Web UI，改用 android_web_dump（DOM 快照，毫秒级、按选择器精准命中）；第三方网页仍只能靠坐标。`
+          : ''
         return {
           ok: true,
           denied: false,
@@ -662,7 +686,8 @@ function tools(ctx: Context, priv: PrivilegeFace) {
           rawCount: pruned.rawCount,
           nodes: pruned.nodes as unknown as JsonValue[],
           note: '无障碍通道（backend=a11y）：id 仅在最近一次 dump 内有效；页面变化后请重新 dump',
-          text: `控件清单（无障碍通道，未截断）：${pruned.nodes.length} 个节点（原始 ${pruned.rawCount}，剔除 ${pruned.rawCount - pruned.nodes.length} 个零尺寸/完全重复节点，屏幕 ${screen.w}x${screen.h}）`,
+          text: `控件清单（无障碍通道，未截断）：${pruned.nodes.length} 个节点（原始 ${pruned.rawCount}，剔除 ${pruned.rawCount - pruned.nodes.length} 个零尺寸/完全重复节点，屏幕 ${screen.w}x${screen.h}；前台 ${fg?.pkg ?? '?'}/${fg?.activity ?? '?'}）`
+            + warn + webHint,
         }
       }
       if (!priv.execAdbLine) return { ok: false, denied: false, screen: { w: 0, h: 0 }, rotation: 0, count: 0, rawCount: 0, nodes: [], text: 'ADB 执行通道未接通（dsh-android-bridge 未提供 execAdbLine）' }
@@ -759,6 +784,34 @@ function tools(ctx: Context, priv: PrivilegeFace) {
         typeof nx === 'number' && Number.isFinite(nx) && nx >= 0 && nx <= 1 &&
         typeof ny === 'number' && Number.isFinite(ny) && ny >= 0 && ny <= 1
       if (!useRef && !useNorm) return { ok: false, denied: false, text: '需要 ref（语义引用）或 nx/ny（0-1 归一化坐标）二者之一' }
+      // #128 L1：WebView DOM 引用（wN / css: / text: / role:）走自有 WebView 通道，
+      // 不依赖无障碍虚拟树，也不需要坐标。
+      if (useRef) {
+        const webRef = ref!.trim()
+        const isWebRef = /^w\d+$/.test(webRef) || webRef.startsWith('css:') || webRef.startsWith('text:') || webRef.startsWith('role:')
+        if (isWebRef) {
+          const payload: Record<string, unknown> = { op: 'click' }
+          if (/^w\d+$/.test(webRef)) payload.ref = webRef
+          else if (webRef.startsWith('css:')) payload.sel = webRef.slice(4).trim()
+          else if (webRef.startsWith('text:')) payload.text = webRef.slice(5).trim()
+          else payload.role = webRef.slice(5).trim()
+          const wr = await a11yExec('webAction', payload, 8000)
+          if (!wr.ok) return { ok: false, denied: false, text: 'WebView 点击失败：' + wr.error }
+          const wd = (wr.data ?? {}) as { ok?: boolean; error?: string; via?: string; target?: { tag?: string; text?: string } }
+          if (wd.ok === false) return { ok: false, denied: false, text: 'WebView 点击失败：' + (wd.error ?? '未知') }
+          const verdict = await verifyClick(uiCache?.gen, exec as ExecLike)
+          return {
+            ok: true,
+            denied: false,
+            ref: webRef,
+            id: webRef,
+            label: (wd.target?.text ?? '').slice(0, 24),
+            x: 0,
+            y: 0,
+            text: `已在 WebView 内点击 ${wd.target?.tag ?? ''}「${(wd.target?.text ?? '').slice(0, 24)}」（DOM 通道 via=${wd.via ?? 'ref'}）；${verdict}`,
+          }
+        }
+      }
       // 0.13.5 W4：无障碍通道优先。坐标由壳侧用**它自己的屏幕尺寸**换算——
       // 工具层不再需要屏幕尺寸，也就不会因「dump 缓存过期」把 nx/ny 点击误拒（实机踩坑）。
       if (controlDecision('click', exec as { agent?: { session?: unknown } }).backend === 'a11y') {
@@ -998,6 +1051,27 @@ function tools(ctx: Context, priv: PrivilegeFace) {
       if (!a.ok) return { ok: false, denied: true, text: a.guidance }
       const raw = typeof text === 'string' ? text : ''
       if (!clear && (raw.length === 0 || raw.length > 500)) return { ok: false, denied: false, text: 'text 长度需为 1-500，或传 clear: true 单独清空' }
+      // #128 L1：WebView DOM 引用（wN / css: / text: / role:）→ 自有 WebView 通道直接写值
+      // （原生 value setter + input/change 事件，兼容 React 受控组件），不经 IME、不会汉字化。
+      const webRef = typeof ref === 'string' ? ref.trim() : ''
+      const isWebRef = /^w\d+$/.test(webRef) || webRef.startsWith('css:') || webRef.startsWith('text:') || webRef.startsWith('role:')
+      if (isWebRef) {
+        const payload: Record<string, unknown> = { op: 'setText', value: raw }
+        if (/^w\d+$/.test(webRef)) payload.ref = webRef
+        else if (webRef.startsWith('css:')) payload.sel = webRef.slice(4).trim()
+        else if (webRef.startsWith('text:')) payload.text = webRef.slice(5).trim()
+        else payload.role = webRef.slice(5).trim()
+        const wr = await a11yExec('webAction', payload, 8000)
+        if (!wr.ok) return { ok: false, denied: false, channel: 'web', text: 'WebView 输入失败：' + wr.error }
+        const wd = (wr.data ?? {}) as { ok?: boolean; error?: string; via?: string; value?: string; target?: { text?: string } }
+        if (wd.ok === false) return { ok: false, denied: false, channel: 'web', text: 'WebView 输入失败：' + (wd.error ?? '未知') }
+        return {
+          ok: true,
+          denied: false,
+          channel: 'web',
+          text: `已在 WebView 内写入「${(wd.value ?? raw).slice(0, 40)}」（DOM 通道 via=${wd.via ?? 'ref'}，目标 ${(wd.target?.text ?? '').slice(0, 20)}）`,
+        }
+      }
       // 0.13.5 W4：无障碍通道优先（ACTION_SET_TEXT 原子写入——绕开 IME 切换与丢字问题 F5）
       if (controlDecision('setText', exec as { agent?: { session?: unknown } }).backend === 'a11y') {
         const payload: Record<string, unknown> = { text: raw, clear: clear === true }
@@ -1035,15 +1109,45 @@ function tools(ctx: Context, priv: PrivilegeFace) {
           r = await priv.execAdbShell(p)
           if (!r.ok) break
         }
+        // 现场实测（2026-09-10）：`input text` 偶发丢尾字符、中文 IME 可能把字母汉字化——
+        // 注入后**回读断言**（壳侧 nodeText 读聚焦框，便宜），不一致自动重试一次。
+        let readBack: string | null = null
+        if (r.ok && raw.length > 0) {
+          const read = async (): Promise<string | null> => {
+            const nt = await a11yExec('nodeText', {}, 4000)
+            if (!nt.ok) return null
+            const d = (nt.data ?? {}) as { text?: string }
+            return d.text ?? ''
+          }
+          await new Promise((resolve) => setTimeout(resolve, 260))
+          readBack = await read()
+          if (readBack !== null && readBack !== raw) {
+            await priv.execAdbShell(`am broadcast -a ADB_CLEAR_TEXT`).catch(() => undefined)
+            await priv.execAdbShell(`am broadcast -a ADB_INPUT_TEXT --es msg '${raw.replace(/'/g, `'\\''`)}'`).catch(() => undefined)
+            await new Promise((resolve) => setTimeout(resolve, 320))
+            readBack = await read()
+          }
+        }
         // 还原用户原 IME（广播已被接收器入队提交，留 0.4s 提交窗口防切换竞态）。
         if (needSwitch) await priv.execAdbShell(`sleep 0.4; ime set ${prev}`).catch(() => undefined)
         if (!r.ok) return { ok: false, denied: false, channel: 'adbkeyboard', text: r.guidance ?? (r.stdout || 'ADBKeyboard 输入失败') }
+        if (readBack !== null && raw.length > 0 && readBack !== raw) {
+          return {
+            ok: false,
+            denied: false,
+            channel: 'adbkeyboard',
+            text: `输入未落地：期望「${raw.slice(0, 30)}」，回读实际「${readBack.slice(0, 30)}」——`
+              + '已自动重试一次仍不一致；建议：确认目标输入框处于聚焦态后重试，或改用 android_web_dump + ref=wN（自有 Web UI），'
+              + '纯 ASCII 也可试 channel:"input"',
+          }
+        }
         const act = [clear ? '已清空' : '', raw ? `已输入 ${raw.slice(0, 24)}${raw.length > 24 ? '…' : ''}` : ''].filter(Boolean).join(' + ')
+        const verifyNote = readBack === null ? '' : '，回读一致'
         return {
           ok: true,
           denied: false,
           channel: 'adbkeyboard',
-          text: `${act}（ADBKeyboard${needSwitch ? '，IME 已临时切换并还原；若文本未落地请确认页面输入框处于聚焦态' : ''}）`,
+          text: `${act}（ADBKeyboard${needSwitch ? '，IME 已临时切换并还原' : ''}${verifyNote}）`,
         }
       }
       // input text 兜底（channel: "input" 强制；仅可见 ASCII——部分 ROM 丢字/丢空格，F5 不推荐）
@@ -1058,7 +1162,212 @@ function tools(ctx: Context, priv: PrivilegeFace) {
     },
   })
 
-  return [screenshot, uiTree, deviceInfo, actInput, uiDump, uiClick, uiScroll, uiInput]
+  /** #128 L1：WebView DOM 快照节点（与壳侧 webSnapshot 回包同形）。 */
+  type WebNode = {
+    ref: string
+    sel?: string
+    tag?: string
+    role?: string
+    text?: string
+    editable?: boolean
+    disabled?: boolean
+    inView?: boolean
+    bounds?: number[]
+  }
+
+  /**
+   * #128 L1：DSH 自有 WebView 的 DOM 语义快照（毫秒级、按选择器精准命中，不依赖无障碍虚拟树）。
+   * 第三方应用的 WebView 不属于本通道（不是我们的页面）。
+   */
+  const webDump = defineTool({
+    name: 'android_web_dump',
+    description:
+      '【WebView 专用，首选】导出 DSH 自有 Web UI（WebView 页面）的 DOM 语义快照：每个可交互元素给 '
+      + 'ref（wN，可直接用于 android_ui_click / android_ui_input）/ CSS 选择器 / role / 文本 / bounds / 可编辑 / 是否在视口内。'
+      + '解决「无障碍树只看到一个 WebView 容器、内部控件不可见」的问题（issue #128）。'
+      + '仅对 DSH 自己的 Web UI 有效；第三方 App 的网页仍用 android_ui_dump + 坐标。',
+    parameters: {
+      root: { type: 'string', description: '可选：限定根选择器（CSS），默认整页' },
+    },
+    output: {
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          ok: { type: 'boolean', required: true },
+          denied: { type: 'boolean' },
+          count: { type: 'number' },
+          url: { type: 'string' },
+          title: { type: 'string' },
+          nodes: {
+            type: 'array',
+            items: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                ref: { type: 'string', required: true },
+                sel: { type: 'string' },
+                tag: { type: 'string' },
+                role: { type: 'string' },
+                text: { type: 'string' },
+                editable: { type: 'boolean' },
+                disabled: { type: 'boolean' },
+                inView: { type: 'boolean' },
+                bounds: { type: 'array', items: { type: 'number' } },
+              },
+            },
+          },
+          text: { type: 'string' },
+        },
+      },
+      render: (_args, v: Record<string, unknown>) => [
+        { type: 'text', text: String(v.text ?? '(no output)') },
+      ],
+    },
+    execute: async ({ root }: { root?: string }, exec) => {
+      const a = guard('web_dump', { root }, exec as { agent?: { session?: unknown } })
+      if (!a.ok) return { ok: false, denied: true, count: 0, nodes: [] as WebNode[], text: a.guidance }
+      const r = await a11yExec('webSnapshot', root ? { root } : {}, 8000)
+      if (!r.ok) return { ok: false, denied: false, count: 0, nodes: [] as WebNode[], text: 'WebView DOM 快照失败：' + r.error }
+      const data = (r.data ?? {}) as {
+        ok?: boolean; error?: string; url?: string; title?: string; vw?: number; vh?: number
+        scrollY?: number; total?: number; nodes?: WebNode[]
+      }
+      if (data.ok === false) {
+        return { ok: false, denied: false, count: 0, nodes: [] as WebNode[], text: 'WebView DOM 快照失败：' + (data.error ?? '未知') }
+      }
+      const nodes = data.nodes ?? []
+      const lines = nodes.map((n) => {
+        const flags = [n.disabled === true ? '禁用' : '', n.editable === true ? '可编辑' : '', n.inView === false ? '视口外' : ''].filter(Boolean).join('/')
+        return `  ${String(n.ref)} ${String(n.role || n.tag || '')}${flags ? '[' + flags + ']' : ''} "${String(n.text ?? '').slice(0, 40)}" sel=${String(n.sel ?? '')}`
+      })
+      return {
+        ok: true,
+        denied: false,
+        count: nodes.length,
+        url: data.url,
+        title: data.title,
+        nodes: nodes as WebNode[],
+        text: `WebView DOM 快照：${data.title ?? ''} ${data.url ?? ''}（视口 ${data.vw ?? '?'}x${data.vh ?? '?'}，滚动 ${data.scrollY ?? 0}；`
+          + `命中 ${data.total ?? nodes.length} 个可交互元素，返回 ${nodes.length} 个）\n` + lines.join('\n')
+          + '\n点击用 ref=wN，或 css:<选择器> / text:<文本> / role:<role>。',
+      }
+    },
+  })
+
+  /**
+   * 环境一次性准备（现场实测建议先跑）：关动画让 dump/tap 后界面立即稳定；
+   * 启用内嵌 ADBKeyboard 协议输入法，治「中文 IME 把字母汉字化 / input text 丢尾字符」。
+   */
+  const envPrepare = defineTool({
+    name: 'android_env_prepare',
+    description:
+      '设备环境一次性准备（现场实测推荐在长流程开始前跑一次）：① 关闭三项系统动画（dump/tap 后界面立即稳定，减少等待）；'
+      + '② 启用内嵌 ADBKeyboard 协议输入法 com.dsharnessmobile.shell/.AdbKeyboardService（中文 IME 汉字化/丢字的治本手段）。'
+      + 'restore=true 时恢复动画（输入法不还原）；setImeDefault=true 时把该输入法设为默认（会改变用户全局输入法，谨慎）。'
+      + '需 ADB 授权或无障碍通道。',
+    parameters: {
+      animations: { type: 'boolean', description: '是否处理动画（默认 true）' },
+      ime: { type: 'boolean', description: '是否启用内嵌输入法（默认 true）' },
+      restore: { type: 'boolean', description: 'true = 恢复动画默认值（1）而不是关闭' },
+      setImeDefault: { type: 'boolean', description: 'true = 同时设为默认输入法（默认 false，仅启用）' },
+    },
+    output: {
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          ok: { type: 'boolean', required: true },
+          denied: { type: 'boolean' },
+          text: { type: 'string' },
+        },
+      },
+      render: (_args, v: Record<string, unknown>) => [{ type: 'text', text: String(v.text ?? '') }],
+    },
+    execute: async (
+      { animations = true, ime = true, restore = false, setImeDefault = false }: { animations?: boolean; ime?: boolean; restore?: boolean; setImeDefault?: boolean },
+      exec,
+    ) => {
+      const a = guard('env_prepare', { animations, ime, restore, setImeDefault }, exec as { agent?: { session?: unknown } })
+      if (!a.ok) return { ok: false, denied: true, text: a.guidance }
+      if (!priv.execAdbShell) return { ok: false, denied: false, text: 'ADB 执行通道未接通（本工具需要 adb shell；无障碍通道无法改系统设置）' }
+      const lines: string[] = []
+      if (animations) {
+        if (restore) {
+          await restoreAnimScales({})
+          lines.push('动画：已恢复默认（1）')
+        } else {
+          await setAnimScales('0')
+          lines.push('动画：已关闭（window/transition/animator 三项 = 0）')
+        }
+      }
+      if (ime) {
+        const IME_ID = 'com.dsharnessmobile.shell/.AdbKeyboardService'
+        const en = await priv.execAdbShell(`ime enable ${IME_ID}`)
+        const list = await priv.execAdbShell(`ime list -s | grep -c dsharnessmobile`)
+        const enabled = list.ok && Number.parseInt(list.stdout.trim(), 10) > 0
+        if (!enabled) {
+          lines.push('输入法：启用失败——请在「设置 → 系统 → 语言与输入法」里手动启用「DSH 设备键盘」后重试')
+        } else if (setImeDefault) {
+          const cur = await priv.execAdbShell(`settings get secure default_input_method`)
+          const prev = (cur.ok ? cur.stdout : '').trim().replace(/^"|"$/g, '')
+          const set = await priv.execAdbShell(`ime set ${IME_ID}`)
+          lines.push(`输入法：已启用并设为默认（原默认 ${prev || '?'}；如需还原：ime set ${prev || '<原输入法>' }）`)
+          if (!set.ok) lines.push('输入法：设为默认失败——' + (set.stdout || '').slice(0, 120))
+        } else {
+          lines.push(`输入法：已启用（${IME_ID}）；android_ui_input 会在注入时临时切换并在结束后还原，无需设为默认`)
+        }
+        if (!en.ok) lines.push('（ime enable 返回异常：' + (en.stdout || '').slice(0, 120) + '）')
+      }
+      return { ok: true, denied: false, text: '环境准备完成：\n- ' + lines.join('\n- ') }
+    },
+  })
+
+  /** 拉起应用（现场实测每次都要手写 monkey；包名由 pm list packages 先查）。 */
+  const appLaunch = defineTool({
+    name: 'android_app_launch',
+    description:
+      '按包名拉起应用主界面（monkey -p <pkg> -c android.intent.category.LAUNCHER 1），等待后回报前台 Activity。'
+      + '先用 android_device_info 或 pm list packages 找到包名。需 ADB 授权。',
+    parameters: {
+      pkg: { type: 'string', required: true, description: '应用包名（如 com.netease.cloudmusic）' },
+      waitMs: { type: 'number', description: '拉起后等待毫秒数（默认 2500）' },
+    },
+    output: {
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          ok: { type: 'boolean', required: true },
+          denied: { type: 'boolean' },
+          pkg: { type: 'string' },
+          foreground: { type: 'string' },
+          text: { type: 'string' },
+        },
+      },
+      render: (_args, v: Record<string, unknown>) => [{ type: 'text', text: String(v.text ?? '') }],
+    },
+    execute: async ({ pkg, waitMs = 2500 }: { pkg: string; waitMs?: number }, exec) => {
+      const a = guard('app_launch', { pkg }, exec as { agent?: { session?: unknown } })
+      if (!a.ok) return { ok: false, denied: true, pkg, text: a.guidance }
+      if (!/^[a-zA-Z][\w.]*$/.test(pkg)) return { ok: false, denied: false, pkg, text: '包名不合法：' + pkg }
+      if (!priv.execAdbShell) return { ok: false, denied: false, pkg, text: 'ADB 执行通道未接通' }
+      const r = await priv.execAdbShell(`monkey -p ${pkg} -c android.intent.category.LAUNCHER 1`)
+      if (!r.ok) return { ok: false, denied: false, pkg, text: r.guidance ?? (r.stdout || '拉起失败') }
+      await new Promise((resolve) => setTimeout(resolve, Math.max(500, Math.min(waitMs, 8000))))
+      const fg = await foregroundInfo()
+      const matched = fg !== null && fg.pkg === pkg
+      return {
+        ok: true,
+        denied: false,
+        pkg,
+        foreground: fg ? `${fg.pkg}/${fg.activity}` : '',
+        text: `已拉起 ${pkg}；前台 ${fg ? `${fg.pkg}/${fg.activity}` : '未知'}` + (matched ? '' : `（前台不是目标包——可能被权限弹窗/其他窗口遮挡，请 android_ui_dump 核对）`),
+      }
+    },
+  })
+
+  return [screenshot, uiTree, deviceInfo, actInput, uiDump, uiClick, uiScroll, uiInput, webDump, envPrepare, appLaunch]
 }
 
 export function apply(ctx: Context, _config: Record<string, unknown> = {}) {


### PR DESCRIPTION
## 变更说明

- **#128 L1**：`MainActivity` 暴露 `webViewRef`；`DeviceControlService` 新增 `webSnapshot` / `webAction`（页面上下文 DOM 快照 + 按 ref/选择器/文本/role 执行 click/setText/scroll，setText 走原生 value setter 兼容 React 受控组件）与 `nodeText`（输入回读）。
- **关键修复**：`assets/patched/attachment-local-index.js`（**运行时补丁**）加同一守卫——它启动后覆盖引擎树，会让构建期补丁失效（本轮实测踩中：构建期 4/4 applied 但设备侧仍是原版）。
- **#133 收尾**：一次性清理旧 `files/control-shots`。
- **#130**：`EngineManager` 播种 `phone-control` 预设（`$DSH_HOME/.agent-presets/`，组成取自带 standard + 自带 SKILL 固定流程纪律）。
- **光环提亮**：峰值内移 + 加过渡段 + 四态 alpha 提档（半径不动，保持贴边不被裁）。
- 子仓镜像：ui-responsive 0.1.14 / manage 0.2.2 / bridge 0.2.2 / model-capability 0.2.1。

## 关联 issue

Refs #128, #130, #127, #133

## 测试

- [x] `compileDebugKotlin` + `assembleDebug` 通过；装机后设备侧 `grep -c durable-walk` = 1
- [x] 设备实证（模拟器 16416）：图片发送 accepted=true；DOM 快照 61 节点；`android_web_dump` 已注册；`phone-control` 预设文件已播种
- [ ] 真机 arm64 复验（设备未接入）

## 破坏性变更

无。