### PR TITLE
fix: 引擎令牌出口脱敏——日志/诊断包/引导页三路径 + 门禁扩展（#184）

### DIFF
--- a/app/src/main/java/com/dsharnessmobile/shell/EngineAuth.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/EngineAuth.kt
@@ -49,10 +49,18 @@ object EngineAuth {
   const val BASE_URL = "http://$AUTHORITY"
   private const val COOKIE_NAME_PREFIX = "dsh-auth-"
   private const val TOKEN_LINE = "dsh web: "
-  private val TOKEN_RE = Regex("""dsh web: \S*/\?token=([A-Za-z0-9_\-]{40,})""")
+  internal val TOKEN_RE = Regex("""dsh web: \S*/\?token=([A-Za-z0-9_\-]{40,})""")
   private const val SECRET_RECORD_KEY = "client-connection/browser-session"
 
   @Volatile private var cached: String? = null
+
+  /**
+   * 日志出口脱敏（0.13.8 #184，唯一正则来源 = TOKEN_RE）：把启动令牌行替换为
+   * `?token=***`，保留 URL 形状与其余信息，不整行删除。
+   * 硬约束：只允许作用于**副本/落盘/展示出口**（日志、诊断包、引导页摘录），
+   * 绝不能改写 filesDir/engine.log 本体——壳侧鉴权链（tokenFromLog）依赖该行。
+   */
+  fun redact(text: String): String = text.replace(TOKEN_RE, "dsh web: ***?token=***")
 
   @Volatile private var appContext: Context? = null
 

--- a/app/src/main/java/com/dsharnessmobile/shell/EngineManager.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/EngineManager.kt
@@ -531,9 +531,10 @@ class EngineManager(private val context: Context, private val pickToken: String?
           "  exports/                 会话与配置的导出物\n" +
           "    config/settings.yaml   配置导出（设置 > 开发者选项 > 导出配置 生成）\n" +
           "                           修改本文件后点「导入配置」即可生效（无需重装）\n" +
-          "  log/                     开发者调试日志（默认关，设置 > 开发者选项 开启）\n" +
-          "  diagnostics/             启动失败/崩溃时自动生成的诊断包（engine.log + 环境信息 + logcat），\n" +
-          "                           反馈 issue 时直接整目录打包上传即可\n\n" +
+          "  log/                     开发者调试日志（默认关，设置 > 开发者选项 开启；含令牌脱敏，"
+            + "但仍有命令与模型内容）\n" +
+          "  diagnostics/             启动失败/崩溃时自动生成的诊断包（engine.log 脱敏副本 + 环境信息 + logcat），\n" +
+          "                           令牌已替换为 ***，反馈 issue 时直接整目录打包上传即可\n\n" +
           "改配置的正确途径：设置界面各项开关；或 导出配置 -> 文件管理器编辑 -> 导入配置；\n" +
           "进阶：设置 > 开发者选项 > 打开控制台（快照内 bash，可直接 vi settings.yaml）。\n",
       )
@@ -806,20 +807,22 @@ class EngineManager(private val context: Context, private val pickToken: String?
       val dir = File(File(dshDataDir, "diagnostics"), ts + "-" + reason)
       if (!dir.mkdirs() && !dir.isDirectory) return
       val log = File(context.filesDir, "engine.log")
+      // 0.13.8 #184：诊断包落共享存储（任何持 All Files Access 的应用可读），engine.log
+      // 内含引擎 launch token——副本先过 redact，本体不动（壳侧鉴权链 tokenFromLog 依赖）。
       for (f in arrayOf(log, File(log.parentFile, "engine.log.1"), File(log.parentFile, "engine.log.2"))) {
         try {
-          if (f.exists()) f.copyTo(File(dir, f.name), overwrite = true)
+          if (f.exists()) File(dir, f.name).writeText(EngineAuth.redact(f.readText()))
         } catch (_: Throwable) {
         }
       }
       try {
-        File(dir, "info.txt").writeText(buildDiagnosticsText(reason))
+        File(dir, "info.txt").writeText(EngineAuth.redact(buildDiagnosticsText(reason)))
       } catch (_: Throwable) {
       }
       try {
         val p = ProcessBuilder("logcat", "-d", "-v", "threadtime", "-t", "400").redirectErrorStream(true).start()
         val out = p.inputStream.readBytes()
-        if (out.isNotEmpty()) File(dir, "logcat-recent.txt").writeBytes(out)
+        if (out.isNotEmpty()) File(dir, "logcat-recent.txt").writeText(EngineAuth.redact(String(out)))
       } catch (_: Throwable) {
       }
       LogCollector.log(TAG, "diagnostics mirrored: " + dir.absolutePath)

--- a/app/src/main/java/com/dsharnessmobile/shell/GuidePageRenderer.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/GuidePageRenderer.kt
@@ -210,7 +210,8 @@ internal class GuidePageRenderer(private val activity: MainActivity) {
     refreshGuideMeta()
   }
 
-  /** engine.log 尾部摘要（测试界面诊断用；缺失/不可读返回空）。 */
+  /** engine.log 尾部摘要（测试界面诊断用；缺失/不可读返回空）。
+   *  展示出口脱敏（0.13.8 #184）：用户截图上报即外发，令牌行不得进入。 */
   private fun tailEngineLog(lines: Int): String {
     val f = File(activity.filesDir, "engine.log")
     if (!f.exists()) return ""
@@ -225,7 +226,7 @@ internal class GuidePageRenderer(private val activity: MainActivity) {
           if (tail.size == lines) tail.removeFirst()
           tail.addLast(line)
         }
-        tail.joinToString("\n")
+        EngineAuth.redact(tail.joinToString("\n"))
       }
     } catch (_: Exception) {
       ""

--- a/app/src/main/java/com/dsharnessmobile/shell/LogCollector.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/LogCollector.kt
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit
  * dsh-<date>.1.log; a new file starts on each new day. Process-level singleton, start/stop idempotent.
  *
  * Privacy: logs contain commands and model content, for troubleshooting only; no credential files are read.
+ * All sink writes pass EngineAuth.redact() (0.13.8 #184) — launch tokens never reach shared copies.
  */
 object LogCollector {
 
@@ -158,16 +159,19 @@ object LogCollector {
     }
   }
 
-  /** Daily rotation: dsh-<date>.log, rotating to dsh-<date>.1.log when over the size limit. */
+  /** Daily rotation: dsh-<date>.log, rotating to dsh-<date>.1.log when over the size limit.
+   *  出口脱敏（0.13.8 #184）：本函数是所有日志落盘（事件/logcat/engine.log 尾巴）的唯一
+   *  咽喉，写前过 EngineAuth.redact——engine.log 本体不动（鉴权链依赖），脱敏只作用于这份副本。 */
   private fun appendToDayFile(ctx: Context, text: String) {
     val day = SimpleDateFormat("yyyy-MM-dd", Locale.US).format(Date())
     val dir = currentDir(ctx)
+    val safe = EngineAuth.redact(text)
     val file = File(dir, "dsh-$day.log")
     if (file.exists() && file.length() > MAX_FILE_BYTES) {
       val rotated = File(dir, "dsh-$day.1.log")
       if (rotated.exists()) rotated.delete()
       file.renameTo(rotated)
     }
-    file.appendText(text)
+    file.appendText(safe)
   }
 }

--- a/app/src/main/java/com/dsharnessmobile/shell/MainActivity.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/MainActivity.kt
@@ -471,7 +471,8 @@ class MainActivity : ComponentActivity() {
             LogCollector.log("dsh-shell", "dev log enabled by user")
             showTestNotification(
               "开发者日志已开启",
-              "运行日志按天写入 " + LogCollector.currentDir(this).absolutePath,
+              "运行日志按天写入 " + LogCollector.currentDir(this).absolutePath +
+                "（共享存储，其他应用可读；启动令牌已自动脱敏，日志仍含命令与模型内容）",
             )
           } else {
             LogCollector.log("dsh-shell", "dev log disabled by user")

--- a/app/src/test/java/com/dsharnessmobile/shell/LogRedactionTest.kt
+++ b/app/src/test/java/com/dsharnessmobile/shell/LogRedactionTest.kt
@@ -1,0 +1,62 @@
+package com.dsharnessmobile.shell
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #184 回归：日志出口脱敏唯一入口 EngineAuth.redact（正则来源 = TOKEN_RE，与
+ * tokenFromLog 解析同源）。表驱动覆盖单令牌 / LAN 双令牌 / 无令牌 / 短令牌不误伤。
+ */
+class LogRedactionTest {
+
+  private val token = "ZPBs2spM1bfLo10cQwEOjV13FvNHBRE0fWd-hGKUG_U" // 43 字符，与产线同形态
+  private val line = "dsh web: http://127.0.0.1:3080/?token=$token"
+
+  @Test
+  fun redactsSingleTokenLine() {
+    val out = EngineAuth.redact("boot ok\n$line\ndone")
+    assertFalse("令牌不得残留", out.contains(token))
+    assertTrue("保留 URL 形状", out.contains("dsh web: ***?token=***"))
+    assertTrue("非令牌行不受影响", out.contains("boot ok") && out.contains("done"))
+  }
+
+  @Test
+  fun redactsBothTokensOnLanLine() {
+    // LAN 通告行含两个 token（本机 + 局域网地址，见 web-app.spec:146）
+    val lan = "dsh web: http://192.168.1.8:3080/?token=$token  dsh web: http://127.0.0.1:3080/?token=$token"
+    val out = EngineAuth.redact(lan)
+    assertEquals("双令牌全部替换", 0, out.split(token).size - 1)
+    assertEquals("两次替换", 2, out.split("***?token=***").size - 1)
+  }
+
+  @Test
+  fun keepsLinesWithoutTokens() {
+    val plain = "2026-09-12 00:00:00.000 dsh-shell: engine started\nexit code 0\n"
+    assertEquals(plain, EngineAuth.redact(plain))
+  }
+
+  @Test
+  fun doesNotTouchShortTokenLookalikes() {
+    // 不足 40 字符的 ?token= 不匹配产线正则——避免误伤其他 URL 参数
+    val short = "dsh web: http://127.0.0.1:3080/?token=abc123"
+    assertEquals(short, EngineAuth.redact(short))
+  }
+
+  @Test
+  fun regexIsSameSourceAsTokenParser() {
+    // 同一正则必须既能解析（tokenFromLog）又能脱敏——防止两份正则漂移
+    val m = EngineAuth.TOKEN_RE.find(line)
+    assertTrue(m != null)
+    assertEquals(token, m!!.groupValues[1])
+  }
+
+  @Test
+  fun emptyAndBinarySafe() {
+    assertEquals("", EngineAuth.redact(""))
+    val weird = "dsh web: /?token=" + "A".repeat(50) + "\u4e2d\u6587"
+    assertFalse(EngineAuth.redact(weird).contains("A".repeat(50)))
+    assertTrue(EngineAuth.redact(weird).contains("\u4e2d\u6587"))
+  }
+}

--- a/scripts/check-snapshot-secrets.mjs
+++ b/scripts/check-snapshot-secrets.mjs
@@ -49,7 +49,7 @@ const hasSettings = pathHits(/home\/\.dsh\/settings\.yaml/i)
 if (hasSettings.length) {
   let content = ''
   try { content = sh(`tar -xOf "${abs}" home/.dsh/settings.yaml 2>/dev/null`) } catch { /* 空 */ }
-  const leakRe = /(sk-|apiKey\s*:\s*\S|api[_-]?key\s*=\s*\S|BEGIN (RSA|OPENSSH|PRIVATE))/i
+  const leakRe = /(sk-|apiKey\s*:\s*\S|api[_-]?key\s*=\s*\S|BEGIN (RSA|OPENSSH|PRIVATE)|dsh web: \S*\/\?token=[A-Za-z0-9_-]{40,})/i
   const m = leakRe.exec(content)
   if (m) { console.error(`FAIL[settings-yaml-secret]: ${m[0]}`); fail = true }
 }

--- a/scripts/check-snapshot-secrets.ps1
+++ b/scripts/check-snapshot-secrets.ps1
@@ -22,7 +22,7 @@ Check 'anon-id' '.anonymous-user-id'
   $hasSettings = cmd /c ('tar -tJf "' + $SnapshotPath + '" 2>nul | findstr /i /c:"home/.dsh/settings.yaml"')
   if ($hasSettings) {
     $content = cmd /c ('tar -xOf "' + $SnapshotPath + '" "home/.dsh/settings.yaml" 2>nul')
-    $leak = $content | Select-String -Pattern 'sk-[A-Za-z0-9]{12}|apiKey\s*:\s*\S|api[_-]?key\s*=\s*\S|BEGIN (RSA|OPENSSH|PRIVATE)' | Select-Object -First 1
+    $leak = $content | Select-String -Pattern 'sk-[A-Za-z0-9]{12}|apiKey\s*:\s*\S|api[_-]?key\s*=\s*\S|BEGIN (RSA|OPENSSH|PRIVATE)|dsh web: \S*/\?token=[A-Za-z0-9_-]{40,}' | Select-Object -First 1
     if ($leak) {
       # 脱敏后再输出（疑似密钥不落构建日志/工单）：sk-xxx / key 值截断
       $sample = $leak.Line.Trim()


### PR DESCRIPTION
## 变更说明
apk #184（P1，条件 P0）——引擎 launch token 明文经共享存储外泄的两条路径封死，0.13.8 PR-B2：

- EngineAuth.redact()：唯一脱敏入口，正则与 tokenFromLog 解析同源（防两份正则漂移）
- LogCollector.appendToDayFile 单咽喉脱敏（事件/logcat/engine.log 尾巴全走这里）
- mirrorDiagnosticsToShared：engine.log 副本 + info.txt + logcat-recent 全写脱敏文本
- GuidePage tailEngineLog 展示前脱敏（用户截图上报即外发）
- README/设置页文案：明示共享存储、令牌已脱敏、仍含命令与模型内容
- check-snapshot-secrets（ps1 双仓 + mjs）增加 dsh web: ...?token= 形态扫描

硬约束保持：redact 只作用于副本/落盘/展示出口，filesDir/engine.log 本体绝不改写
（壳侧鉴权链 tokenFromLog 依赖该行）——模拟器实测确认本体令牌行完好。

## 关联 issue
Closes #184

## 测试
- [x] LogRedactionTest 6 例全绿（单令牌/LAN 双令牌/无令牌/短令牌不误伤/正则同源/空与多字节）
- [x] 模拟器实测：开启开发者日志 + 引擎冷重启后，共享日文件原始令牌 0 处、脱敏形态 2 处、engine.log 本体 1 处完好
- [x] 全套 :app:testDebugUnitTest 绿
- [ ] CI 通过

## 破坏性变更
无
