### PR TITLE
fix: 运行时补丁补齐会话迁移发布的 link→rename 回退（修 0.13.7 旧会话打开 EACCES，issue #154）

### DIFF
--- a/app/src/main/assets/patched/session-persistence-jsonl-index.js
+++ b/app/src/main/assets/patched/session-persistence-jsonl-index.js
@@ -2033,8 +2033,9 @@ async function publishCurrentExclusive(staged, currentPath, internals) {
 	} catch (error) {
 		/* v8 ignore else -- a non-collision filesystem error propagates unchanged. */
 		if (isEEXIST(error)) return false;
-		/* v8 ignore next -- the filesystem error is already complete. */
-		throw error;
+		/* dsh-mobile link->rename fallback: Android app-private dirs reject link(2) (EACCES). */
+		if (!(error instanceof Error && "code" in error && (error.code === "EACCES" || error.code === "EPERM" || error.code === "ENOTSUP"))) throw error;
+		await rename(staged, currentPath);
 	}
 	await syncDirectory(dirname(currentPath), internals);
 	return true;

--- a/docs/AGENTS/RUNTIME-PATCHES.md
+++ b/docs/AGENTS/RUNTIME-PATCHES.md
@@ -48,6 +48,7 @@
 |---|---|
 | v1→v2 asset 更新被跳过 | 固定 marker 字符串在目标文件更新后仍命中 → 新 asset 永不落盘；改为内容指纹判定（:404-405、:432-434） |
 | 2026-08-23 前端审核 CRITICAL#4 | 引擎升级换 bundle hash → patched 模板旧引用 404 白屏；加 hashAdaptive（:435-438、:471-490） |
+| 2026-09-11 旧会话迁移 EACCES（issue #154） | asset 只覆盖 `materialize` 的 `link(tmp, finalPath)`，漏了 `publishCurrentExclusive` 的 `link(staged, currentPath)`；0.13.7 格式升 v3 后旧会话首次打开必经迁移发布 → 全部旧会话 EACCES 打不开。教训：**link(2) 回退要按调用点逐一清点**，不能只补历史锚点 |
 | v0.12.4（rc8）迁移批 | onImagePicked/describeImage/bundle-hardening/textzoom 四补丁删除（上游 rc.8 原生覆盖 + textzoom 功能取消）；textzoom 桥方法保留（:413-416） |
 | rc.1 → rc.2 链路 | rc.1 丢 rename 回退 → fs-local/session-persistence-jsonl 两补丁补回；rc.2 原生捆绑 vision-exp → llm-deepseek 补丁退役为遗留资产（:399-425） |
 | 目标包缺席语义 | 上游裁包（如某版本依赖图变动）时跳过而非报错/硬写，避免死覆盖（:440-446） |
@@ -68,7 +69,7 @@
 | asset | 目标 | 本次 delta（相对 0.1.5-rc.1 原文件） |
 |---|---|---|
 | `attachment-local-index.js` | `dsh-attachment-local/lib/index.js` | F2 祖先 fsync 守卫（`ensureDurableDirectory` 里的 `syncDirectory(parent)`；与 `scripts/patches/` 构建期补丁同源）+ **两处** link(2)→rename 回退（`publishImmutableAlias` 的 `source`、`publishStagedObject` 的 `staged.path`——0.1.5 变量名已变，旧锚点 `temporary/target` 失效）+ `publishStagedObject` 主链 `unlink(staged.path)` 容忍 ENOENT |
-| `session-persistence-jsonl-index.js` | `dsh-session-persistence-jsonl/lib/index.js` | import 行加 `rename` + `link(tmp, finalPath)` 的 EACCES/EPERM/ENOTSUP → rename 回退（0.1.5 锚点仍在） |
+| `session-persistence-jsonl-index.js` | `dsh-session-persistence-jsonl/lib/index.js` | import 行加 `rename` + **两处** EACCES/EPERM/ENOTSUP → rename 回退：① `link(tmp, finalPath)`（`materialize` 路径，0.1.5 锚点仍在）；② **`link(staged, currentPath)`（`publishCurrentExclusive`，迁移/新代的原子发布）**——②此前漏打：0.13.7 起旧会话 `v0→v3` 迁移必经此路径 → 升级后**全部旧会话打不开**（EACCES，issue #154）；本次补齐 |
 | `web-frontend-index.html` | `dist/index.html`（hashAdaptive） | 与 0.1.5 dist 模板同源；资产里的 hash 由壳侧 `adaptIndexHashes` 跟随引擎改写，无需人工维护 |
 | ~~`llm-deepseek-index.js`~~ | — | **删除**：无 `applyAssetPatch` 调用点（rc.2 原生含 vision 后已成死资产，39KB） |
 


