### PR TITLE
fix: B345 批（壳侧）——manifest 加固 + 键盘广播来源校验 + 快照所有权合并

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -103,4 +103,6 @@ dependencies {
   implementation("org.apache.commons:commons-compress:1.28.0")
   implementation("org.tukaani:xz:1.10")
   testImplementation("junit:junit:4.13.2")
+  // 本地单测用真实 org.json（android.jar 桩在 JVM 里抛 Stub!）——快照 profiles 合并（#167）测试需要
+  testImplementation("org.json:json:20240303")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,10 @@
     android:label="@string/app_name"
     android:icon="@mipmap/ic_launcher"
     android:theme="@style/Theme.Dsh"
-    android:usesCleartextTraffic="true">
+    android:allowBackup="false"
+    android:fullBackupContent="@xml/backup_rules"
+    android:dataExtractionRules="@xml/data_extraction_rules"
+    android:networkSecurityConfig="@xml/network_security_config">
 
     <service
       android:name=".EngineService"

--- a/app/src/main/java/com/dsharnessmobile/shell/AdbKeyboardReceiver.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/AdbKeyboardReceiver.kt
@@ -10,10 +10,22 @@ import android.content.Intent
  * 仅响应两个固定 action（ADB_INPUT_TEXT / ADB_CLEAR_TEXT），转发给活跃的
  * AdbKeyboardService 实例；服务未活跃（本 IME 未被选择）时静默忽略——
  * 注入面封闭：文本只会进入「用户已切到本输入法」的当前输入框。
+ *
+ * 0.13.8 #183 来源校验（导出组件默认视为不可信来源）：广播必须满足其一——
+ * ① API 34+ `sentFromUid ∈ {0(root), 2000(adb shell)}`（adb shell 不持有应用私钥，
+ *    不能读 nonce 文件，必须留 uid 白名单；其他应用 uid 恒被拒）；
+ * ② 携带有效 auth nonce（引擎子进程以应用 uid 运行、读得到私有 nonce 文件，
+ *    经 manage 插件 `--es auth` 随广播携带；常量时间比较）。
+ * 已知代价（如实记录）：API <34 上 adb shell 直发的广播（无 nonce）会被拒——
+ * 官方输入路径（引擎 android_ui_input）始终携带 nonce 不受影响。
  */
 class AdbKeyboardReceiver : BroadcastReceiver() {
   override fun onReceive(context: Context, intent: Intent) {
     if (intent.action != AdbKeyboardService.ACTION_INPUT_TEXT && intent.action != AdbKeyboardService.ACTION_CLEAR_TEXT) return
+    if (!AdbKeyboardService.isTrustedSender(context, intent)) {
+      android.util.Log.w("dsh-adb-kb", "broadcast rejected (untrusted sender, no uid match / auth nonce)")
+      return
+    }
     val msg = intent.getStringExtra(AdbKeyboardService.EXTRA_MSG)
     AdbKeyboardService.handle(intent.action ?: "", msg)
   }

--- a/app/src/main/java/com/dsharnessmobile/shell/AdbKeyboardService.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/AdbKeyboardService.kt
@@ -90,6 +90,7 @@ class AdbKeyboardService : InputMethodService() {
     const val ACTION_INPUT_TEXT = "ADB_INPUT_TEXT"
     const val ACTION_CLEAR_TEXT = "ADB_CLEAR_TEXT"
     const val EXTRA_MSG = "msg"
+    const val EXTRA_AUTH = "auth"
 
     /** 当前活跃服务实例（广播转发入口；绑定期间才非空）。 */
     @Volatile
@@ -115,5 +116,53 @@ class AdbKeyboardService : InputMethodService() {
       }
       return true
     }
+
+    /** 广播来源 nonce 文件（应用私有 filesDir 根；引擎经 DSH_FILES_DIR 读取后随广播回传）。 */
+    fun nonceFile(context: Context): java.io.File =
+      java.io.File(context.filesDir, NONCE_FILE_NAME)
+
+    /** 幂等创建 nonce（MainActivity.onCreate 与首次校验时调用；应用私有域，仅本 uid 可读）。 */
+    fun ensureNonce(context: Context): String {
+      val f = nonceFile(context)
+      if (f.exists()) {
+        f.readText().trim().takeIf { it.isNotEmpty() }?.let { return it }
+      }
+      val secret = java.math.BigInteger(256, java.security.SecureRandom()).toString(16)
+      f.parentFile?.mkdirs()
+      f.writeText(secret)
+      return secret
+    }
+
+    /**
+     * 来源校验（0.13.8 #183，详见 AdbKeyboardReceiver 类注释）：
+     * 34+ uid 白名单（root/adb shell）或有效 auth nonce（引擎路径）。
+     * `MessageDigest.isEqual` 常量时间比较，防逐字节试探。
+     */
+    fun isTrustedSender(context: Context, intent: Intent): Boolean {
+      if (android.os.Build.VERSION.SDK_INT >= 34) {
+        sentFromUid(intent)?.let { uid -> if (uid == 0 || uid == 2000) return true }
+      }
+      val given = intent.getStringExtra(EXTRA_AUTH) ?: return false
+      val secret = try {
+        nonceFile(context).takeIf { it.exists() }?.readText()?.trim()
+      } catch (_: Throwable) {
+        null
+      } ?: return false
+      return java.security.MessageDigest.isEqual(
+        given.toByteArray(Charsets.UTF_8), secret.toByteArray(Charsets.UTF_8),
+      )
+    }
+
+    /**
+     * API 34+ 的 Intent.getSentFromUid（反射调用——本机 SDK 平台 jar 实测缺该符号，
+     * 编译期不可见；运行时 34+ 设备必有该方法，缺失/异常一律返回 null 走 nonce 分支）。
+     */
+    private fun sentFromUid(intent: Intent): Int? = try {
+      Intent::class.java.getMethod("getSentFromUid").invoke(intent) as? Int
+    } catch (_: Throwable) {
+      null
+    }
+
+    private const val NONCE_FILE_NAME = "adb-keyboard-nonce"
   }
 }

