### PR TITLE
fix(mobile): 侧边栏抽屉底部安全区避让，设置入口不再被系统手势条遮挡（apk #153）

### DIFF
--- a/dsh-client-ui-responsive/src/client/mobile/mobile-form.css.ts
+++ b/dsh-client-ui-responsive/src/client/mobile/mobile-form.css.ts
@@ -37,6 +37,9 @@ export const MOBILE_FORM_CSS: string = `
     background: var(--dsw-specific-sidebar-fill);
     transform: translateX(-100%);
     transition: transform var(--ds-transition-duration-slow, 200ms) var(--ds-ease-in-out, ease);
+    /* 底部安全区：抽屉全高贴底时，底部设置入口会被系统手势条遮挡（apk #153）。
+       与 composer-insets 的底部 inset 处理保持一致。 */
+    padding-bottom: max(env(safe-area-inset-bottom, 0px), var(--dsh-android-system-bottom, 0px));
   }
 
   [data-dsh-frame]:not([data-sidebar-collapsed]) > [class*='sidebarCol'] {


### PR DESCRIPTION
## 问题

移动端侧边栏抽屉（drawer）全高贴底，底部设置入口与系统手势条/导航条重叠，点击困难（#153）。

## 根因

`mobile-form.css.ts` 中 `[data-dsh-frame] > [class*='sidebarCol']` 规则将抽屉固定为 `top: 0; bottom: 0`，未对底部系统安全区做避让。在全面屏手势导航（edge-to-edge）设备上，抽屉底部内容被系统手势条遮挡。

## 修复

在抽屉规则上补充底部安全区 padding：

```css
padding-bottom: max(env(safe-area-inset-bottom, 0px), var(--dsh-android-system-bottom, 0px));
```

与已有 `composer-insets.css.ts` 的底部 inset 处理方式保持一致；桌面端/非 Android 环境变量未设置时 `max(0px, 0px)` 干净归零，无副作用。

## 改动范围

- `dsh-client-ui-responsive/src/client/mobile/mobile-form.css.ts`（单文件，仅加一条 padding 声明 + 注释）

## 验证

- 全面屏手势导航设备上，抽屉底部设置入口完整可见、可点击。
- 桌面端布局不受影响（媒体查询限定在 767px 以内，且 inset 变量默认为 0）。
