### PR TITLE
docs: 0.13.6 全量认证记录

### DIFF
--- a/docs/AGENTS/0.13.6-CERTIFICATION.md
+++ b/docs/AGENTS/0.13.6-CERTIFICATION.md
@@ -1,0 +1,47 @@
+# 0.13.6 全量认证记录（2026-09-10）
+
+> 认证人：AI 开发助手。范围：x86_64 模拟器双形态（竖屏 16416 / 横屏 16384）+ 全门禁 + 双 ABI 纯净构建。
+> arm64 真机验证按用户要求由用户执行；本文件是发版判定的证据台账。
+
+## 1. 结论
+
+| 认证项 | 结果 | 证据 |
+|---|---|---|
+| PR 合并 | 通过 | `dsh-mobile#32`、`dsh-mobile-apk#138` CI 绿后合并，分支已删，两仓 main 同步 |
+| 统一补丁 | 通过 | arm64/x86_64 双份快照均 `applied 4/4`（pi-drift-F1 / **attach-durable-F2** / boot-pending-G1 / pi-toolcall-G2） |
+| 引擎 overlay 抽验 | 通过 | 构建日志 `引擎 overlay 完成（264 包，@ 0.1.2-rc.1）` |
+| 单 pass 注入 + 挂载集 | 通过 | `patch mounts ok: 11 个注入包全部挂载` |
+| 权限模式门禁 | 通过 | arm64 `51825` 文件 / x86_64 `51707` 文件 |
+| 第三方 / elf / 机密 | 通过 | 构建链门禁链全绿（未拒打包） |
+| gradle 双 ABI | 通过 | arm64 165.96 MB / x86_64 163.10 MB `BUILD SUCCESSFUL` |
+| 快照资产一致性 | 通过 | `PASS arm64 7ee82e93…` / `PASS x86_64 b9ac5a70…`（与 APK 内嵌同源） |
+| 单测 | 通过 | ui-responsive **85/85**、model-capability **30/30**、manage **5/5** |
+| 冒烟 | 通过 | `smoke-bridge` SMOKE PASS（18/18，修掉 0.13.5 门禁重构后失效的 5 条断言） |
+| 设备回归（竖屏 16416） | 通过 | 见 §2 |
+| 设备回归（横屏 16384） | 部分 | 见 §3 |
+| arm64 真机 | 待用户执行 | 设备未接入 |
+
+## 2. 竖屏 16416 设备回归（release x86_64 包，指纹 `b9ac5a70…`）
+
+- **图片上传发送**：`{"ok":true,"value":{"accepted":true}}`，附件 `sha256:c414cd0e…` 正常提交（修前为 `prompt rejected (session/agent-busy)`，真因 `EACCES open '/data/user/0'`）。
+- **#130 `android_env_prepare`**：`环境准备完成：动画：已关闭（三项=0）；输入法：启用失败——请手动启用「DSH 设备键盘」`（模拟器未注册该 IME，工具按设计给出可执行指引而非静默失败）。
+- **#128 `android_web_dump`**：`WebView DOM 快照：DeepSeek Harness … 命中 106 个可交互元素`，节点样例 `w1 button "打开导航" sel=#root > div:nth-child(1) …`、`w20 textbox[可编辑] "发消息或做任务…"`、`w106 button[视口外] "设置"`（对照无障碍通道仅 4 个节点）。
+- **#127 `android_screenshot`**：`截图已内联返回（… 238239 字节，临时文件已删除）。图像就在本结果里，无需再调用 read_image`，图像块随结果内联（`sha256:91ca9df4…`，900x1600）——一次性闭环成立。
+- 门禁正确性：a11y 未绑定期间三个工具一律回「设备控制未授权」并给出两条可执行路径（fail-closed 符合设计）。
+
+## 3. 横屏 16384 设备回归（release x86_64 包，同指纹）
+
+- 布局/渲染正常（1600x900 视口，侧边栏+对话区+悬浮球在场）。
+- **图片附件**：`session/attachment-invalid：Model "deepseek-v4-flash" does not support image input`——模型能力门禁给出**明确原因**（不再是 agent-busy 兜底），符合设计。
+- 该设备当前会话档位为 `workspace-write`，设备控制面按设计拒绝；工具端到端未在此形态复跑（需要 danger-full-access 会话）。
+
+## 4. 本轮修复的根因（发版前必须知道）
+
+- **附件持久化祖先 fsync 在 Android 上 EACCES**：`dsh-attachment-local.ensureDurableDirectory()` 从 `DSH_HOME` 一路 fsync 到文件系统根，而 `/data/user/0` 对应用不可读 → 所有图片上传在 prompt 准入阶段抛错，api-proxy 兜底成 `session/agent-busy`（真因藏在 `details.reason`）。同一根因解释 `read_image` 读任意路径都报同一 EACCES。
+- **修复必须双写**：构建期补丁 `attach-durable-F2` **加上** 运行时补丁 `app/src/main/assets/patched/attachment-local-index.js`——后者启动后覆盖引擎树，只打构建期补丁会被盖回原版（本轮实测踩中）。
+
+## 5. 待办（发版前）
+
+1. arm64 真机验证（用户执行）：安装 + 引擎起来 + 图片上传 + `android_web_dump` + 截屏内联。
+2. 横屏形态的工具端到端（在 danger-full-access 会话下复跑一次）。
+3. 版本号/CHANGELOG/Release notes 更新到 0.13.6（当前仓库仍为 0.13.5）。


### PR DESCRIPTION
## 变更说明

新增 `docs/AGENTS/0.13.6-CERTIFICATION.md`：0.13.6 全量认证证据台账（全门禁 / 双 ABI 纯净构建 / 快照资产一致性双 PASS / 单测 85-30-5 / smoke PASS / 竖屏 16416 三项工具端到端实证 / 横屏 16384 现状 / 根因与「构建期+运行时补丁必须双写」的教训 / 发版前待办）。

## 关联 issue

Refs #127, #128, #130, #133, #135

## 测试

- [x] 文档类改动；认证证据见文件 §1-§3
- [x] CI Gate

## 破坏性变更

无。