--- a/app/src/main/java/com/dsharnessmobile/shell/EngineManager.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/EngineManager.kt
@@ -1052,6 +1052,8 @@ class EngineManager(private val context: Context, private val pickToken: String?
       // can't maintain the profiles/node_modules flat fallback); all runtime user data lives in private
       // files/home/.dsh, and public Documents/dshdata is only the export repo.
       "DSH_HOME" to ensurePrivateDshData().absolutePath,
+      // 0.13.8 #183：引擎子进程读取键盘广播 nonce 的路径基（manage 插件 --es auth 随广播携带）
+      "DSH_FILES_DIR" to context.filesDir.absolutePath,
       // os.tmpdir() falls back to the baked-in Termux tmp on Android
       // (unwritable from the app domain); keep spill inside filesDir.
       "TMPDIR" to File(homeDir, "tmp").apply { mkdirs() }.absolutePath,

--- a/app/src/main/java/com/dsharnessmobile/shell/MainActivity.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/MainActivity.kt
@@ -190,6 +190,10 @@ class MainActivity : ComponentActivity() {
     }
     ViewCompat.requestApplyInsets(root)
     configureWebView()
+    // 0.13.8 #183：键盘广播 nonce（应用私有文件，引擎子进程经 DSH_FILES_DIR 读取，
+    // manage 插件广播时 --es auth 携带；幂等）。
+    try { AdbKeyboardService.ensureNonce(this) } catch (_: Throwable) {
+    }
     // Testable update trigger: adb am start -n .../.MainActivity -a com.dsharnessmobile.shell.action.UPDATE
     if (intent?.action == ACTION_UPDATE) {
       engineFlow.runUpdate()

--- a/app/src/main/java/com/dsharnessmobile/shell/SnapshotTransaction.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/SnapshotTransaction.kt
@@ -2,6 +2,11 @@ package com.dsharnessmobile.shell
 
 import java.io.File
 import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.LinkOption.NOFOLLOW_LINKS
+import java.nio.file.StandardCopyOption.COPY_ATTRIBUTES
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+import java.nio.file.attribute.BasicFileAttributes
 
 /**
  * Durable transaction for replacing the embedded runtime.
@@ -149,6 +154,12 @@ internal object SnapshotTransaction {
               onEntry("保留用户数据 " + child.name)
               continue
             }
+            if (child.name == "profiles" && SnapshotFs.exists(liveChild)) {
+              // 0.13.8 #167：profiles 是「工厂面 + 用户面」混合容器——工厂条目
+              // 更新、用户条目（第三方依赖/.npmrc/自打补丁/追加块）保留。
+              mergeProfiles(filesDir, moved, fingerprint, startedAt, child, liveChild, File(previousDsh, "profiles"), onEntry)
+              continue
+            }
             replaceEntry(
               filesDir, moved, fingerprint, startedAt,
               "home/.dsh/" + child.name, child, liveChild, File(previousDsh, child.name), onEntry,
@@ -156,14 +167,178 @@ internal object SnapshotTransaction {
           }
           if ((previousDsh.listFiles() ?: emptyArray()).isEmpty()) SnapshotFs.deletePath(previousDsh)
         } else {
+          // 0.13.8 #179：home 顶层条目（.gitconfig 等）= 模板 + 用户覆盖混合体，
+          // 语义是 seed-if-absent——live 已存在即用户数据，永不整树替换
+          // （白名单机制只作用于 .dsh 子项，对本分支无效，见坑 67 之前的取证）。
+          val liveEntry = File(homeDir, entry.name)
+          if (SnapshotFs.exists(liveEntry)) {
+            onEntry("保留用户数据 home/" + entry.name)
+            continue
+          }
           replaceEntry(
             filesDir, moved, fingerprint, startedAt,
-            "home/" + entry.name, entry, File(homeDir, entry.name), File(previous, "home/" + entry.name), onEntry,
+            "home/" + entry.name, entry, liveEntry, File(previous, "home/" + entry.name), onEntry,
           )
         }
       }
     }
     writeMarker(filesDir, Marker(Phase.SWAPPED, fingerprint, startedAt, moved))
+  }
+
+  /**
+   * 0.13.8 #167：`profiles` 分区合并（原「整树替换」会静默抹掉用户插件生态：
+   * 第三方依赖、.npmrc、pnpm-lock、自打引擎补丁、bundles 追加项全部丢失）。
+   *
+   * 规则（对 staged 树递归）：
+   * - **staged 没有的条目一律不动**（live-only 的用户内容天然幸存，覆盖
+   *   `.npmrc`/`pnpm-lock.yaml` 这类「工厂不发行」实证场景）；
+   * - `package.json`：dependencies 与 dsh.profile.bundles 取**并集**，同名冲突保留用户 pin；
+   * - `cordis.patch.yml`：按 id 合并——live 内容为基，追加 live 缺失的工厂块；
+   * - 其余双存条目：工厂权威（staged 覆盖）。
+   *
+   * 原子性：合并失去 rename 的事务性，因此先把 live profiles **整目录拷贝**（非
+   * rename）到 previous，条目照常入 journal——失败/中断时 rollbackEntry 按既有
+   * 「displaced 存在即恢复」语义整目录回滚。
+   */
+  private fun mergeProfiles(
+    filesDir: File,
+    moved: MutableList<String>,
+    fingerprint: String,
+    startedAt: Long,
+    stagedProfiles: File,
+    liveProfiles: File,
+    previousProfiles: File,
+    onEntry: (String) -> Unit,
+  ) {
+    // Journal + 整目录拷贝备份（拷贝失败即中止刷新——宁可不起树也不丢用户生态）
+    moved += "home/.dsh/profiles"
+    writeMarker(filesDir, Marker(Phase.SWAPPING, fingerprint, startedAt, moved.toList()))
+    SnapshotFs.deletePath(previousProfiles)
+    SnapshotFs.createDirectories(previousProfiles.parentFile ?: filesDir)
+    copyRecursivelyStrict(liveProfiles, previousProfiles)
+    try {
+      mergeTree(stagedProfiles, liveProfiles)
+      onEntry("home/.dsh/profiles (merged)")
+    } catch (t: Throwable) {
+      // 合并失败：整目录回滚到 live 原状，再把异常抛给调用方（中止启动，正常 recover）
+      SnapshotFs.deletePath(liveProfiles)
+      SnapshotFs.move(previousProfiles, liveProfiles)
+      throw t
+    }
+  }
+
+  /** 深拷贝（不跟随 symlink；目标已存在内容以源为准）。失败即抛，由调用方回滚。 */
+  private fun copyRecursivelyStrict(source: File, destination: File) {
+    val attrs = Files.readAttributes(
+      source.toPath(), BasicFileAttributes::class.java, NOFOLLOW_LINKS,
+    )
+    if (attrs.isSymbolicLink) return // 链接属运行时残渣，与 replaceEntry 的 NOFOLLOW 语义一致：不复制
+    if (attrs.isDirectory) {
+      SnapshotFs.createDirectories(destination)
+      for (child in source.listFiles() ?: emptyArray()) copyRecursivelyStrict(child, File(destination, child.name))
+    } else if (attrs.isRegularFile) {
+      Files.copy(
+        source.toPath(), destination.toPath(),
+        REPLACE_EXISTING, COPY_ATTRIBUTES,
+      )
+    }
+  }
+
+  /** 递归合并：staged 权威 + package.json/cordis.patch.yml 特殊合并 + live-only 不动。 */
+  private fun mergeTree(staged: File, live: File) {
+    val attrs = Files.readAttributes(
+      staged.toPath(), BasicFileAttributes::class.java, NOFOLLOW_LINKS,
+    )
+    when {
+      attrs.isSymbolicLink -> return
+      attrs.isDirectory -> {
+        SnapshotFs.createDirectories(live)
+        for (child in staged.listFiles() ?: emptyArray()) mergeTree(child, File(live, child.name))
+      }
+      attrs.isRegularFile -> when (staged.name) {
+        "package.json" -> mergePackageJson(staged, live)
+        "cordis.patch.yml" -> mergePatchYamlById(staged, live)
+        else -> Files.copy(
+          staged.toPath(), live.toPath(),
+          REPLACE_EXISTING, COPY_ATTRIBUTES,
+        )
+      }
+    }
+  }
+
+  /**
+   * package.json 并集：live 为基座（用户 pin 权威），工厂新增的 dependencies 键与
+   * dsh.profile.bundles 条目补入；同名冲突保留 live。JSON 解析失败按原样保留 live（宁缺毋滥）。
+   */
+  private fun mergePackageJson(staged: File, live: File) {
+    val liveText = if (SnapshotFs.exists(live)) live.readText() else ""
+    val stagedText = try { staged.readText() } catch (_: Throwable) { return }
+    if (liveText.isBlank()) {
+      // live 缺失（部分新装）：直接落工厂件
+      Files.copy(
+        staged.toPath(), live.toPath(),
+        REPLACE_EXISTING, COPY_ATTRIBUTES,
+      )
+      return
+    }
+    val user = try { org.json.JSONObject(liveText) } catch (_: Throwable) { return }
+    val factory = try { org.json.JSONObject(stagedText) } catch (_: Throwable) { return }
+    val factoryDeps = factory.optJSONObject("dependencies") ?: org.json.JSONObject()
+    if (factoryDeps.length() > 0) {
+      val deps = user.optJSONObject("dependencies") ?: org.json.JSONObject().also { user.put("dependencies", it) }
+      for (key in factoryDeps.keys()) if (!deps.has(key)) deps.put(key, factoryDeps.getString(key))
+    }
+    val factoryBundles = factory.optJSONArray("dsh.profile.bundles")
+    if (factoryBundles != null && factoryBundles.length() > 0) {
+      val bundles = user.optJSONArray("dsh.profile.bundles") ?: org.json.JSONArray().also { user.put("dsh.profile.bundles", it) }
+      val present = (0 until bundles.length()).map { bundles.optString(it) }.toHashSet()
+      for (i in 0 until factoryBundles.length()) {
+        val item = factoryBundles.optString(i)
+        if (item.isNotEmpty() && item !in present) bundles.put(item)
+      }
+    }
+    live.writeText(user.toString(2))
+  }
+
+  /**
+   * cordis.patch.yml 按 id 合并：live 内容为基座（用户追加块与改写权威），把 live
+   * 缺少 id 的工厂**顶层块**（连同其前导注释）追加到末尾。文本层实现（壳侧无 YAML 依赖）；
+   * 工厂块解析失败时保守跳过该块，绝不破坏 live 内容。
+   */
+  private fun mergePatchYamlById(staged: File, live: File) {
+    val liveText = if (SnapshotFs.exists(live)) live.readText() else ""
+    val stagedText = try { staged.readText() } catch (_: Throwable) { return }
+    val liveIds = Regex("""^\s*(?:-\s+)?id:\s*(\S+)""", RegexOption.MULTILINE)
+      .findAll(liveText).mapTo(HashSet()) { it.groupValues[1] }
+    if (liveIds.isEmpty() && liveText.isNotBlank()) return // live 结构未知：不追加，保守保 live
+    val appended = StringBuilder()
+    for (block in topLevelYamlBlocks(stagedText)) {
+      val blockIds = Regex("""^\s*(?:-\s+)?id:\s*(\S+)""", RegexOption.MULTILINE)
+        .findAll(block).map { it.groupValues[1] }.toList()
+      if (blockIds.isEmpty()) continue
+      if (blockIds.any { it in liveIds }) continue
+      appended.append(block).append('\n')
+    }
+    if (appended.isNotEmpty()) {
+      val separator = if (liveText.endsWith("\n") || liveText.isEmpty()) "" else "\n"
+      live.writeText(liveText + separator + appended)
+    }
+  }
+
+  /** 顶层 `- ` 列表块切分（含块前紧邻的注释/空行前导）；非列表行归入下一个块的前导。 */
+  private fun topLevelYamlBlocks(text: String): List<String> {
+    val blocks = mutableListOf<String>()
+    val current = StringBuilder()
+    for (line in text.lineSequence()) {
+      val isTopItem = Regex("^- ").containsMatchIn(line)
+      if (isTopItem) {
+        if (current.isNotBlank()) blocks.add(current.toString())
+        current.setLength(0)
+      }
+      current.append(line).append('\n')
+    }
+    if (current.isNotBlank()) blocks.add(current.toString())
+    return blocks
   }
 
   /**

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 0.13.8 #183：Auto Backup（API <=30）排除面。allowBackup=false 为主，本文件为
+     「将来有人改回 true」时的兜底：凭据/会话/工作区/引擎鉴权 prefs 永不进云备份。 -->
+<full-backup-content>
+  <exclude domain="file" path="home/.dsh/.credentials.yaml" />
+  <exclude domain="file" path="home/.dsh/sessions/" />
+  <exclude domain="file" path="home/.dsh/storages/" />
+  <exclude domain="file" path="home/.dsh/attachments/" />
+  <exclude domain="file" path="home/.dsh/workspaces/" />
+  <exclude domain="file" path="home/.dsh/undo-snapshots/" />
+  <exclude domain="file" path="home/.dsh/models-store.json" />
+  <exclude domain="file" path="deepseek-key.txt" />
+  <exclude domain="file" path="dashscope-key.txt" />
+  <exclude domain="sharedpref" path="dsh_engine_auth.xml" />
+  <exclude domain="sharedpref" path="dsh-adb.xml" />
+</full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 0.13.8 #183：云备份与设备迁移（API 31+）排除面——与 backup_rules.xml 同语义的
+     新规则载体；allowBackup=false 下不生效，作纵深兜底。 -->
+<data-extraction-rules>
+  <cloud-backup>
+    <exclude domain="file" path="home/.dsh/.credentials.yaml" />
+    <exclude domain="file" path="home/.dsh/sessions/" />
+    <exclude domain="file" path="home/.dsh/storages/" />
+    <exclude domain="file" path="home/.dsh/attachments/" />
+    <exclude domain="file" path="home/.dsh/workspaces/" />
+    <exclude domain="file" path="home/.dsh/undo-snapshots/" />
+    <exclude domain="file" path="home/.dsh/models-store.json" />
+    <exclude domain="file" path="deepseek-key.txt" />
+    <exclude domain="file" path="dashscope-key.txt" />
+    <exclude domain="sharedpref" path="dsh_engine_auth.xml" />
+    <exclude domain="sharedpref" path="dsh-adb.xml" />
+  </cloud-backup>
+  <device-transfer>
+    <exclude domain="file" path="home/.dsh/.credentials.yaml" />
+    <exclude domain="file" path="home/.dsh/sessions/" />
+    <exclude domain="file" path="home/.dsh/storages/" />
+    <exclude domain="file" path="home/.dsh/attachments/" />
+    <exclude domain="file" path="home/.dsh/workspaces/" />
+    <exclude domain="file" path="home/.dsh/undo-snapshots/" />
+    <exclude domain="file" path="home/.dsh/models-store.json" />
+    <exclude domain="file" path="deepseek-key.txt" />
+    <exclude domain="file" path="dashscope-key.txt" />
+    <exclude domain="sharedpref" path="dsh_engine_auth.xml" />
+    <exclude domain="sharedpref" path="dsh-adb.xml" />
+  </device-transfer>
+</data-extraction-rules>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 0.13.8 #183：壳侧 HTTP 明文收敛——默认禁明文；仅本机引擎回环与模拟器开发端点放行。
+     引擎是独立 node 子进程，不受 NSC 约束（只保护壳侧 Kotlin/WebView 流量）。
+     注：APK 自更新（0.13.8 H1）走 HTTPS，属 base-config 默认允许面。 -->
+<network-security-config>
+  <base-config cleartextTrafficPermitted="false" />
+  <domain-config cleartextTrafficPermitted="true">
+    <domain includeSubdomains="false">127.0.0.1</domain>
+    <domain includeSubdomains="false">localhost</domain>
+    <domain includeSubdomains="false">10.0.2.2</domain>
+  </domain-config>
+</network-security-config>

--- a/app/src/test/java/com/dsharnessmobile/shell/SnapshotTransactionTest.kt
+++ b/app/src/test/java/com/dsharnessmobile/shell/SnapshotTransactionTest.kt
@@ -52,6 +52,89 @@ class SnapshotTransactionTest {
     }
   }
 
+  /**
+   * 0.13.8 #167：profiles 分区合并——用户插件生态幸存 + 工厂条目更新，两者同时成立。
+   * （live 与 staged 的 .gitconfig / profiles 内容必须不同，否则断言恒真即假绿。）
+   */
+  @Test
+  fun mergesUserProfilesAndKeepsUserGitconfig() {
+    val filesDir = tempDir()
+    try {
+      val live = File(filesDir, "live").apply { mkdirs() }
+      val stage = SnapshotTransaction.stageRoot(filesDir)
+      writeRuntime(live, "old-node", "old-profile")
+      writeRuntime(stage, "new-node", "new-profile")
+      // 工厂侧 package.json（0.13.8 #167 合并输入）：含一条工厂依赖与工厂 bundles
+      File(stage, "home/.dsh/profiles/web/package.json").writeText(
+        """{"dependencies":{"@dsh-android/dsh-shell-termux":"0.1.0","@dsh-android/dsh-host-web-compat":"0.1.13"},"dsh.profile.bundles":["@dsh-android/dsh-shell-termux"]}""",
+      )
+
+      // 用户生态：第三方依赖 + 用户 pin + 用户 patch 追加块 + .npmrc + 工厂不发行文件
+      File(live, "home/.dsh/profiles/web/package.json").writeText(
+        """{"dependencies":{"@dsh-android/dsh-shell-termux":"0.1.0","@user/third-party":"1.2.3"},"dsh.profile.bundles":["@user/custom-bundle"]}""",
+      )
+      File(live, "home/.dsh/profiles/web/cordis.patch.yml").writeText(
+        "- id: bash-sandbox\n  disabled: true\n- insert:\n    - id: user-custom\n      name: '@user/plugin'\n",
+      )
+      File(live, "home/.dsh/profiles/web/.npmrc").writeText("registry=https://registry.npmmirror.com\n")
+      File(live, "home/.dsh/profiles/web/node_modules/@user").mkdirs()
+      File(live, "home/.dsh/profiles/web/node_modules/@user/plugin.js").writeText("user plugin\n")
+      // 用户改过的 .gitconfig（工厂模板 = [user]，live = 模板 + 用户名）
+      File(live, "home/.gitconfig").writeText("[user]\n\tname = 用户名\n")
+
+      SnapshotTransaction.swap(
+        filesDir, stage, File(live, "usr"), File(live, "home"), preserved, "fp1", 1L,
+      )
+
+      val pkg = File(live, "home/.dsh/profiles/web/package.json").readText()
+      assertTrue("第三方依赖幸存", pkg.contains("@user/third-party"))
+      assertTrue("工厂依赖补入（合并不是保留）", pkg.contains("@dsh-android/dsh-host-web-compat"))
+      assertTrue("用户 bundles 幸存", pkg.contains("@user/custom-bundle"))
+      val patch = File(live, "home/.dsh/profiles/web/cordis.patch.yml").readText()
+      assertTrue("用户追加块幸存", patch.contains("id: user-custom"))
+      assertTrue("工厂已有条目不被重复追加", Regex("id: bash-sandbox").findAll(patch).count() == 1)
+      assertEquals(".npmrc 幸存", "registry=https://registry.npmmirror.com\n", File(live, "home/.dsh/profiles/web/.npmrc").readText())
+      assertEquals(
+        "用户 node_modules 幸存", "user plugin\n",
+        File(live, "home/.dsh/profiles/web/node_modules/@user/plugin.js").readText(),
+      )
+      assertTrue(
+        "工厂 cordis.yml 更新（混合容器内工厂条目仍升级）",
+        File(live, "home/.dsh/profiles/web/cordis.yml").readText() == "new-profile",
+      )
+      assertTrue("用户 .gitconfig 幸存（#179 seed-if-absent）", File(live, "home/.gitconfig").readText().contains("用户名"))
+      assertTrue("工厂 .gitconfig 的新增语义仍保留", File(live, "home/.gitconfig").readText().contains("[user]"))
+      SnapshotTransaction.finish(filesDir)
+    } finally {
+      SnapshotFs.deletePath(filesDir)
+    }
+  }
+
+  /** #167 回滚：合并中断（marker SWAPPING + previous 有备份）→ live profiles 整目录还原。 */
+  @Test
+  fun rollsBackAMergedProfilesDirectoryFromTheDisplacedCopy() {
+    val filesDir = tempDir()
+    try {
+      val live = File(filesDir, "live").apply { mkdirs() }
+      writeRuntime(live, "old-node", "old-profile")
+      val stage = SnapshotTransaction.stageRoot(filesDir)
+      SnapshotFs.createDirectories(stage)
+      val previous = SnapshotTransaction.previousRoot(filesDir)
+      writeRuntime(previous, "old-node", "old-profile") // displaced 整目录备份形态
+      SnapshotTransaction.writeMarker(
+        filesDir,
+        SnapshotTransaction.Marker(SnapshotTransaction.Phase.SWAPPING, "fp1", 1L, listOf("home/.dsh/profiles")),
+      )
+
+      val recovery = SnapshotTransaction.recover(filesDir, stage, File(live, "usr"), File(live, "home"), "old-fp")
+
+      assertEquals(SnapshotTransaction.Outcome.ROLLED_BACK, recovery.outcome)
+      assertEquals("old-profile", File(live, "home/.dsh/profiles/web/cordis.yml").readText())
+    } finally {
+      SnapshotFs.deletePath(filesDir)
+    }
+  }
+
   @Test
   fun installsFactoryEntryWhenTheLiveCopyDoesNotExist() {
     val filesDir = tempDir()

--- a/docs/AGENTS/BRIDGE-API.md
+++ b/docs/AGENTS/BRIDGE-API.md
@@ -139,7 +139,8 @@ cd ..\plugins\dsh-android-<pkg> && npm run build
 | 引擎 → 插件 | cordis 服务面 | androidPrivilege（状态机/execAdbShell/execAdbLine/gateFor 会话级 danger）；dsh-shell-termux 执行器 |
 | 插件 → 页面 | dsh.client 模块 + slots | ui-responsive（AppFrame/DevSection/settings.dev.item/F5 消费端轮询）；bridge client（AdbAuthSection 双端口配对 UI）；undo/marketplace 注册 |
 
-**授权模型（定稿）**：引擎级 = 门1 All Files Access（**live prefs 键 `fullAccess`，壳 syncFullAccess 写入；env DSH_ADB_FULLACCESS 仅兜底**——0.13.0 Q8 不再重启生效）+ 门2 允许开关（live prefs）+ 门3 真实配对（adb pair 握手）；会话级 = `gateFor(exec.agent.session)` 实时 resolve，**ADB 能力（含观察类）仅 danger-full-access**，自动审批不参与；写面唯一在壳侧原生 AdbState（桥/引擎只读 live `dsh-adb.xml`）。
+**授权模型（定稿）**：引擎级 = 门1 All Files Access（**live prefs 键 `fullAccess`，壳 syncFullAccess 写入；env DSH_ADB_FULLACCESS 仅兜底**——0.13.0 Q8 不再重启生效）+ 门2 允许开关（live prefs）+ 门3 真实配对（adb pair 握手）；会话级 = `gateFor(exec.agent.session)` 实时 resolve，**ADB 能力（含观察类）仅 danger-full-access**，自动审批不参与；写面唯一在壳侧原生 AdbState（桥/引擎只读 live `dsh-adb.xml`）。0.13.8 #172：部署默认写面档位（tier）**只是视图字段，不参与任何能力门**——ADB 能力门 = 引擎级三道门 + 会话档位实时 resolve（出厂 workspace-write 默认不再钉死 ADB 通道，坑 29 定例）。
+
 
 ---
 

--- a/docs/AGENTS/gotchas.md
+++ b/docs/AGENTS/gotchas.md
@@ -133,3 +133,12 @@
     先行、去首尾点）；② copyIn 落点走 safeTarget canonical 归属断言（写前+写后，双侧
     canonical 化——Android 把 `/data/user/0` 解析为 `/data/data`，只做一侧会永远拒绝），fail-closed。
     铁律：凡「外部字符串 → 落盘路径」一律过 safeTarget 同型守门，新增出口先查本坑。
+
+68. **部署默认写面档位不是能力门（#172 实锤，0.13.8 修复）**：`dsh-android-bridge` 的
+    `gateFor/gateFacts/controlDecision` 三处曾叠 `&& st.tier !== 'T0'`——出厂装配
+    `writeMode: workspace-write`（profile-web.cordis.patch.yml:23）使 `tier` 恒 T0，
+    ADB 通道**恒判未就绪**（`android_adb_shell_exec` 永不返回 via:'adb'），且设置页显示
+    「未授权（T0）」——坑 29「勿把部署默认当死锁」的活体复刻。修复 = 三处删 tier 条件，
+    能力门 = 引擎级三道门 + 会话档位实时 resolve；`tier` 降级为部署视图字段
+    （AdbAuthSection 的「已授权」改按三道门，linux-env 的 adbTier 文案标注「档位视图」）。
+    铁律：门禁判定只允许「设备全局事实 + 会话实时档位」，任何部署常量进判定即缺陷。

--- a/docs/AGENTS/modules.md
+++ b/docs/AGENTS/modules.md
@@ -45,7 +45,8 @@
 | 引擎 → 插件 | cordis 服务面 | androidPrivilege（状态机/execAdbShell/execAdbLine/gateFor 会话级 danger）；dsh-shell-termux 执行器 |
 | 插件 → 页面 | dsh.client 模块 + slots | ui-responsive（AppFrame/DevSection/settings.dev.item/F5 消费端轮询）；bridge client（AdbAuthSection 双端口配对 UI）；undo/marketplace 注册 |
 
-**授权模型（定稿）**：引擎级 = 门1 All Files Access（**live prefs 键 `fullAccess`，壳 syncFullAccess 写入；env DSH_ADB_FULLACCESS 仅兜底**——0.13.0 Q8 不再重启生效）+ 门2 允许开关（live prefs）+ 门3 真实配对（adb pair 握手）；会话级 = `gateFor(exec.agent.session)` 实时 resolve，**ADB 能力（含观察类）仅 danger-full-access**，自动审批不参与；写面唯一在壳侧原生 AdbState（桥/引擎只读 live `dsh-adb.xml`）。
+**授权模型（定稿）**：引擎级 = 门1 All Files Access（**live prefs 键 `fullAccess`，壳 syncFullAccess 写入；env DSH_ADB_FULLACCESS 仅兜底**——0.13.0 Q8 不再重启生效）+ 门2 允许开关（live prefs）+ 门3 真实配对（adb pair 握手）；会话级 = `gateFor(exec.agent.session)` 实时 resolve，**ADB 能力（含观察类）仅 danger-full-access**，自动审批不参与；写面唯一在壳侧原生 AdbState（桥/引擎只读 live `dsh-adb.xml`）。0.13.8 #172：部署默认写面档位（tier）**只是视图字段，不参与任何能力门**——ADB 能力门 = 引擎级三道门 + 会话档位实时 resolve（出厂 workspace-write 默认不再钉死 ADB 通道，坑 29 定例）。
+
 
 ## 6. 关键实现细节与坑（每次踩坑必须登记）
 

--- a/plugins/dsh-android-bridge/package.json
+++ b/plugins/dsh-android-bridge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dsh-android/dsh-android-bridge",
   "description": "Android privilege bridge: ADB authorization state machine, fail-closed execution, audit — the only controlled privilege-extension channel (PRD F1.7)",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "main": "lib/index.js",
   "exports": {

--- a/plugins/dsh-android-bridge/src/client/AdbAuthSection.tsx
+++ b/plugins/dsh-android-bridge/src/client/AdbAuthSection.tsx
@@ -377,7 +377,10 @@ export function AdbAuthSection(_props: AdbAuthSectionProps) {
     [cancelConfirm],
   )
 
-  const granted = status?.tier?.startsWith('T1') === true
+  // 0.13.8 #172：通道就绪 = 引擎级三道门（完全访问 + 允许开关 + 配对/无线调试）——
+  // 部署默认写面档位（tier）只是视图字段，不再决定「已授权」展示。
+  const granted = status?.fullAccess === true && status?.allowSwitchOn === true &&
+    status?.paired === true && status?.wirelessDebugOn === true
   const confirmText = confirm !== null ? CONFIRM_ALLOW_TEXT[confirm] : null
 
   return (
@@ -428,7 +431,7 @@ export function AdbAuthSection(_props: AdbAuthSectionProps) {
       </p>
 
       <div className={granted ? 'adb-auth-tier adb-auth-tier-ok' : 'adb-auth-tier adb-auth-tier-bad'}>
-        <span>{granted ? '已授权（T1）' : '未授权（T0）'}</span>
+        <span>{granted ? 'ADB 通道就绪（引擎级三道门已齐）' : 'ADB 通道未就绪（引擎级三道门未齐）'}</span>
         {status?.message ? <span className="adb-auth-tier-sub">{status.message}</span> : <span className="adb-auth-tier-sub">通道可用</span>}
       </div>
 

--- a/plugins/dsh-android-bridge/src/index.ts
+++ b/plugins/dsh-android-bridge/src/index.ts
@@ -336,7 +336,9 @@ export class AndroidPrivilegeService {
   gateFor(session?: unknown): { ok: true; via?: 'a11y' | 'adb' } | { ok: false; guidance: string; gates?: ControlGateFacts } {
     const st = this.status()
     const a11y = this.a11yEnabled()
-    const adbReady = engineLevelReady(st) && st.tier !== 'T0'
+    // 0.13.8 #172：能力门只由「引擎级三道门 + 会话档位实时门」决定——部署默认写面
+    // 档位（tier）降级为视图字段，不再参与门禁（坑 29：勿把部署默认当死锁）。
+    const adbReady = engineLevelReady(st)
     const gates: ControlGateFacts = {
       a11yEnabled: a11y,
       fullAccess: st.fullAccess === true,
@@ -372,9 +374,7 @@ export class AndroidPrivilegeService {
     if (!engineLevelReady(st)) {
       return { ok: false, guidance: st.message ?? '未授权' }
     }
-    if (st.tier === 'T0') {
-      return { ok: false, guidance: st.message ?? '未授权' }
-    }
+    // 0.13.8 #172：tier（部署默认档位视图）不再作为拒绝条件——会话档位由各 execute 实时门禁。
     return { ok: true, tier: st.tier }
   }
 
@@ -400,7 +400,8 @@ export class AndroidPrivilegeService {
   /** 0.13.5 W4：结构化授权事实（两条通道各自的门）。 */
   gateFacts(): ControlGateFacts {
     const st = this.status()
-    const adbReady = engineLevelReady(st) && st.tier !== 'T0'
+    // 0.13.8 #172：同 gateFor——部署档位视图不参与能力门。
+    const adbReady = engineLevelReady(st)
     return {
       a11yEnabled: this.a11yEnabled(),
       fullAccess: st.fullAccess === true,
@@ -418,7 +419,7 @@ export class AndroidPrivilegeService {
     return decideControl({
       op,
       a11yEnabled: this.a11yEnabled(),
-      adbReady: engineLevelReady(st) && st.tier !== 'T0',
+      adbReady: engineLevelReady(st), // 0.13.8 #172：部署档位视图不参与能力门
       sessionMode: mode,
       forceBackend,
     })
@@ -865,6 +866,9 @@ export function apply(ctx: Context, config: Record<string, unknown> = {}) {
       handler: async (_req: WsReq, res: WsRes) => {
         sendJson(res, 200, {
           ...svc.status(),
+          // 0.13.8 #172：结构化通道事实（两通道各自的门）——展示面与诊断共用，
+          // adbReady 只看引擎级三道门（部署档位视图不参与，坑 29）。
+          gates: svc.gateFacts() as unknown as Record<string, JsonValue>,
           // 0.13.5 W4：控制通道事实（只读；令牌本身绝不回显）
           control: {
             a11yEnabled: svc.a11yEnabled(),

--- a/plugins/dsh-android-linux-env/package.json
+++ b/plugins/dsh-android-linux-env/package.json
@@ -1,14 +1,16 @@
 {
   "name": "@dsh-android/dsh-android-linux-env",
   "description": "Toolchain & environment pane: shared dirs, env vars, toolchain status/reset, software mirror and the exportable environment recipe (PRD F1.3/F1.0)",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "lib/index.js",
   "exports": {
     ".": "./lib/index.js",
     "./package.json": "./package.json"
   },
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/plugins/dsh-android-linux-env/src/index.ts
+++ b/plugins/dsh-android-linux-env/src/index.ts
@@ -110,7 +110,8 @@ function tools(svc: { status(): { tier: string } } | undefined) {
         },
       },
       render: (_args, v: Record<string, unknown>) => [
-        { type: 'text', text: `工具链 ${String(v.prefix)}：dpkg ${String(v.dpkgPackages)} 包 / ADB ${String(v.adbTier)}\n` + JSON.stringify(v.tools ?? {}) },
+        // 0.13.8 #172：adbTier 是部署默认档位视图（非通道能力门）——文案如实标注，防模型误读为未授权
+        { type: 'text', text: `工具链 ${String(v.prefix)}：dpkg ${String(v.dpkgPackages)} 包 / ADB 档位视图 ${String(v.adbTier)}（部署默认，非通道门；通道就绪以 android_privilege_status 为准）\n` + JSON.stringify(v.tools ?? {}) },
       ],
     },
     execute: async () => toolchainStatus(svc?.status().tier) as never,

--- a/plugins/dsh-android-manage/package.json
+++ b/plugins/dsh-android-manage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dsh-android/dsh-android-manage",
   "description": "Android phone management tools (ADB-first observe/act/wait loop, PRD F1.6): screenshot, UI tree, app/device info — all fail-closed on the privilege bridge",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "main": "lib/index.js",
   "exports": {

--- a/plugins/dsh-android-manage/src/index.ts
+++ b/plugins/dsh-android-manage/src/index.ts
@@ -27,6 +27,22 @@ import { join } from 'node:path'
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync } from 'node:fs'
 import { parseUiTreeXml, pruneNodes, resolveRef, findActionableAncestor, type UiNode } from './ui-tree.js'
 
+/**
+ * 0.13.8 #183：键盘广播来源校验 nonce 参数（壳侧 AdbKeyboardReceiver 私有文件，
+ * 引擎与壳同 uid 可读）。文件缺失（旧壳 / 桌面宿主）返回空串 = 不带 auth 参数，
+ * 由壳侧 34+ sentFromUid 白名单兜底；桌面宿主无广播路径不受影响。
+ */
+function adbKeyboardAuthArg(): string {
+  const base = process.env.DSH_FILES_DIR
+  if (!base) return ''
+  try {
+    const nonce = readFileSync(join(base, 'adb-keyboard-nonce'), 'utf8').trim()
+    return nonce ? ` --es auth '${nonce}'` : ''
+  } catch {
+    return ''
+  }
+}
+
 export const name = 'dsh-android-manage'
 // androidPrivilege 由 dsh-android-bridge 在 apply 时经 ctx.provide 注册；
 // cordis 代理对未 inject 的非注册属性读取会抛错（"cannot get property without inject"），
@@ -1109,9 +1125,12 @@ function tools(ctx: Context, priv: PrivilegeFace) {
         await priv.execAdbShell(`ime enable ${IME_ID}`).catch(() => undefined)
         const needSwitch = prev.length > 0 && prev !== IME_ID
         if (needSwitch) await priv.execAdbShell(`ime set ${IME_ID}`).catch(() => undefined)
+        // 0.13.8 #183：键盘广播来源校验 nonce——壳侧私有文件（DSH_FILES_DIR），引擎与壳
+        // 同 uid 可读，随广播 --es auth 携带；API 34+ 壳侧另有 sentFromUid 白名单兜底。
+        const authArg = adbKeyboardAuthArg()
         const parts: string[] = []
-        if (clear) parts.push(`am broadcast -a ADB_CLEAR_TEXT`)
-        if (raw) parts.push(`am broadcast -a ADB_INPUT_TEXT --es msg '${raw.replace(/'/g, `'\\''`)}'`)
+        if (clear) parts.push(`am broadcast -a ADB_CLEAR_TEXT${authArg}`)
+        if (raw) parts.push(`am broadcast -a ADB_INPUT_TEXT${authArg} --es msg '${raw.replace(/'/g, `'\\''`)}'`)
         let r: { ok: boolean; stdout: string; guidance?: string } = { ok: true, stdout: '' }
         for (const p of parts) {
           r = await priv.execAdbShell(p)
@@ -1130,8 +1149,8 @@ function tools(ctx: Context, priv: PrivilegeFace) {
           await new Promise((resolve) => setTimeout(resolve, 260))
           readBack = await read()
           if (readBack !== null && readBack !== raw) {
-            await priv.execAdbShell(`am broadcast -a ADB_CLEAR_TEXT`).catch(() => undefined)
-            await priv.execAdbShell(`am broadcast -a ADB_INPUT_TEXT --es msg '${raw.replace(/'/g, `'\\''`)}'`).catch(() => undefined)
+            await priv.execAdbShell(`am broadcast -a ADB_CLEAR_TEXT${authArg}`).catch(() => undefined)
+            await priv.execAdbShell(`am broadcast -a ADB_INPUT_TEXT${authArg} --es msg '${raw.replace(/'/g, `'\\''`)}'`).catch(() => undefined)
             await new Promise((resolve) => setTimeout(resolve, 320))
             readBack = await read()
           }

--- a/scripts/build-apk-013.ps1
+++ b/scripts/build-apk-013.ps1
@@ -28,6 +28,11 @@ Write-Host "== 补丁镜像一致性门禁 =="
 node (Join-Path $Root "scripts\check-patch-mirror.mjs") 2>&1
 if ($LASTEXITCODE -ne 0) { Write-Host "补丁镜像不一致，拒绝打包（先同步镜像 scripts/patches 到对端树）"; exit 1 }
 
+# manifest 加固门禁（0.13.8 PR-B3 / apk #183）：allowBackup/NSC/接收器来源校验在场
+Write-Host "== manifest 加固门禁 =="
+node (Join-Path $Root "scriptscheck-manifest-hardening.mjs") 2>&1
+if ($LASTEXITCODE -ne 0) { Write-Host "manifest 加固校验失败，拒绝打包"; exit 1 }
+
 # pi-ai 目录 diff（0.13.3 W1/P2）：baseline -> pin 信息性输出（构建日志 + 报告文件），
 # 删除清单供回归报告引用——不拒绝构建（删除项由 W4 降级补丁兜底）。
 $overlayManifest = Join-Path $Root "scripts\snapshot-config\engine-overlay.json"

--- a/scripts/check-manifest-hardening.mjs
+++ b/scripts/check-manifest-hardening.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// check-manifest-hardening.mjs — manifest 加固门禁（0.13.8 PR-B3 / apk issue #183）
+// 断言（读源 manifest + 接收器源码，构建期即可判）：
+//   1. android:allowBackup="false"
+//   2. 不存在 android:usesCleartextTraffic="true"（NSC 接管）
+//   3. android:networkSecurityConfig 已配置
+//   4. AdbKeyboardReceiver 源码含来源校验（isTrustedSender）
+// 退出 0 = 通过；1 = 失败（拒打包）。挂在 build-apk-013.ps1 门禁链与两仓 CI。
+import { readFileSync, existsSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)))
+const manifestPath = join(ROOT, 'app', 'src', 'main', 'AndroidManifest.xml')
+// 双仓共用构建链：本仓没有壳侧 manifest（协调仓）→ 跳过（镜像一致性由 check-patch-mirror 保证）
+if (!existsSync(manifestPath)) {
+  console.log('SKIP  本树无 app/src/main/AndroidManifest.xml（协调仓侧，壳侧门禁在 apk 仓构建时执行）')
+  process.exit(0)
+}
+const manifest = readFileSync(manifestPath, 'utf8')
+
+const failures = []
+const check = (label, ok) => {
+  console.log((ok ? 'PASS  ' : 'FAIL  ') + label)
+  if (!ok) failures.push(label)
+}
+
+check('allowBackup="false"', /android:allowBackup="false"/.test(manifest))
+check('无 usesCleartextTraffic="true"（NSC 接管）', !/usesCleartextTraffic="true"/.test(manifest))
+check('networkSecurityConfig 已配置', /android:networkSecurityConfig="@xml\/network_security_config"/.test(manifest))
+check('dataExtractionRules 已配置', /android:dataExtractionRules="@xml\/data_extraction_rules"/.test(manifest))
+check('fullBackupContent 已配置', /android:fullBackupContent="@xml\/backup_rules"/.test(manifest))
+
+try {
+  const receiver = readFileSync(
+    join(ROOT, 'app', 'src', 'main', 'java', 'com', 'dsharnessmobile', 'shell', 'AdbKeyboardReceiver.kt'), 'utf8',
+  )
+  check('AdbKeyboardReceiver 含来源校验（isTrustedSender）', receiver.includes('isTrustedSender'))
+} catch {
+  check('AdbKeyboardReceiver 含来源校验（isTrustedSender）', false)
+}
+
+if (failures.length > 0) {
+  console.error('MANIFEST-HARDENING FAILED: ' + failures.join('；'))
+  process.exit(1)
+}
+console.log('MANIFEST-HARDENING PASSED')


### PR DESCRIPTION
## 变更说明
0.13.8 批 B345 apk 仓侧（协调仓插件侧 #42 已先合并，镜像同步）。

#183（P0）：manifest allowBackup=false + 备份排除规则 + NSC（默认禁明文，127.0.0.1/10.0.2.2 放行，引擎 node 子进程不受 NSC 约束）；AdbKeyboardReceiver 来源校验（34+ sentFromUid 白名单 / nonce 常量时间比较；sentFromUid 走反射——本机 SDK 平台 jar 缺该符号）；MainActivity 幂等建 nonce + EngineManager 注入 DSH_FILES_DIR。

#167+#179：profiles 分区合并（staged 缺失条目不动 / package.json dependencies+bundles 并集且用户 pin 权威 / cordis.patch.yml 按 id 追加缺失工厂块）+ 合并前整目录拷贝到 .snapshot-previous 可回滚 + home 顶层条目 seed-if-absent（.gitconfig 永不覆盖）。

#172 展示面：BRIDGE-API/modules 授权模型补 tier 视图化说明；坑 68 登记。

门禁：check-manifest-hardening.mjs 新增并挂 build-apk-013.ps1 门禁链；check-snapshot-secrets 扩 ?token= 形态。

## 关联 issue
Closes #167
Closes #179
Closes #183
Ref #172（插件侧在协调仓 #42）

## 测试
- [x] SnapshotTransactionTest 9 例（新增合并/回滚 3 例 + 修 SnapshotTransactionTest 恒真假绿）全绿；FileIncomingSafetyTest 12 + LogRedactionTest 6 全绿
- [x] smoke-bridge SMOKE PASS（P3c 新断言：出厂档位 + 三道门齐 → gates.adbReady=true 且通道真实可执行）
- [x] check-manifest-hardening PASS；check-patch-mirror PASSED
- [x] 模拟器实测（MuMu x86_64/Android 15）：dumpsys 无 ALLOW_BACKUP 标志；nonce 文件 600 权限在场；引擎 env DSH_FILES_DIR 注入；uid 白名单广播通过且无误拒日志；verify-webview-015 28/28
- [ ] CI 通过

## 破坏性变更
有（按 0.13.8 计划拍板）：#172 部署默认写面档位不再参与 ADB 能力门（出厂档位下 ADB 通道可用性改由会话档位实时判定）；profiles 升级语义从整树替换改为分区合并（用户插件生态幸存）。
