### PR TITLE
chore: 发版 0.13.7——版本号单一来源 + 引擎版本环境变量

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,14 +14,15 @@ android {
     // (the embedded engine, bash, and every child command would need linker64
     // wrappers); 34 keeps native exec working on Android 15/16 devices.
     targetSdk = 34
-    // 0.13.6：versionCode 33（修复批：附件持久化祖先 fsync Android 守卫——图片上传/read_image 全链修复；
-    // 自有 WebView DOM 快速通道 webSnapshot/webAction + android_web_dump；android_ui_global 返回/主页/
-    // 最近任务；android_env_prepare/android_app_launch/前台真值/输入回读断言；phone-control 预设；
-    // 顶部系统 inset 通道 + 弹出面板几何守卫 + 悬浮球光环提亮；覆盖安装 0.13.5(32)）。
-    versionCode = 33
-    // Snapshot builds append a suffix (e.g. -SN-1-RC8) via -PversionNameSuffix; release builds pass none.
+    // 0.13.7：versionCode 34（追上游 dsh 0.1.5-rc.1：上游 ui-layout 基线 + 移动适配层 0.2.0 +
+    // 原生「打开方式」PathOpen/openPathChooser + 引擎树补丁 F3/F4 + polyfill 装配与 Iterator 垫片修复 +
+    // UI 冗余清理（退役 attachment-formats、快照徽章折叠成小绿点）；覆盖安装 0.13.6(33)）。
+    versionCode = 34
+    // Snapshot builds append a suffix (e.g. -SN-1-RC13) via -PversionNameSuffix; release builds pass none.
     val snapshotSuffix = providers.gradleProperty("versionNameSuffix").getOrElse("")
-    versionName = "0.13.6" + snapshotSuffix
+    // 版本号单一来源：UI（GuidePageRenderer）、桥（androidBridge.version）、诊断日志、引擎环境变量
+    // （DSH_APP_VERSION，见 EngineManager.engineEnv）全部读这里，禁止任何地方再硬编码版本字面量。
+    versionName = "0.13.7" + snapshotSuffix
     buildConfigField("String", "TERMUX_VERSION", "\"0.118.3\"")
   }
 

--- a/app/src/main/java/com/dsharnessmobile/shell/EngineManager.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/EngineManager.kt
@@ -1077,6 +1077,11 @@ class EngineManager(private val context: Context, private val pickToken: String?
       "TERMUX_APP__DATA_DIR" to context.filesDir.parentFile.absolutePath,
       "TERMUX_APP__LEGACY_DATA_DIR" to "/data/data/com.dsharnessmobile.shell",
       "TERMUX_VERSION" to BuildConfig.TERMUX_VERSION,
+      // 版本口径单一来源（2026-09-10 用户定例）：壳侧 UI/桥/诊断都读 BuildConfig.VERSION_NAME，
+      // 引擎侧插件（如 android-linux-env 导出的环境配方）一律读这两个环境变量，
+      // 不许再出现「界面显示 0.13.x 而插件里写 0.13.0」这类内部口径分裂。
+      "DSH_APP_VERSION" to BuildConfig.VERSION_NAME,
+      "DSH_APP_VERSION_CODE" to BuildConfig.VERSION_CODE.toString(),
       // Directory-picker endpoint auth token (validated by the web-compat plugin via x-dsh-pick-token).
       "DSH_PICK_TOKEN" to (pickToken ?: ""),
       // ADB 授权状态（0.13.0 F1.7）：dsh-android-bridge 插件据此失败关闭；门控=完全访问档位+开关+配对。

--- a/plugins/dsh-android-linux-env/src/index.ts
+++ b/plugins/dsh-android-linux-env/src/index.ts
@@ -80,7 +80,9 @@ function recipeExport(): Record<string, unknown> {
   for (const k of allowlisted) if (process.env[k]) env[k] = process.env[k]!
   return {
     exportedAt: new Date().toISOString(),
-    version: '0.13.0',
+    // 版本口径单一来源：壳侧 BuildConfig.VERSION_NAME 经引擎环境传入（DSH_APP_VERSION）——
+    // 硬编码会让「界面 0.13.7 / 配方 0.13.0」口径分裂（2026-09-10 用户定例）。
+    version: process.env.DSH_APP_VERSION ?? 'unknown',
     env,
     dpkgPackages: dpkgList,
     profilePatch: readText(join(profile, 'cordis.patch.yml')),

--- a/scripts/build-snapshot-013.mjs
+++ b/scripts/build-snapshot-013.mjs
@@ -286,6 +286,21 @@ for (const entry of OVERLAY.keepUnpublished ?? []) {
     }
   }
   log(`引擎树补丁就位（${enginePatches.length} 项 marker 在场）`)
+  // 行为回归（0.13.7）：G1/G2 这类补丁光有 marker 不足以证明「改完还能跑」——marker 只证文本被替换。
+  // 两个测试直接驱动刚打过补丁的产物（不联网、不花额度），缺目标文件时自行 skip（裸 clone 正常）。
+  for (const [label, script, flag, target] of [
+    ['boot-pending-G1', 'boot-pending.test.mjs', '--boot', join(stageRoot, 'usr/lib/node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-app-boot/lib/index.js')],
+    ['pi-toolcall-G2', 'pi-toolcall.test.mjs', '--pi-ai', join(stageRoot, 'usr/lib/node_modules/@deepseek-ai/dsh/node_modules/@earendil-works/pi-ai/dist/api/openai-completions.js')],
+  ]) {
+    const out = execSync(`node "${join(ROOT, 'scripts', 'tests', script)}" ${flag} "${target}"`, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
+    const pass = /(?:^|\n)ℹ pass (\d+)/.exec(out)?.[1] ?? '0'
+    const fail = /(?:^|\n)ℹ fail (\d+)/.exec(out)?.[1] ?? '0'
+    if (Number(fail) > 0 || out.includes('[skip]')) {
+      console.error(`[引擎树补丁行为回归失败] ${label}: pass=${pass} fail=${fail}${out.includes('[skip]') ? '（目标文件不在场）' : ''}`)
+      process.exit(1)
+    }
+    log(`引擎树补丁行为回归 ${label}: pass=${pass} fail=${fail}`)
+  }
 }
 
 // ── 0g. 能力发现目录快照（0.13.5 W3）：从 stage 引擎树生成 dsh-model-capability 的厂商目录索引 ──


### PR DESCRIPTION
## 目的

发版 0.13.7，并落实用户定例：**内部界面与实际版本必须口径统一**。

## 改动

- `build.gradle.kts`：`versionCode` 33 → **34**，`versionName` 0.13.6 → **0.13.7**。
- `EngineManager.engineEnv` 新增 `DSH_APP_VERSION` / `DSH_APP_VERSION_CODE`（取自 BuildConfig），供引擎侧插件读取。
- 同步协调仓 `build-snapshot-013.mjs`（引擎树补丁行为回归入链）与 `plugins/dsh-android-linux-env` 副本。

## 口径核查（谁显示版本，来源在哪）

| 显示面 | 来源 |
|---|---|
| 引导页 `v…` | `BuildConfig.VERSION_NAME`（GuidePageRenderer） |
| 桥 `androidBridge.version()` | 同上 |
| 诊断日志 `app: … (versionCode …)` | 同上 |
| 引擎侧 `android_env_recipe` 配方 version | `DSH_APP_VERSION`（本轮追加通道） |
| 设置页/其他插件 | 全仓扫描无其他版本字面量 |