### PR TITLE
fix: phone-control 预设 SKILL 每次启动刷新

### DIFF
--- a/app/src/main/java/com/dsharnessmobile/shell/EngineManager.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/EngineManager.kt
@@ -350,6 +350,14 @@ class EngineManager(private val context: Context, private val pickToken: String?
   private fun seedPhoneControlPreset(privateDsh: File) {
     try {
       val dir = File(File(privateDsh, ".agent-presets"), "phone-control")
+      // SKILL.md 是我们管理的纪律文案：每次启动都刷新（保证升级后纪律立即生效）；
+      // preset.yml / agent.cordis.yml 只在缺失时播种，保留用户可能的改动。
+      val skillDir = File(dir, "skills/phone-control").apply { mkdirs() }
+      val skillFile = File(skillDir, "SKILL.md")
+      if (skillFile.readText().trim() != PHONE_CONTROL_SKILL.trim()) {
+        skillFile.writeText(PHONE_CONTROL_SKILL)
+        Log.i(TAG, "phone-control SKILL refreshed")
+      }
       if (File(dir, "preset.yml").exists()) return
       val shipped = File(
         context.filesDir,
@@ -359,14 +367,12 @@ class EngineManager(private val context: Context, private val pickToken: String?
         Log.w(TAG, "phone-control preset skipped: shipped standard composition absent at " + shipped.absolutePath)
         return
       }
-      val skillDir = File(dir, "skills/phone-control").apply { mkdirs() }
       File(dir, "agent.cordis.yml").writeText(shipped.readText())
       File(dir, "preset.yml").writeText(
         "name: 手机操控\n" +
           "description: 以无障碍语义树 / DOM 快照驱动的手机操控预设：dump → 按 ref 点击或输入 → 校验 → 再 dump；禁止盲点坐标。\n" +
           "order: 50\n",
       )
-      File(skillDir, "SKILL.md").writeText(PHONE_CONTROL_SKILL)
       Log.i(TAG, "phone-control preset seeded -> " + dir.absolutePath)
     } catch (t: Throwable) {
       Log.w(TAG, "phone-control preset seeding failed", t)


### PR DESCRIPTION
## 变更说明

真机复验发现：`phone-control` 预设的 `SKILL.md` 只在预设目录缺失时播种，升级后**旧纪律文案不会更新**（实测设备上 SKILL 仍是上一版，没有「先 back / 不绕 Termux」）。改为**每次启动刷新 SKILL.md**（我们管理的文案），`preset.yml` / `agent.cordis.yml` 仍只在缺失时播种以保留用户改动。

## 关联 issue

Refs #130

## 测试

- [x] `compileDebugKotlin` 通过
- [x] 设备侧已热修验证（`SKILL.md` 含 `android_ui_global`，grep=1）

## 破坏性变更

无。