### PR DESCRIPTION
## 问题
升级到 0.13.7 后，**所有 0.13.6 及更早写入的会话都无法打开**（不是个别会话）：报错固定在会话格式迁移的最后一步——
```
gateway/internal: resume failed for session "session-<id>":
Error: EACCES: permission denied,
link '.../session.migration.<token>.tmp' -> '.../session.v3.jsonl.zstd'
```
详见 issue #154。

## 根因
0.13.7 把会话格式推到 v3（`dsh-session-format-catalog: currentVersion=3`），旧会话 header 是 `version:0` → 首次打开必然触发 `v0→v1→v2→v3` 迁移；迁移最后一步 `publishCurrentExclusive()` 用 `link(2)` 原子发布。而 Android 应用私有目录在 SELinux 层**拒绝 `untrusted_app` 创建 hardlink**（`EACCES`，denial 被 dontaudit 静默、`dmesg` 无 avc 记录）。

本 asset 此前只补了 `materialize` 路径的 `link(tmp, finalPath)`（见 `RUNTIME-PATCHES.md` §7 原文），**漏了 `publishCurrentExclusive` 的 `link(staged, currentPath)`** —— 后者正是 0.13.7 起旧会话迁移的必经路径。

## 改动（2 个文件）
1. `app/src/main/assets/patched/session-persistence-jsonl-index.js`：给 `publishCurrentExclusive` 补上与同文件 `materialize` 路径一致的 `EACCES/EPERM/ENOTSUP → rename` 回退。**用模块顶层导入的 `rename`**（`node:fs/promises`，与该文件 2973 行既有写法一致）；LF 行尾保持，`node --check`（ESM）通过。
2. `docs/AGENTS/RUNTIME-PATCHES.md`：§7 行更新为「两处 link 回退」；§5 机制演进史登记教训（**link(2) 回退须按调用点逐一清点**，不能只补历史锚点）。

## 验证
### ① 函数级忠实复现（本机，SELinux **Enforcing**）
方法：从 asset 原文**逐字抽取** `publishCurrentExclusive` + `syncDirectory`，配**与引擎完全一致的 `defaultFileSystem`**（`open/readFile/readdir/stat/lstat/link/rm`），在应用私有目录真实调用一次发布：

| 变体 | 结果 |
|---|---|
| 原版（未打补丁） | ❌ `EACCES: permission denied, link ...`（忠实复现 issue 症状） |
| **本 PR（裸 `rename`）** | ✅ 返回 `true`，目标文件发布成功 |
| 反例：`internals.fs.rename(...)` | ❌ `TypeError: internals.fs.rename is not a function` |

> 反例特意记录，供后续维护者避坑：**`internals.fs`（`defaultFileSystem`）并不暴露 `rename`**（其成员只有 `open/readFile/readdir/stat/lstat/link/rm`）。回退必须用模块顶层导入的 `rename`——与同文件 `materialize` 路径的既有实现保持一致。

### ② 环境侧机制验证（同机）
| 测试 | 结果 |
|---|---|
| 应用 uid 在会话目录 `ln`（Enforcing） | `Permission denied` |
| 应用 uid 同目录 `ln`（`setenforce 0`） | 成功 → 确认是 SELinux 域策略而非 DAC/文件系统 |
| root 同目录 `ln` | 成功 |
| 同目录 `rename`（mv/cp） | 完全可用 |

### ③ 说明（未做的验证，避免误导）
运行时 asset **只在重新打包 APK 后生效**，因此本机无法做"打完补丁后由引擎端到端打开旧会话"的验证。本机现有会话是通过临时放宽 SELinux（`setenforce 0`）完成迁移的——那是用户侧绕行，**不属于本补丁的行为验证**；本补丁的行为由上面 ①（与引擎一致的 internals 形状 + 真实应用私有目录）覆盖。

## 备注
- `rename` 覆盖语义 vs `link` 的 EEXIST 独占：此处沿用同文件 `materialize` 路径的既有取舍（调用方在 `published=false` 分支另有「比对已存在 current 与 staged 摘要」的兜底）。若要保独占，可在 rename 前 `stat` 目标、存在即 `return false`——听维护者意见。
- 若更倾向构建期固化（`scope: engine`，见 §6），同一改动也可落 `scripts/patches/`；运行时 asset 需同步同源（§7.1「两者内容一致才不会互相回退」）。
