### PR TITLE
fix: 手机操控预设补 back/不绕路纪律 + 镜像 manage 0.2.3

### DIFF
--- a/app/src/main/java/com/dsharnessmobile/shell/EngineManager.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/EngineManager.kt
@@ -1102,18 +1102,20 @@ class EngineManager(private val context: Context, private val pickToken: String?
 # 手机操控流程（DSH 设备控制）
 
 ## 固定顺序
-1. 会话档位必须是 danger-full-access，否则设备工具一律拒绝。
+1. 会话档位必须是 danger-full-access，否则设备工具一律拒绝（切换入口：会话底部权限芯片 → 完全权限；**不要试图让工具自己提权**，也不要用 Termux/ADB 绕路）。
 2. 长流程开始前跑一次 android_env_prepare（关动画 + 启用内嵌 ADB 键盘），之后 dump/tap 更稳。
 3. 感知：android_ui_dump（无障碍语义树，首选）→ 若结果是 WebView 容器或目标是 DSH 自己的 Web UI，改用 android_web_dump（DOM 快照）。
-4. 动作：android_ui_click / android_ui_input，引用用 ref（id:nN / text:精确文本#k / desc: / rid: / wN / css: / text: / role:）。
-5. 校验：工具自带回执（点击回报「已生效 / 未观察到界面变化」；输入回报「回读一致 / 未落地」）——不要假设动作成功。
-6. 需要看画面时用 android_screenshot（图像直接随结果返回，不需要再 read_image）。
+4. 卡住时：**先 android_ui_global back**（返回上一级），或 home 回桌面重新进入——子菜单/弹窗/详情页出不来时这是第一步。
+5. 动作：android_ui_click / android_ui_input，引用用 ref（id:nN / text:精确文本#k / desc: / rid: / wN / css: / text: / role:）。
+6. 校验：工具自带回执（点击回报「已生效 / 未观察到界面变化」；输入回报「回读一致 / 未落地」）——不要假设动作成功。
+7. 需要看画面时用 android_screenshot（图像直接随结果返回，不需要再 read_image）。
 
 ## 纪律
 - 禁止盲点坐标点击；nx/ny 仅作兜底，且必须说明理由。
 - 同名节点必须消歧：用 dump 里的 #k 序号（text:设置#2）。
 - 抓到的包名与前台不一致时以 dumpsys 为准（uiautomator/无障碍可能抓到覆盖层）。
 - 输入只走单次注入 + 回读断言；不要用 keyevent 打字母（中文 IME 会汉字化），不要拆成多段输入。
+- dump 失败（重 UI / 播放页常见）时按提示走：先 back 退出重页面，或截图看画面；**不要转去尝试 Termux 或 ADB**（未配对时那条路不存在，只会浪费轮次）。
 - 连续两次动作未产生预期变化时停下来重新 dump，并如实汇报当前界面状态，不要继续猜测。
 """
 

--- a/plugins/dsh-android-bridge/src/control-policy.ts
+++ b/plugins/dsh-android-bridge/src/control-policy.ts
@@ -50,7 +50,8 @@ export function decideControl(input: ControlPolicyInput): ControlDecision {
     return {
       backend: 'deny',
       reason: `会话档位为 ${input.sessionMode ?? '未知'}，设备控制面要求 ${REQUIRED_SESSION_MODE}`,
-      guidance: '在会话的权限档位里切到「完全访问」后重试（无障碍通道同样受此门约束）。',
+      guidance: '在会话底部的权限芯片里切到「完全权限」后重试（设置 → 通用设置 → 新会话默认权限模式 也可改默认；'
+        + '无障碍通道同样受此门约束）。这是用户侧的一次点击，工具无法自行提权。',
     }
   }
 

--- a/plugins/dsh-android-manage/package.json
+++ b/plugins/dsh-android-manage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dsh-android/dsh-android-manage",
   "description": "Android phone management tools (ADB-first observe/act/wait loop, PRD F1.6): screenshot, UI tree, app/device info — all fail-closed on the privilege bridge",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "main": "lib/index.js",
   "exports": {

--- a/plugins/dsh-android-manage/src/index.ts
+++ b/plugins/dsh-android-manage/src/index.ts
@@ -652,8 +652,16 @@ function tools(ctx: Context, priv: PrivilegeFace) {
       if (!a.ok) return { ok: false, denied: true, screen: { w: 0, h: 0 }, rotation: 0, count: 0, rawCount: 0, nodes: [], text: a.guidance }
       // 0.13.5 W4：无障碍通道优先（一次系统开关即用；不经 uiautomator，故不受 F1 idle 阻塞影响）
       if (controlDecision('snapshot', exec as { agent?: { session?: unknown } }).backend === 'a11y') {
-        const r = await a11yExec('snapshot', {})
-        if (!r.ok) return { ok: false, denied: false, screen: { w: 0, h: 0 }, rotation: 0, count: 0, rawCount: 0, nodes: [], text: '无障碍取树失败：' + r.error }
+        // 现场实测（2026-09-10 真机，B 站播放页）：重 UI/常驻动画页面建树慢，8s 默认超时频繁失败——
+        // 这里给到 15s；仍失败则明确指引「先 android_ui_global back 退出重页面再 dump」。
+        const r = await a11yExec('snapshot', {}, 15_000)
+        if (!r.ok) {
+          return {
+            ok: false, denied: false, screen: { w: 0, h: 0 }, rotation: 0, count: 0, rawCount: 0, nodes: [],
+            text: `无障碍取树失败：${r.error}——重 UI/播放页常见；建议：① android_ui_global back 退回上一级再 dump；`
+              + '② 或 android_screenshot 直接看画面；③ ADB 已配对时用 android_ui_tree（uiautomator）。',
+          }
+        }
         const data = (r.data ?? {}) as A11ySnapshot
         const pruned = pruneNodes(data.nodes ?? [])
         const screen = data.screen && data.screen.w > 0 ? data.screen : { w: 0, h: 0 }
@@ -1367,7 +1375,56 @@ function tools(ctx: Context, priv: PrivilegeFace) {
     },
   })
 
-  return [screenshot, uiTree, deviceInfo, actInput, uiDump, uiClick, uiScroll, uiInput, webDump, envPrepare, appLaunch]
+  /**
+   * 全局动作（无障碍通道，无需 ADB）：返回 / 主页 / 最近任务 / 通知栏。
+   * 现场实测缺口（2026-09-10 真机）：AI 在子菜单里出不来——此前没有任何工具能按返回键，
+   * `android_act_input keyevent` 又依赖 ADB 通道（未配对即不可用）。
+   */
+  const uiGlobal = defineTool({
+    name: 'android_ui_global',
+    description:
+      '【首选】系统级导航动作（无障碍通道，不需要 ADB）：back=返回上一级、home=回桌面、'
+      + 'recents=最近任务、notifications=下拉通知栏。卡在子菜单/弹窗/详情页出不来时，第一步就用 back。'
+      + '需设备控制授权（无障碍服务已开启即可）+ 会话档位 danger-full-access。',
+    parameters: {
+      action: { type: 'string', required: true, enum: ['back', 'home', 'recents', 'notifications'], description: '要执行的全局动作' },
+    },
+    output: {
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          ok: { type: 'boolean', required: true },
+          denied: { type: 'boolean' },
+          action: { type: 'string' },
+          text: { type: 'string' },
+        },
+      },
+      render: (_args, v: Record<string, unknown>) => [{ type: 'text', text: String(v.text ?? '') }],
+    },
+    execute: async ({ action }: { action: string }, exec) => {
+      const a = guard('ui_global', { action }, exec as { agent?: { session?: unknown } })
+      if (!a.ok) return { ok: false, denied: true, action, text: a.guidance }
+      if (!['back', 'home', 'recents', 'notifications'].includes(action)) {
+        return { ok: false, denied: false, action, text: 'action 必须是 back / home / recents / notifications' }
+      }
+      const r = await a11yExec('global', { action }, 6000)
+      if (!r.ok) {
+        return { ok: false, denied: false, action, text: `全局动作 ${action} 失败：${r.error}（无障碍通道不可用时，改用 android_act_input keyevent，但那条路需要 ADB 配对）` }
+      }
+      const d = (r.data ?? {}) as { global?: string }
+      return {
+        ok: true,
+        denied: false,
+        action,
+        text: `已执行全局动作 ${d.global ?? action}`
+          + (action === 'back' ? '（返回上一级；页面已变化，请重新 dump 再定位）' : '')
+          + (action === 'home' ? '（已回桌面）' : ''),
+      }
+    },
+  })
+
+  return [screenshot, uiTree, deviceInfo, actInput, uiDump, uiClick, uiScroll, uiInput, webDump, envPrepare, appLaunch, uiGlobal]
 }
 
 export function apply(ctx: Context, _config: Record<string, unknown> = {}) {


### PR DESCRIPTION
## 变更说明

- `phone-control` 预设 SKILL 补两条真机纪律：**卡在子菜单先 `android_ui_global back`**；dump 失败时按提示走（back / 截图），**不要转去尝试 Termux 或 ADB**（未配对时那条路不存在）；并明确「提权由用户切换会话档位，工具不要自己提权」。
- 镜像 manage 0.2.3（含 `android_ui_global` 工具与 15s 取树超时）。

## 关联 issue

Refs #128, #130

## 测试

- [x] `compileDebugKotlin` 通过
- [ ] 真机复验（待用户）

## 破坏性变更

无。