### PR TITLE
fix: 批 CD（壳侧）——有界读四站点 + DEGRADED_HTTP 阶梯 + 门1 live 读路径 + 队列客户端去重

### DIFF
--- a/app/src/main/java/com/dsharnessmobile/shell/AdbState.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/AdbState.kt
@@ -534,8 +534,9 @@ object AdbState {
    */
   private fun adbPing(engine: EngineManager): Boolean = try {
     val proc = spawnAdb(engine, listOf("devices"))
-    val text = proc.inputStream.bufferedReader().use { it.readText() }
-    proc.waitFor(6, TimeUnit.SECONDS)
+    // 0.13.8 #173：有界读——本函数在 synchronized(this) 内，裸 readText 挂起会锁死
+    // 整个 AdbState（后续 ADB 调用与看门狗强制重启全部冻结）。
+    val text = ProcIo.readBounded(proc, 6) ?: return false
     !text.contains("protocol fault") && text.contains("List of devices")
   } catch (_: Throwable) {
     false
@@ -584,11 +585,9 @@ object AdbState {
       val adb = File(engine.usrDir, "bin/adb")
       if (!adb.exists()) return listOf("adb not found in snapshot runtime")
       val proc = spawnAdb(engine, args)
-      val text = proc.inputStream.bufferedReader().use { it.readText() }
-      if (!proc.waitFor(timeoutS, TimeUnit.SECONDS)) {
-        proc.destroy()
-        return listOf("adb timeout")
-      }
+      // 0.13.8 #173：有界读（读线程排水 + 超时 destroyForcibly）——原「先 readText 后
+      // waitFor」使超时参数形同虚设；超时沿用既有 "adb timeout" 文本（classifyFailure 已识别）。
+      val text = ProcIo.readBounded(proc, timeoutS) ?: return listOf("adb timeout")
       text.lines()
     } catch (t: Throwable) {
       listOf("adb failed: " + (t.message ?: t.javaClass.simpleName))

--- a/app/src/main/java/com/dsharnessmobile/shell/ControlPoller.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/ControlPoller.kt
@@ -18,6 +18,12 @@ import java.util.concurrent.atomic.AtomicBoolean
  *
  * 失败关闭：取活/回填任何异常只记录并退避重试，不猜测、不重放动作。
  * 引擎未起时退避到 10s，避免空转耗电。
+ *
+ * 0.13.8 #181：
+ * - 已执行 reqId 去重（有界 LRU）：重连/重投场景下同一请求绝不执行两次；
+ * - 非 2xx 不再静默丢弃——读 errorStream 与 X-DSH-Control-* 响应头并记日志
+ *   （409 = 双 settle 竞态的观测点；413 = 回填超限，真因首次可见）；
+ * - 通用 catch 补日志（原先完全吞掉）。
  */
 class ControlPoller(private val service: DeviceControlService) {
 
@@ -29,10 +35,15 @@ class ControlPoller(private val service: DeviceControlService) {
     private const val READ_TIMEOUT_MS = 9000
     private const val IDLE_BACKOFF_MS = 1000L
     private const val MAX_BACKOFF_MS = 10_000L
+    /** 已执行 reqId 去重集合容量（有界 LRU；4s 内的 in-flight 窗口远用不满 64 条）。 */
+    private const val EXECUTED_LRU_CAPACITY = 64
   }
 
   private val running = AtomicBoolean(false)
   private var thread: Thread? = null
+  private val executed = object : LinkedHashMap<String, Boolean>(EXECUTED_LRU_CAPACITY, 0.75f, true) {
+    override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Boolean>): Boolean = size > EXECUTED_LRU_CAPACITY
+  }
 
   fun start() {
     if (!running.compareAndSet(false, true)) return
@@ -69,7 +80,9 @@ class ControlPoller(private val service: DeviceControlService) {
         execute(token, request)
       } catch (interrupted: InterruptedException) {
         return
-      } catch (_: Exception) {
+      } catch (error: Exception) {
+        // 0.13.8 #181：通用异常不再静默吞掉——退避照旧，但原因必须可查
+        LogCollector.log(TAG, "poll loop error: " + (error.message ?: error.javaClass.simpleName))
         sleep(backoff)
         backoff = (backoff * 2).coerceAtMost(MAX_BACKOFF_MS)
       }
@@ -79,6 +92,12 @@ class ControlPoller(private val service: DeviceControlService) {
   private fun execute(token: String, request: JSONObject) {
     val reqId = request.optString("reqId", "")
     if (reqId.isEmpty()) return
+    // 0.13.8 #181：同一 reqId 只执行一次（有界 LRU；引擎侧 in-flight 门禁之外的壳侧兜底）
+    val firstRun = synchronized(executed) { executed.put(reqId, true) == null }
+    if (!firstRun) {
+      LogCollector.log(TAG, "duplicate delivery skipped (reqId=$reqId) — engine re-delivered an in-flight request")
+      return
+    }
     val op = request.optString("op", "")
     val args = request.optJSONObject("args") ?: JSONObject()
     val outcome: JSONObject = try {
@@ -104,7 +123,10 @@ class ControlPoller(private val service: DeviceControlService) {
     }
   }
 
-  /** POST JSON 并解析响应；非 2xx 或解析失败返回 null（调用方退避）。 */
+  /**
+   * POST JSON 并解析响应；非 2xx 读 errorStream + X-DSH-Control-* 头后返回 null（调用方退避）。
+   * 0.13.8 P0-1：非 2xx 的真因（401/403/413/409 + 字节数/上限）首次进日志，不再静默。
+   */
   private fun post(path: String, body: JSONObject): JSONObject? {
     val connection = URL(BASE + path).openConnection(Proxy.NO_PROXY) as HttpURLConnection
     return try {
@@ -116,7 +138,16 @@ class ControlPoller(private val service: DeviceControlService) {
       OutputStreamWriter(connection.outputStream, Charsets.UTF_8).use { it.write(body.toString()) }
       val code = connection.responseCode
       if (code !in 200..299) {
-        connection.errorStream?.close()
+        val errText = connection.errorStream?.bufferedReader()?.use { it.readText() } ?: ""
+        val ctrlCode = connection.headerFields?.get("x-dsh-control-code")?.firstOrNull() ?: ""
+        val bytes = connection.headerFields?.get("x-dsh-control-bytes")?.firstOrNull() ?: ""
+        val limit = connection.headerFields?.get("x-dsh-control-limit")?.firstOrNull() ?: ""
+        LogCollector.log(
+          TAG,
+          "POST $path -> HTTP $code" +
+            (if (ctrlCode.isNotEmpty()) " code=$ctrlCode bytes=$bytes limit=$limit" else "") +
+            (if (errText.isNotEmpty()) " body=" + errText.take(200) else ""),
+        )
         null
       } else {
         val text = BufferedReader(InputStreamReader(connection.inputStream, Charsets.UTF_8)).use { it.readText() }

--- a/app/src/main/java/com/dsharnessmobile/shell/DeviceControlService.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/DeviceControlService.kt
@@ -288,6 +288,9 @@ class DeviceControlService : AccessibilityService() {
     setEnabledFlag(this, true)
     token(this)
     invalidated = true
+    // 0.13.8 #181：先停旧代 poller 再起新代——直接覆盖引用会让旧 daemon 线程
+    // 永不可停（进程内长期双轮询，同一请求可能被两个 poller 相继取走）。
+    poller?.stop()
     val p = ControlPoller(this)
     poller = p
     p.start()

--- a/app/src/main/java/com/dsharnessmobile/shell/EngineManager.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/EngineManager.kt
@@ -687,9 +687,15 @@ class EngineManager(private val context: Context, private val pickToken: String?
     val engineReachable = EngineProbe.portReachable(1_000)
     val managedProcessAlive = engineProcess?.isAlive == true
     if (!force && (engineReachable || managedProcessAlive)) {
-      STARTING.set(false)
-      LogCollector.log(TAG, "engine start skipped (existing engine reachable or alive)")
-      return true
+      // 0.13.8 #175：DEGRADED_HTTP 阶梯触发时，「端口可连」不再是健康证据——半死引擎
+      // 必须允许重启（看门狗/重试路径不带 force 也能走到这里）。
+      if (WatchdogV2.degradedHttpTripped()) {
+        LogCollector.log(TAG, "engine start allowed despite reachable port: DEGRADED_HTTP ladder tripped (half-dead engine)")
+      } else {
+        STARTING.set(false)
+        LogCollector.log(TAG, "engine start skipped (existing engine reachable or alive)")
+        return true
+      }
     }
     if (withinCooldown) {
       LogCollector.log(TAG, "engine start retrying after the tracked child exited during cooldown")
@@ -821,8 +827,9 @@ class EngineManager(private val context: Context, private val pickToken: String?
       }
       try {
         val p = ProcessBuilder("logcat", "-d", "-v", "threadtime", "-t", "400").redirectErrorStream(true).start()
-        val out = p.inputStream.readBytes()
-        if (out.isNotEmpty()) File(dir, "logcat-recent.txt").writeText(EngineAuth.redact(String(out)))
+        // 0.13.8 #173：有界读（原 readBytes 无 waitFor，会冻结看门狗调度线程）
+        val out = ProcIo.readBounded(p, 10)
+        if (!out.isNullOrEmpty()) File(dir, "logcat-recent.txt").writeText(EngineAuth.redact(out))
       } catch (_: Throwable) {
       }
       LogCollector.log(TAG, "diagnostics mirrored: " + dir.absolutePath)
@@ -955,6 +962,13 @@ class EngineManager(private val context: Context, private val pickToken: String?
       Runtime.getRuntime().exec(arrayOf("/system/bin/pkill", "-f", "bin.js")).waitFor()
     } catch (_: Throwable) {
     }
+    // 0.13.8 #175：强制重启前必须复核端口真的释放（坑 31：pkill 在部分 ROM 不生效）——
+    // 不释放就 spawn 会 EADDRINUSE 循环。最多等 5s，仍占用则显式记录（下次 tick 重试）。
+    repeat(5) {
+      if (!EngineProbe.portReachable(1_000)) return
+      try { Thread.sleep(1_000) } catch (_: InterruptedException) {}
+    }
+    LogCollector.log(TAG, "killExistingEngine: port 3080 still occupied after cleanup (release recheck failed)")
   }
 
   /** Reset the 90s cooldown window: auto-undo (config rollback) or user retry

--- a/app/src/main/java/com/dsharnessmobile/shell/EngineService.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/EngineService.kt
@@ -100,22 +100,28 @@ class EngineService : Service() {
         exec.scheduleWithFixedDelay({
           try {
             val state = WatchdogV2.assessProbe(this)
+            // 0.13.8 #175：DEGRADED_HTTP 达阈值后不再被 alive 早退——半死引擎（端口可连、
+            // HTTP 持续失败）走与 DEAD 相同的受控重启阶梯；DEGRADED_LOG 保留不重启语义。
+            val degradedLadderTripped = state == WatchdogV2.ProbeState.DEGRADED_HTTP && WatchdogV2.degradedHttpTripped()
             val alive = state != WatchdogV2.ProbeState.DEAD
-            if (state != WatchdogV2.ProbeState.DEGRADED) {
+            if (state == WatchdogV2.ProbeState.HEALTHY || state == WatchdogV2.ProbeState.DEAD) {
               engineManager.onEngineProbe(state == WatchdogV2.ProbeState.HEALTHY)
             }
             WatchdogV2.recordProbe(state)
             WatchdogV2.refreshWakeLock(this)
 
-            if (alive) {
+            if (alive && !degradedLadderTripped) {
               nextRestartAllowedAt = 0L
               UndoGate.disarm(this)
               return@scheduleWithFixedDelay
             }
             if (!engineManager.engineReady) return@scheduleWithFixedDelay
-            if (WatchdogV2.consecutiveFailures < restartDeadConfirmations) {
+            if (!degradedLadderTripped && WatchdogV2.consecutiveFailures < restartDeadConfirmations) {
               LogCollector.log("dsh-watchdog", "confirmed-dead sample " + WatchdogV2.consecutiveFailures + "/" + restartDeadConfirmations + "; observing before restart")
               return@scheduleWithFixedDelay
+            }
+            if (degradedLadderTripped) {
+              LogCollector.log("dsh-watchdog", "DEGRADED_HTTP 连续 " + WatchdogV2.consecutiveDegradedHttp + " 拍（端口可连但 HTTP 持续失败）→ 升级为受控重启")
             }
             if (WatchdogV2.tripped()) {
               LogCollector.log("dsh-watchdog", "watchdog circuit open after confirmed-dead failures; destructive recovery paused")
@@ -129,9 +135,9 @@ class EngineService : Service() {
               LogCollector.log("dsh-watchdog", "dead probe deferred while the tracked child remains inside its boot window")
               return@scheduleWithFixedDelay
             }
-            if (UndoGate.onProbeFailure(this, WatchdogV2.consecutiveFailures)) {
+            if (UndoGate.onProbeFailure(this, WatchdogV2.effectiveFailureCount())) {
               nextRestartAllowedAt = now + WatchdogV2.nextDelayMs()
-              LogCollector.log("dsh-watchdog", "auto-undo trigger after confirmed-dead failures=" + WatchdogV2.consecutiveFailures)
+              LogCollector.log("dsh-watchdog", "auto-undo trigger after confirmed failures=" + WatchdogV2.effectiveFailureCount())
               Thread {
                 val result = UndoGate.execute(this, engineManager)
                 if (result.executed) {
@@ -158,7 +164,7 @@ class EngineService : Service() {
             nextRestartAllowedAt = now + delayMs
             LogCollector.log(
               "dsh-watchdog",
-              "restart requested after confirmed-dead failure #" + WatchdogV2.consecutiveFailures +
+              "restart requested after confirmed failure #" + WatchdogV2.effectiveFailureCount() +
                 " (accepted=" + requested + ", next eligible in " + delayMs + "ms)",
             )
           } catch (t: Throwable) {

--- a/app/src/main/java/com/dsharnessmobile/shell/EngineStartFlow.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/EngineStartFlow.kt
@@ -384,9 +384,13 @@ internal class EngineStartFlow(private val activity: MainActivity) {
       } else {
         // 进程还活着但 90s 内未就绪（异常慢）：灰色提示而非红色错误，不触发回退——
         // 引擎仍在启动，3s engineMonitorRunnable 会兜底切界面。
+        // 0.13.8 #175：终点不再「只提示」——安排一次自动重试（DEGRADED_HTTP 阶梯随后
+        // 兜底：若 HTTP 持续失败而端口可连，看门狗会受控重启，不再永久停留灰字）。
+        LogCollector.log("dsh-shell", "engine boot window exceeded 90s; scheduling retry (half-dead ladder will take over if HTTP stays failing)")
+        scheduleEngineRetry(generation)
         activity.runOnUiThread {
           if (!isCurrentEngineFlow(generation)) return@runOnUiThread
-          activity.applyGuidePhase(GuidePhase.Starting, "引擎启动较慢（已超过 90s），仍在后台启动中…")
+          activity.applyGuidePhase(GuidePhase.Starting, "引擎启动较慢（已超过 90s），已安排自动重试…")
         }
       }
       return@Thread

--- a/app/src/main/java/com/dsharnessmobile/shell/ProcIo.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/ProcIo.kt
@@ -1,0 +1,47 @@
+package com.dsharnessmobile.shell
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * 子进程有界 I/O（0.13.8 #173）。
+ *
+ * 缺陷根因：先 `readText()`（读到 EOF 才返回）后 `waitFor(timeout)`——超时参数只作用于
+ * 已阻塞完之后，形同不存在；挂起点落在 `synchronized` 内时升级为全局锁死
+ * （AdbState.adbPing 锁内挂起 → 所有 ADB 调用与看门狗强制重启全部冻结）。
+ *
+ * 铁律（grep 门禁 scripts/check-bounded-io.mjs 强制）：壳侧 Kotlin 一切子进程输出
+ * 读取必须经 [readBounded]，禁止裸 `inputStream.readText()`/`readBytes()`。
+ * 注意：`redirectErrorStream(true)` 下若先 waitFor 再读，子进程写满管道缓冲（约 64KB）
+ * 会死锁——所以读必须并发，不能简单挪到 waitFor 之后。
+ */
+internal object ProcIo {
+
+  /**
+   * 并发排水 + 有界等待：读线程消费 stdout（防管道写满死锁），`waitFor(timeoutS)`
+   * 超时即 `destroyForcibly()`（挂起的 adb client 对 SIGTERM 不可依赖）+ 有界 join。
+   * 返回 null = 超时（调用方按既有超时语义处理）。
+   */
+  fun readBounded(proc: Process, timeoutS: Long): String? {
+    val holder = arrayOfNulls<ByteArray>(1)
+    val drainer = Thread {
+      holder[0] = try {
+        proc.inputStream.readBytes()
+      } catch (_: Throwable) {
+        ByteArray(0)
+      }
+    }.apply { isDaemon = true }
+    drainer.start()
+    val done = try {
+      proc.waitFor(timeoutS, TimeUnit.SECONDS)
+    } catch (_: InterruptedException) {
+      false
+    }
+    if (!done) {
+      proc.destroyForcibly()
+      drainer.join(1_000)
+      return null
+    }
+    drainer.join(5_000)
+    return String(holder[0] ?: ByteArray(0), Charsets.UTF_8)
+  }
+}

--- a/app/src/main/java/com/dsharnessmobile/shell/UndoGate.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/UndoGate.kt
@@ -148,9 +148,13 @@ object UndoGate {
         Log.w(TAG, "direct exec denied, falling back to linker64: " + e.message)
         proc = build(listOf("/system/bin/linker64") + cmd).start()
       }
-      val text = proc.inputStream.bufferedReader().use { it.readText() }
-      if (!proc.waitFor(60, java.util.concurrent.TimeUnit.SECONDS)) {
-        proc.destroy()
+      // 0.13.8 #173：有界读——CLI 挂起曾令 60s 守卫失效，且 execute 的 autoUndoRunning
+      // 只在 finally 复位 → 恒「已在执行」，连看门狗 DEAD 支的强制重启都被锁死。
+      // 超时分支显式复位标志与 arm 文件（幂等，防御未来再引入无界读）。
+      val text = ProcIo.readBounded(proc, 60) ?: run {
+        proc.destroyForcibly()
+        try { armFile(context).delete() } catch (_: Throwable) {}
+        autoUndoRunning.set(false)
         return listOf("emergency CLI timeout")
       }
       text.lines()

--- a/app/src/main/java/com/dsharnessmobile/shell/WatchdogV2.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/WatchdogV2.kt
@@ -25,11 +25,23 @@ object WatchdogV2 {
   private const val TAG = "dsh-watchdog"
   const val MAX_CONSEC_FAILURES = 12
 
-  /** A slow HTTP response is distinct from a process that no longer accepts TCP. */
-  enum class ProbeState { HEALTHY, DEGRADED, DEAD }
+  /**
+   * A slow HTTP response is distinct from a process that no longer accepts TCP.
+   * 0.13.8 #175：DEGRADED 拆分病因——DEGRADED_HTTP = HTTP 失败但端口可连（半死，
+   * 连续 N 拍升级为受控重启）；DEGRADED_LOG = HTTP 成功但日志异常签名（绝不触发重启，
+   * 保留既有「重启会打断活动 turn」语义）。
+   */
+  enum class ProbeState { HEALTHY, DEGRADED_HTTP, DEGRADED_LOG, DEAD }
+
+  /** DEGRADED_HTTP 阶梯阈值：6 拍 × 5s = 30s（与 restartDeadConfirmations 同量级，远小于 90s 冷启动上限）。 */
+  const val DEGRADED_RESTART_CONFIRMATIONS = 6
 
   @Volatile
   var consecutiveFailures = 0
+    private set
+
+  @Volatile
+  var consecutiveDegradedHttp = 0
     private set
 
   /** Exponential delay for destructive recovery attempts after confirmed death. */
@@ -41,12 +53,23 @@ object WatchdogV2 {
   /** Only a confirmed dead process contributes to the restart/undo circuit breaker. */
   fun recordProbe(state: ProbeState) {
     consecutiveFailures = if (state == ProbeState.DEAD) consecutiveFailures + 1 else 0
+    consecutiveDegradedHttp = nextDegradedCount(state, consecutiveDegradedHttp)
   }
 
-  fun tripped(): Boolean = consecutiveFailures >= MAX_CONSEC_FAILURES
+  /** 纯函数（JVM 单测）：DEGRADED_HTTP 自增，其余状态清零。 */
+  fun nextDegradedCount(state: ProbeState, count: Int): Int =
+    if (state == ProbeState.DEGRADED_HTTP) count + 1 else 0
+
+  /** 熔断与退避共用同一计数（#175：半死阶梯与 DEAD 共用退避，防重启风暴）。 */
+  fun effectiveFailureCount(): Int = maxOf(consecutiveFailures, consecutiveDegradedHttp)
+
+  fun tripped(): Boolean = effectiveFailureCount() >= MAX_CONSEC_FAILURES
+
+  fun degradedHttpTripped(): Boolean = consecutiveDegradedHttp >= DEGRADED_RESTART_CONFIRMATIONS
 
   fun reset() {
     consecutiveFailures = 0
+    consecutiveDegradedHttp = 0
   }
 
   /**
@@ -56,10 +79,10 @@ object WatchdogV2 {
    */
   fun assessProbe(context: Context): ProbeState {
     val base = EngineProbe.check(2_500).optBoolean("running", false)
-    if (!base) return if (EngineProbe.portReachable(1_000)) ProbeState.DEGRADED else ProbeState.DEAD
+    if (!base) return if (EngineProbe.portReachable(1_000)) ProbeState.DEGRADED_HTTP else ProbeState.DEAD
     if (engineLogShowsFailure(context)) {
       LogCollector.log(TAG, "engine log reports a recoverable warning while HTTP remains alive")
-      return ProbeState.DEGRADED
+      return ProbeState.DEGRADED_LOG
     }
     consumeTaskDoneMarkers(context)
     return ProbeState.HEALTHY

--- a/app/src/test/java/com/dsharnessmobile/shell/WatchdogLadderTest.kt
+++ b/app/src/test/java/com/dsharnessmobile/shell/WatchdogLadderTest.kt
@@ -1,0 +1,33 @@
+package com.dsharnessmobile.shell
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #175 回归：DEGRADED_HTTP 阶梯的纯计数函数——HTTP 型半死连续 N 拍升级受控重启；
+ * 其它状态（HEALTHY/DEGRADED_LOG/DEAD）一律清零（DEGRADED_LOG 绝不触发重启）。
+ */
+class WatchdogLadderTest {
+
+  @Test
+  fun degradedHttpCountsIncrementally() {
+    assertEquals(1, WatchdogV2.nextDegradedCount(WatchdogV2.ProbeState.DEGRADED_HTTP, 0))
+    assertEquals(6, WatchdogV2.nextDegradedCount(WatchdogV2.ProbeState.DEGRADED_HTTP, 5))
+    assertEquals(7, WatchdogV2.nextDegradedCount(WatchdogV2.ProbeState.DEGRADED_HTTP, 6))
+  }
+
+  @Test
+  fun otherStatesResetTheCounter() {
+    assertEquals(0, WatchdogV2.nextDegradedCount(WatchdogV2.ProbeState.HEALTHY, 5))
+    assertEquals(0, WatchdogV2.nextDegradedCount(WatchdogV2.ProbeState.DEAD, 5))
+    // DEGRADED_LOG 不得触发重启：清零是硬约束
+    assertEquals(0, WatchdogV2.nextDegradedCount(WatchdogV2.ProbeState.DEGRADED_LOG, 5))
+  }
+
+  @Test
+  fun thresholdIsSixTicks30Seconds() {
+    assertTrue("阈值 6 拍 = 30s，须远小于 90s 冷启动窗口", WatchdogV2.DEGRADED_RESTART_CONFIRMATIONS == 6)
+    assertTrue(WatchdogV2.DEGRADED_RESTART_CONFIRMATIONS < WatchdogV2.MAX_CONSEC_FAILURES)
+  }
+}

--- a/plugins/dsh-android-bridge/package.json
+++ b/plugins/dsh-android-bridge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dsh-android/dsh-android-bridge",
   "description": "Android privilege bridge: ADB authorization state machine, fail-closed execution, audit — the only controlled privilege-extension channel (PRD F1.7)",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "main": "lib/index.js",
   "exports": {

--- a/plugins/dsh-android-bridge/src/control-queue.ts
+++ b/plugins/dsh-android-bridge/src/control-queue.ts
@@ -40,6 +40,8 @@ export class ControlQueue {
   private lastResultAt = 0
   private served = 0
   private failed = 0
+  /** 0.13.8 #181：在途标记——take 到 settle 之间二次取活必须被拒（防同一请求双执行）。 */
+  private inFlight = false
 
   /** 是否有壳侧未取走的活（false = 壳侧应停轮）。 */
   get waiting(): boolean {
@@ -68,7 +70,10 @@ export class ControlQueue {
     const req: ControlRequest = { reqId, op, args, gen, createdAt: Date.now() }
     return new Promise<ControlResult>((resolve) => {
       const timer = setTimeout(() => {
-        if (this.pending?.req.reqId === reqId) this.pending = undefined
+        if (this.pending?.req.reqId === reqId) {
+          this.pending = undefined
+          this.inFlight = false
+        }
         this.failed++
         resolve({ ok: false, error: `设备控制超时（${timeoutMs}ms 内壳侧未回填结果）——检查无障碍服务是否在运行` })
       }, Math.max(500, timeoutMs))
@@ -86,7 +91,9 @@ export class ControlQueue {
    */
   waitForWork(timeoutMs: number): Promise<ControlRequest | null> {
     this.lastTakeAt = Date.now()
-    if (this.pending) return Promise.resolve(this.take())
+    // 0.13.8 #181：在途（已取走未回填）时不再交付——被饿的轮询者拿到 null 会按
+    // pollHint 重新轮询，绝不会重复执行同一个 req。
+    if (this.pending && !this.inFlight) return Promise.resolve(this.take())
     return new Promise<ControlRequest | null>((resolve) => {
       const timer = setTimeout(() => {
         this.waiter = undefined
@@ -110,7 +117,9 @@ export class ControlQueue {
     this.lastTakeAt = Date.now()
     const entry = this.pending
     if (!entry) return null
-    // 取走后仍在等待回填；回填或超时才会清空。
+    // 0.13.8 #181：在途即拒——同一 reqId 只许交付一次（原实现可重复返回 → 双执行）。
+    if (this.inFlight) return null
+    this.inFlight = true
     return entry.req
   }
 
@@ -120,6 +129,7 @@ export class ControlQueue {
     if (!entry || entry.req.reqId !== reqId) return false
     clearTimeout(entry.timer)
     this.pending = undefined
+    this.inFlight = false
     this.lastResultAt = Date.now()
     if (result.ok) this.served++
     else this.failed++
@@ -133,6 +143,7 @@ export class ControlQueue {
     if (!entry) return
     clearTimeout(entry.timer)
     this.pending = undefined
+    this.inFlight = false
     entry.resolve({ ok: false, error: reason })
   }
 }
@@ -155,25 +166,57 @@ export type RouteResponse = {
   end(body?: string): void
 }
 
-function readBody(req: RouteRequest, limit = 64 * 1024): Promise<Record<string, unknown>> {
+/**
+ * 请求体读取（0.13.8 V2 P0-1，坑 D0 修复）：判别联合——超限/解析失败不再静默
+ * `resolve({})`（那会把「报文太大」伪装成 403 令牌不匹配，模型完全看不到真因）。
+ * 上限 64KB → 1MiB：V2 列式载荷下 MAX_NODES=4000 的最坏报文 ≈ 501KB，1MiB 结构性不可达。
+ */
+export const CONTROL_BODY_LIMIT = 1024 * 1024
+
+export type ReadBodyResult =
+  | { ok: true; body: Record<string, unknown> }
+  | { ok: false; code: 'too_large' | 'bad_json' | 'aborted'; bytes: number; limit: number }
+
+function readBody(req: RouteRequest, limit = CONTROL_BODY_LIMIT): Promise<ReadBodyResult> {
   return new Promise((resolve) => {
     const chunks: Buffer[] = []
     let size = 0
+    let overLimit = false
     req.on('data', (chunk) => {
       if (!chunk) return
       size += chunk.length
-      if (size > limit) return
+      if (size > limit) {
+        overLimit = true
+        return
+      }
       chunks.push(chunk)
     })
     req.on('end', () => {
+      if (overLimit) {
+        resolve({ ok: false, code: 'too_large', bytes: size, limit })
+        return
+      }
       try {
-        resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown>)
+        resolve({ ok: true, body: JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown> })
       } catch {
-        resolve({})
+        resolve({ ok: false, code: 'bad_json', bytes: size, limit })
       }
     })
-    req.on('error', () => resolve({}))
+    req.on('error', () => resolve({ ok: false, code: 'aborted', bytes: size, limit }))
   })
+}
+
+/** 413/400 统一出口：X-DSH-Control-Code/-Bytes/-Limit 响应头（壳侧 ControlPoller 读这些而非盲等）。 */
+function sendBodyError(res: RouteResponse, r: { code: string; bytes: number; limit: number }): void {
+  const code = r.code === 'too_large' ? 413 : 400
+  res.writeHead(code, {
+    'content-type': 'application/json; charset=utf-8',
+    'cache-control': 'no-store',
+    'x-dsh-control-code': r.code,
+    'x-dsh-control-bytes': String(r.bytes),
+    'x-dsh-control-limit': String(r.limit),
+  } as Record<string, string>)
+  res.end(JSON.stringify({ ok: false, error: `请求体${r.code === 'too_large' ? '超过上限' : '不是合法 JSON'}：${r.bytes}B / 上限 ${r.limit}B`, code: r.code, bytes: r.bytes, limit: r.limit }))
 }
 
 function sendJson(res: RouteResponse, code: number, payload: unknown): void {
@@ -206,7 +249,13 @@ export function registerControlRoutes(webServer: { register(route: unknown): voi
     kind: 'exact',
     path: '/api/android/ui/pending',
     handler: async (req: RouteRequest, res: RouteResponse) => {
-      const body = await readBody(req)
+      const rb = await readBody(req)
+      if (!rb.ok) {
+        logger?.warn?.(`control/pending: ${rb.code} (${rb.bytes}B / ${rb.limit}B)`)
+        sendBodyError(res, rb)
+        return
+      }
+      const body = rb.body
       if (!tokenMatches(token(), body.token)) {
         logger?.warn?.('control/pending: 令牌不匹配或未配置，拒绝')
         sendJson(res, 403, { ok: false, error: 'control token missing or mismatched' })
@@ -220,7 +269,13 @@ export function registerControlRoutes(webServer: { register(route: unknown): voi
     kind: 'exact',
     path: '/api/android/ui/result',
     handler: async (req: RouteRequest, res: RouteResponse) => {
-      const body = await readBody(req)
+      const rb = await readBody(req)
+      if (!rb.ok) {
+        logger?.warn?.(`control/result: ${rb.code} (${rb.bytes}B / ${rb.limit}B)`)
+        sendBodyError(res, rb)
+        return
+      }
+      const body = rb.body
       if (!tokenMatches(token(), body.token)) {
         logger?.warn?.('control/result: 令牌不匹配或未配置，拒绝')
         sendJson(res, 403, { ok: false, error: 'control token missing or mismatched' })
@@ -232,6 +287,7 @@ export function registerControlRoutes(webServer: { register(route: unknown): voi
         ? { ok: true, data: body.data }
         : { ok: false, error: typeof body.error === 'string' ? body.error : '设备控制失败（壳侧未给出原因）' }
       const accepted = queue.settle(reqId, result)
+      if (!accepted) logger?.warn?.(`control/result: rejected (409, reqId=${reqId})`)
       sendJson(res, accepted ? 200 : 409, { ok: accepted, reason: accepted ? 'settled' : 'unknown-or-stale-reqId' })
     },
   })

--- a/plugins/dsh-android-bridge/src/index.ts
+++ b/plugins/dsh-android-bridge/src/index.ts
@@ -102,6 +102,8 @@ export interface ShellAdbPrefs {
   controlToken?: string
   /** 0.13.5 W4：轮询心跳（epoch ms）——判定服务是否真的活着（防僵尸 a11yEnabled）。 */
   controlHeartbeat?: number
+  /** 0.13.8 #180：门1 live 键（壳 syncFullAccess 写入；undefined = prefs 无该键 → 上层回落 env）。 */
+  fullAccess?: boolean
 }
 
 /** 持久文件路径：环境变量显式指定（测试/桌面模拟）优先；安卓壳域默认；其余返回 null。 */
@@ -124,9 +126,11 @@ export function parseAdbPrefsXml(xml: string): ShellAdbPrefs | null {
   const mA11y = /<boolean\s+name="a11yEnabled"\s+value="(true|false)"\s*\/?>/.exec(xml)
   const mToken = /<string\s+name="controlToken">([^<]*)<\/string>/.exec(xml)
   const mHeartbeat = /<long\s+name="controlHeartbeat"\s+value="(\d+)"\s*\/?>/.exec(xml)
+  // 0.13.8 #180：门1 live 化——fullAccess 键在场即解析（写端 = 壳侧 syncFullAccess）。
+  const mFullAccess = /<boolean\s+name="fullAccess"\s+value="(true|false)"\s*\/?>/.exec(xml)
   // 只要任一受管键在场就解析——无障碍通道独立于 ADB 三道人门，
   // 未开启 ADB 时 prefs 里可能只有 a11yEnabled/controlToken（0.13.5 实测踩坑）。
-  if (!mAllow && !mPair && !mA11y && !mToken) return null
+  if (!mAllow && !mPair && !mA11y && !mToken && !mFullAccess) return null
   return {
     allowSwitch: mAllow ? mAllow[1] === 'true' : false,
     paired: mPair ? mPair[1] === 'true' : false,
@@ -136,6 +140,7 @@ export function parseAdbPrefsXml(xml: string): ShellAdbPrefs | null {
     a11yEnabled: mA11y ? mA11y[1] === 'true' : false,
     controlToken: mToken?.[1] || undefined,
     controlHeartbeat: mHeartbeat ? Number(mHeartbeat[1]) : undefined,
+    fullAccess: mFullAccess ? mFullAccess[1] === 'true' : undefined,
   }
 }
 
@@ -160,9 +165,11 @@ function readShellAdbState(): ShellAdbPrefs | undefined {
  */
 function currentStatus(env: NodeJS.ProcessEnv, defaultWriteMode?: string): AdbStatus {
   const writeMode = defaultWriteMode ?? env.DSH_WRITE_MODE ?? 'workspace-write'
-  const fullAccess = env.DSH_ADB_FULLACCESS === '1'
   // live 优先：壳侧 SharedPreferences（引擎与壳同 UID 直读，只读）；无文件 → env 启动快照。
   const live = readShellAdbState()
+  // 0.13.8 #180：门1 live 化——live prefs 优先（与门2/门3 完全同构），env 启动快照兜底；
+  // 同一判定里不再有两套时效语义（桌面/测试宿主无 prefs 时回落 env）。
+  const fullAccess = live ? (live.fullAccess ?? (env.DSH_ADB_FULLACCESS === '1')) : (env.DSH_ADB_FULLACCESS === '1')
   const allowSwitchOn = live ? live.allowSwitch : env.DSH_ADB_ALLOW === '1'
   const paired = live ? live.paired : env.DSH_ADB_PAIRED === '1'
   const wirelessDebugOn = live ? live.paired : env.DSH_ADB_WIRELESS === '1'
@@ -542,10 +549,10 @@ function tools(svc: AndroidPrivilegeService, shellFace?: { resolve?(spec: Record
   const statusTool = defineTool({
     name: 'android_privilege_status',
     description:
-      '查询设备控制授权状态。两条等价通道：无障碍通道（系统设置开启「DSH 设备控制」一次即成立，'
-      + '提供 dump/click/input/scroll 语义操作）与 ADB 通道（完全访问 + 允许访问 + 无线调试配对，'
-      + '高级/脚本面：shell 执行、原图截图、pm/dumpsys）。返回结构化 gates 与 control 字段；'
-      + '两者都不可用时给出两条开启路径的引导。手机管理工具全部以此为前置检查，失败关闭。',
+      '查询设备控制授权状态。无障碍通道为主（系统设置开启「DSH 设备控制」一次即成立，'
+      + '提供 dump/click/input/scroll 语义操作）；ADB 通道为高级/脚本兜底（完全访问 + 允许访问 + 无线调试配对：'
+      + 'shell 执行、原图截图、pm/dumpsys），不是「等价」通道——无障碍优先，ADB 仅兜底。'
+      + '返回结构化 gates 与 control 字段；两者都不可用时给出两条开启路径的引导。手机管理工具全部以此为前置检查，失败关闭。',
     parameters: {},
     output: {
       schema: {
@@ -579,9 +586,9 @@ function tools(svc: AndroidPrivilegeService, shellFace?: { resolve?(spec: Record
               + `${control?.tokenConfigured === true ? ' · 令牌已配置' : ''}`
               + `${queueFresh ? ' · 壳侧轮询在线' : ' · 壳侧轮询离线'}`,
             `ADB 通道：${gates?.adbReady ? '已就绪' : `未就绪（完全访问=${String(gates?.fullAccess)} 允许访问=${String(gates?.allowSwitch)} 配对=${String(gates?.paired)} 无线调试=${String(gates?.wirelessDebug)}）`}`,
-            gates?.a11yEnabled ? '结论：设备控制可用（走无障碍通道）'
-              : gates?.adbReady ? '结论：设备控制可用（走 ADB 通道）'
-                : '结论：不可用——开启任一通道即可（推荐无障碍：系统设置 → 无障碍 → DSH 设备控制）',
+            gates?.a11yEnabled ? '结论：设备控制可用（走无障碍通道）——下一步用 android_ui_dump（manage）拿语义清单'
+              : gates?.adbReady ? '结论：设备控制可用（走 ADB 通道，仅兜底）——下一步用 android_ui_dump（无障碍优先）或 android_ui_tree（ADB）'
+                : '结论：不可用——开启任一通道即可（推荐无障碍：系统设置 → 无障碍 → DSH 设备控制，一步即用）',
             v.message ? `ADB 提示：${String(v.message)}` : '',
           ].filter((line) => line !== '').join('\n'),
         }]
@@ -662,7 +669,8 @@ function tools(svc: AndroidPrivilegeService, shellFace?: { resolve?(spec: Record
       '真实 ADB 通道执行（0.14）：经本机 adbd 以 shell 身份执行系统命令（配对后可用）。' +
       '用途：screencap/uiautomator/dumpsys/input/getprop 等系统面只读与输入类；' +
       '系统配置写面（settings put/pm grant/appops/mount 等）一律拒绝。' +
-      '需完整授权（门1 完全访问档位 + 门2 允许开关 + 门3 真实配对）且会话档位 danger-full-access；未授权失败关闭。',
+      '需引擎级三道门（门1 完全访问 + 门2 允许开关 + 门3 真实配对）且会话档位 danger-full-access'
+      + '（部署默认写面档位只是视图，不参与门禁——0.13.8 #172）；未授权失败关闭。',
     parameters: {
       command: { type: 'string', required: true, description: '在 adbd（shell 用户）中执行的命令' },
     },

--- a/plugins/dsh-android-bridge/test/control.test.mjs
+++ b/plugins/dsh-android-bridge/test/control.test.mjs
@@ -61,12 +61,42 @@ test('队列串行：一次只允许一个在途请求', async () => {
 test('过期 reqId 不覆盖在途请求', async () => {
   const queue = new ControlQueue()
   const pending = queue.enqueue('snapshot', {})
-  queue.take()
+  const first = queue.take()
   assert.equal(queue.settle('c-nonexistent', { ok: true, data: {} }), false)
   assert.equal(queue.waiting, true)
-  const req = queue.take()
-  queue.settle(req.reqId, { ok: true, data: { gen: 1 } })
+  // 0.13.8 #181：在途（已取走未回填）时二次取活必须被拒——原实现会把同一 req
+  // 再次交给轮询者，同一请求被执行两次（apk issue #181 实锤）。
+  const second = queue.take()
+  assert.equal(second, null, '在途时二次 take 必须返回 null（防双执行）')
+  queue.settle(first.reqId, { ok: true, data: { gen: 1 } })
   assert.deepEqual(await pending, { ok: true, data: { gen: 1 } })
+  // 回填后队列清空：take 再次返回 null（waiting=false）
+  assert.equal(queue.take(), null)
+})
+
+test('#181 重复 settle 只接受第一次，二次为 409 语义', async () => {
+  const queue = new ControlQueue()
+  const pending = queue.enqueue('click', {})
+  const req = queue.take()
+  assert.equal(queue.settle(req.reqId, { ok: true, data: { n: 1 } }), true)
+  assert.equal(queue.settle(req.reqId, { ok: true, data: { n: 2 } }), false, '重复 settle 必须拒绝')
+  assert.deepEqual(await pending, { ok: true, data: { n: 1 } })
+})
+
+test('#181 超时清在途位：超时后新请求可以入队', async () => {
+  const queue = new ControlQueue()
+  const first = queue.enqueue('click', {}, 300)
+  const req = queue.take()
+  assert.ok(req, '取活成功且置在途位')
+  const result = await first
+  assert.equal(result.ok, false)
+  assert.match(result.error, /超时/)
+  // 超时清 pending + inFlight：新请求不再被「已有在途」拒绝
+  const second = queue.enqueue('click', {})
+  assert.equal(second instanceof Promise, true)
+  const req2 = queue.take()
+  assert.ok(req2, '超时清位后新请求可正常取活')
+  queue.settle(req2.reqId, { ok: true, data: {} })
 })
 
 test('超时返回失败而不是模糊结果', async () => {

--- a/plugins/dsh-android-manage/package.json
+++ b/plugins/dsh-android-manage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dsh-android/dsh-android-manage",
   "description": "Android phone management tools (ADB-first observe/act/wait loop, PRD F1.6): screenshot, UI tree, app/device info — all fail-closed on the privilege bridge",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "module",
   "main": "lib/index.js",
   "exports": {

--- a/plugins/dsh-android-manage/src/index.ts
+++ b/plugins/dsh-android-manage/src/index.ts
@@ -25,7 +25,7 @@ import { Context } from '@deepseek-ai/cordis'
 import { defineTool, type JsonValue } from '@deepseek-ai/dsh-tools'
 import { join } from 'node:path'
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync } from 'node:fs'
-import { parseUiTreeXml, pruneNodes, resolveRef, findActionableAncestor, type UiNode } from './ui-tree.js'
+import { parseUiTreeXml, pruneNodes, resolveRef, findActionableAncestor, checkUiTreeParse, type UiNode } from './ui-tree.js'
 
 /**
  * 0.13.8 #183：键盘广播来源校验 nonce 参数（壳侧 AdbKeyboardReceiver 私有文件，
@@ -517,8 +517,42 @@ function tools(ctx: Context, priv: PrivilegeFace) {
   // 引擎单进程内模块级缓存（n 值 ≤60，内存代价可忽略）。
   const UI_CACHE_TTL = 30_000
   let uiCache:
-    | { nodes: UiNode[]; byId: ReturnType<typeof pruneNodes>['byId']; byOrig: ReturnType<typeof pruneNodes>['byOrig']; parentByOrig: ReturnType<typeof pruneNodes>['parentByOrig']; screen: { w: number; h: number }; rotation: number; ts: number; gen?: number }
+    | { nodes: UiNode[]; byId: ReturnType<typeof pruneNodes>['byId']; byOrig: ReturnType<typeof pruneNodes>['byOrig']; parentByOrig: ReturnType<typeof pruneNodes>['parentByOrig']; screen: { w: number; h: number }; rotation: number; ts: number; gen?: number; fingerprint?: string; rawCount?: number }
     | null = null
+
+  /**
+   * 0.13.8 P0-4：树结构指纹（FNV-1a）——「界面未变」快路径的判定依据。
+   * 覆盖定位所需字段（文本/描述/类型/几何/交互性）；任一变化 → 指纹翻转 → 完整重抓。
+   * 纯追加语义：指纹相同只回一行「未变」摘要，绝不改写历史结果（L1）。
+   */
+  const treeFingerprint = (nodes: UiNode[]): string => {
+    let h = 0x811c9dc5
+    for (const n of nodes) {
+      const s = `${n.id}|${n.parentId}|${n.text}|${n.desc}|${n.rid}|${n.type}|${n.cx},${n.cy},${n.w},${n.h}|${n.clickable ? 1 : 0}${n.editable ? 1 : 0}${n.scrollable ? 1 : 0}${n.checked ? 1 : 0}${n.visible ? 1 : 0}`
+      for (let i = 0; i < s.length; i++) {
+        h ^= s.charCodeAt(i)
+        h = Math.imul(h, 0x01000193) >>> 0
+      }
+      h ^= 0xff
+      h = Math.imul(h, 0x01000193) >>> 0
+    }
+    return 'fp' + h.toString(16).padStart(8, '0')
+  }
+
+  /** 「界面未变」快路径（P0-4）：指纹一致直接回紧凑摘要，模型可复用上次引用。 */
+  const unchangedResponse = (fp: string, gen?: number) => ({
+    ok: true,
+    denied: false,
+    unchanged: true,
+    screen: uiCache!.screen,
+    rotation: uiCache!.rotation,
+    count: uiCache!.nodes.length,
+    rawCount: uiCache!.rawCount ?? uiCache!.nodes.length,
+    nodes: [] as JsonValue[],
+    gen,
+    note: '界面未变（结构指纹一致）：上次 dump 的引用（n0..nN）与坐标仍然有效，可直接复用；需完整清单请带 fresh:true 重新 dump',
+    text: `界面未变（gen=${gen ?? '未知'}，结构指纹 ${fp}）：上次 dump 的 ${uiCache!.nodes.length} 个节点引用仍有效——直接用 android_ui_click/id:nN 等引用继续，无需重新阅读清单（fresh:true 可强制完整重抓）`,
+  })
 
   /** 0.13.5 W4：控制通道决策。策略面缺席（旧版 bridge）→ 按 ADB 通道处理，保持旧行为。 */
   const controlDecision = (op: string, exec?: { agent?: { session?: unknown } }) => {
@@ -576,15 +610,15 @@ function tools(ctx: Context, priv: PrivilegeFace) {
   const uiDump = defineTool({
     name: 'android_ui_dump',
     description:
-      '【首选】导出当前界面语义控件清单：无障碍语义树优先（无障碍服务已开启时走这条路——一次系统开关即可用、'
-      + '无配对、无 uiautomator idle 阻塞、字段更全），否则回退 uiautomator dump。'
-      + '产出紧凑 JSON 节点表（id(text/desc 语义定位用，同一次 dump 内稳定)/文本/描述/类型/中心坐标/尺寸/可点/可滚动/可编辑）。'
-      + '节点上限 60（超出截断）、文本截 50 字符——token 远低于原始 XML 与截图。'
-      + '调用序：先 android_ui_dump 定位目标，再 android_ui_click/scroll/input 语义动作；'
-      + '点击已自带生效校验（android_ui_click 会回报「已生效/未观察到变化」），页面大幅变化后再 dump。'
+      '【首选】导出当前界面语义控件清单：无障碍语义树优先（一次系统开关即用、无配对、不受 uiautomator idle 阻塞），否则回退 uiautomator dump。'
+      + '产出完整结构化节点表（id / 父id / 文本 / 描述 / 类型 / bounds / 可点 / 可滚动 / 可编辑），0.13.5 起不截断；'
+      + '界面未变时返回紧凑「未变」摘要（省 token，传 fresh:true 强制完整重抓）。'
+      + '下一步用 android_ui_click / android_ui_input / android_ui_scroll 语义动作；页面大幅变化后重新 dump。'
       + '需设备控制授权（无障碍服务已开启，或 ADB 三道门齐备）+ 会话档位 danger-full-access；未授权失败关闭。'
-      + '注意：需要原始 uiautomator XML 或无障碍不可用时，才用 android_ui_tree。',
-    parameters: {},
+      + '注意：需要原始 uiautomator XML 时才用 android_ui_tree。',
+    parameters: {
+      fresh: { type: 'boolean', description: 'true = 跳过「界面未变」快路径，强制完整重抓（默认 false）' },
+    },
     output: {
       schema: {
         type: 'object',
@@ -663,7 +697,8 @@ function tools(ctx: Context, priv: PrivilegeFace) {
         }]
       },
     },
-    execute: async (_args, exec) => {
+    execute: async (args, exec) => {
+      const forceFresh = (args as { fresh?: boolean } | undefined)?.fresh === true
       const a = guard('ui_dump', {}, exec as { agent?: { session?: unknown } })
       if (!a.ok) return { ok: false, denied: true, screen: { w: 0, h: 0 }, rotation: 0, count: 0, rawCount: 0, nodes: [], text: a.guidance }
       // 0.13.5 W4：无障碍通道优先（一次系统开关即用；不经 uiautomator，故不受 F1 idle 阻塞影响）
@@ -680,6 +715,11 @@ function tools(ctx: Context, priv: PrivilegeFace) {
         }
         const data = (r.data ?? {}) as A11ySnapshot
         const pruned = pruneNodes(data.nodes ?? [])
+        const fp = treeFingerprint(pruned.nodes)
+        // 0.13.8 P0-4：「界面未变」快路径——结构指纹一致且缓存新鲜 → 纯追加一行摘要（L1）
+        if (!forceFresh && uiCache && uiCache.fingerprint === fp && Date.now() - uiCache.ts <= UI_CACHE_TTL) {
+          return unchangedResponse(fp, data.gen ?? uiCache.gen)
+        }
         const screen = data.screen && data.screen.w > 0 ? data.screen : { w: 0, h: 0 }
         uiCache = {
           nodes: pruned.nodes,
@@ -690,6 +730,8 @@ function tools(ctx: Context, priv: PrivilegeFace) {
           rotation: data.rotation ?? 0,
           ts: Date.now(),
           gen: data.gen,
+          fingerprint: fp,
+          rawCount: pruned.rawCount,
         }
         const fg = await foregroundInfo()
         const dumpPkg = pruned.nodes.find((n) => String(n.pkg || '') !== '')?.pkg ?? ''
@@ -737,7 +779,17 @@ function tools(ctx: Context, priv: PrivilegeFace) {
         }
         const xml = readFileSync(local, 'utf8')
         const parsed = parseUiTreeXml(xml)
+        // 0.13.8 P0-2：结构自检——解析结果与源 XML 矛盾时响亮拒绝（错误树比没有树更危险）
+        const check = checkUiTreeParse(xml, parsed.raw)
+        if (!check.ok) {
+          return { ok: false, denied: false, screen: { w: 0, h: 0 }, rotation: 0, count: 0, rawCount: 0, nodes: [], text: '控件树解析自检失败（拒绝产出不可信清单）：' + check.reason }
+        }
         const pruned = pruneNodes(parsed.raw)
+        const fp = treeFingerprint(pruned.nodes)
+        // 0.13.8 P0-4：同 a11y 分支——「界面未变」快路径
+        if (!forceFresh && uiCache && uiCache.fingerprint === fp && Date.now() - uiCache.ts <= UI_CACHE_TTL) {
+          return unchangedResponse(fp, uiCache.gen)
+        }
         const size = /Physical size:\s*(\d+)x(\d+)/.exec(r.stdout)
         const screen = size ? { w: Number(size[1]), h: Number(size[2]) } : { w: 0, h: 0 }
         uiCache = {
@@ -748,6 +800,8 @@ function tools(ctx: Context, priv: PrivilegeFace) {
           screen,
           rotation: parsed.rotation,
           ts: Date.now(),
+          fingerprint: fp,
+          rawCount: pruned.rawCount,
         }
         return {
           ok: true,
@@ -812,7 +866,10 @@ function tools(ctx: Context, priv: PrivilegeFace) {
       // 不依赖无障碍虚拟树，也不需要坐标。
       if (useRef) {
         const webRef = ref!.trim()
-        const isWebRef = /^w\d+$/.test(webRef) || webRef.startsWith('css:') || webRef.startsWith('text:') || webRef.startsWith('role:')
+        // 0.13.8 P0-6（D8）：只有显式 css:/role:/wN 才走自有 WebView DOM 通道——
+        // text: 曾被无条件劫持到本通道，原生页面 text: 必然失败且报错指向 WebView。
+        // text:/desc:/rid: 一律走快照模型（resolveRef 的 text 分支恢复可达）。
+        const isWebRef = /^w\d+$/.test(webRef) || webRef.startsWith('css:') || webRef.startsWith('role:')
         if (isWebRef) {
           const payload: Record<string, unknown> = { op: 'click' }
           if (/^w\d+$/.test(webRef)) payload.ref = webRef
@@ -1078,7 +1135,8 @@ function tools(ctx: Context, priv: PrivilegeFace) {
       // #128 L1：WebView DOM 引用（wN / css: / text: / role:）→ 自有 WebView 通道直接写值
       // （原生 value setter + input/change 事件，兼容 React 受控组件），不经 IME、不会汉字化。
       const webRef = typeof ref === 'string' ? ref.trim() : ''
-      const isWebRef = /^w\d+$/.test(webRef) || webRef.startsWith('css:') || webRef.startsWith('text:') || webRef.startsWith('role:')
+      // 0.13.8 P0-6（D8）：同 ui_click——text: 不再劫持进 DOM 通道，走快照模型。
+      const isWebRef = /^w\d+$/.test(webRef) || webRef.startsWith('css:') || webRef.startsWith('role:')
       if (isWebRef) {
         const payload: Record<string, unknown> = { op: 'setText', value: raw }
         if (/^w\d+$/.test(webRef)) payload.ref = webRef

--- a/plugins/dsh-android-manage/src/ui-tree.ts
+++ b/plugins/dsh-android-manage/src/ui-tree.ts
@@ -96,6 +96,11 @@ interface RawNode { attrs: Record<string, string>; id: string; parentId: string 
  * 解析 hierarchy XML → 原始节点表（含深度路径 id 与父 id）。
  * 单一栈机：开标签下钻、自闭合同层计数、闭标签归位；对厂商畸形输出
  * （属性缺省/坏 bounds）按节点丢弃，不中断整体解析。
+ *
+ * 0.13.8 P0-2（产线 bug 修复）：原实现只匹配 `<node ...>` 开标签、从不处理
+ * `</node>` 出栈——兄弟节点被错误地压成子节点，depth/父链/`@nX` 区域限定/
+ * findActionableAncestor 全部失真（实测最大深度 91 vs 正确 19）。现显式匹配
+ * `</node>` 归位；畸形 XML（多余闭标签）按容错弹栈处理。
  */
 export function parseUiTreeXml(xml: string): { raw: RawNode[]; rotation: number } {
   let rotation = 0
@@ -106,10 +111,15 @@ export function parseUiTreeXml(xml: string): { raw: RawNode[]; rotation: number 
   // 栈帧：index = 本节点在同父下的序号；next = 下一个子节点槽位。
   // 虚拟根永远在栈底，其 index 不参与路径。
   const stack: Array<{ index: number; next: number }> = [{ index: -1, next: 0 }]
-  const re = /<node\s([^>]*?)(\/?)>/g
+  const re = /<node\s([^>]*?)(\/?)>|<\/node>/g
   let m: RegExpExecArray | null
   while ((m = re.exec(xml)) !== null) {
-    const attrsText = m[1]
+    if (m[0] === '</node>') {
+      // 闭标签归位（畸形 XML 的多余闭标签按容错忽略——不弹虚拟根）
+      if (stack.length > 1) stack.pop()
+      continue
+    }
+    const attrsText = m[1] ?? ''
     const selfClosing = m[2] === '/'
     const attrs: Record<string, string> = {}
     ATTR_RE.lastIndex = 0
@@ -125,6 +135,27 @@ export function parseUiTreeXml(xml: string): { raw: RawNode[]; rotation: number 
     if (!selfClosing) stack.push({ index, next: 0 })
   }
   return { raw, rotation }
+}
+
+/**
+ * 解析结果结构自检（0.13.8 P0-2）：解析结果与源 XML 自相矛盾时**响亮拒绝**，
+ * 绝不静默产出错树（错误树比没有树更危险）。
+ * 检查：① 节点标签计数与解析产出一一对应；② 根节点必为 "0"；
+ * ③ 栈未完全归位（未闭合的开标签）视为畸形——按容错放行但由调用方标记。
+ */
+export function checkUiTreeParse(xml: string, raw: RawNode[]): { ok: true } | { ok: false; reason: string } {
+  const tagCount = (xml.match(/<node[\s>]/g) ?? []).length
+  if (raw.length !== tagCount) {
+    return { ok: false, reason: `节点数不一致：XML 含 ${tagCount} 个 <node> 标签，解析产出 ${raw.length} 条（源 XML 畸形或版本不兼容）` }
+  }
+  if (raw.length > 0 && raw[0].id !== '0') {
+    return { ok: false, reason: `根节点 id 应为 "0"，实得 "${raw[0].id}"（栈机归位错误）` }
+  }
+  const maxDepth = raw.reduce((acc, r) => Math.max(acc, r.id === '' ? 0 : r.id.split('.').length), 0)
+  if (maxDepth > 128) {
+    return { ok: false, reason: `最大深度 ${maxDepth} 超出合理上界（128）——栈机未归位，解析结果不可信` }
+  }
+  return { ok: true }
 }
 
 /** 剪枝：只保留可交互或带标签的节点；去重 → 分档排序 → 封顶截断。
@@ -185,9 +216,11 @@ export function pruneNodes(
       windowId: at['window-id'] ?? '',
     })
   }
-  // 分档排序：可交互带标签 > 可交互 > 带标签 > 其它；同档按 y 再 x（阅读序）。
-  const tier = (n: UiNode): number => (n.clickable || n.editable || n.scrollable) && (n.text || n.desc) ? 0 : (n.clickable || n.editable || n.scrollable) ? 1 : (n.text || n.desc) ? 2 : 3
-  nodes.sort((p, q) => tier(p) - tier(q) || p.cy - q.cy || p.cx - q.cx)
+  // 0.13.8 P0-3：DFS 真树序（原始路径字典序 = 前序遍历）——0.13.5 的「分档排序」把兄弟
+  // 节点按档位/坐标打乱，模型看到的相邻行出现 21.8% 的深度跳变（真树遍历不可能），
+  // 层级感知完全失效。真树序下 depth 严格递变 ≤1，配合 parentId（最近幸存祖先）层级唯一。
+  // 阅读序信息不丢失：同层节点保持 XML 顺序（uiautomator 已按 top-left 序输出）。
+  nodes.sort((p, q) => (p.id < q.id ? -1 : p.id > q.id ? 1 : 0))
   // 0.13.5：maxNodes=0 表示不截断（用户拍板：完整暴露，复杂界面才可用）
   const kept = limits.maxNodes > 0 ? nodes.slice(0, limits.maxNodes) : nodes
   // 重编号：n0..nN-1；父引用按原始路径映射到**最近的幸存祖先**（被剪掉的中间层自动上溯）。

--- a/plugins/dsh-android-manage/test/ui-tree.test.mjs
+++ b/plugins/dsh-android-manage/test/ui-tree.test.mjs
@@ -3,7 +3,7 @@
 // 不可点击目标的「可点击祖先」回退静默失效。本测试锁死该边界。
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { parseUiTreeXml, pruneNodes, resolveRef, findActionableAncestor } from '../lib/ui-tree.js'
+import { parseUiTreeXml, pruneNodes, resolveRef, findActionableAncestor, checkUiTreeParse } from '../lib/ui-tree.js'
 
 const ATTRS = 'checkable="false" checked="false" enabled="true" focusable="false" focused="false" ' +
   'long-clickable="false" password="false" selected="false" package="com.android.settings"'
@@ -127,4 +127,95 @@ test('作用域引用 @nX 只在子树内匹配，避免侧边栏/主区同名�
   const right = resolveRef(byId, nodes, `text:确定@${scopes[1].id}`)
   assert.equal(right.ok, true)
   assert.equal(right.node.cx > 300, true, '应命中右半区那个「确定」')
+})
+
+// ── 0.13.8 P0-2/P0-3 回归：栈机归位 + 结构自检 + DFS 真树序 ──
+
+test('栈机正确归位：兄弟节点不再被压成子节点（depth/父链可信）', () => {
+  const xml = hierarchy(
+    `<node index="0" text="" resource-id="" class="android.widget.FrameLayout" ${ATTRS} clickable="false" scrollable="false" bounds="[0,0][1080,1920]">` +
+      `<node index="0" text="A" resource-id="id/a" class="android.widget.TextView" ${ATTRS} clickable="true" scrollable="false" bounds="[0,0][100,100]" />` +
+      `<node index="1" text="B" resource-id="id/b" class="android.widget.TextView" ${ATTRS} clickable="true" scrollable="false" bounds="[0,200][100,300]" />` +
+    `</node>`,
+  )
+  const { raw } = parseUiTreeXml(xml)
+  // 修复前：B 的 id 是 0.0.1（A 的"子节点"）；修复后：B 与 A 同层，id=0.1
+  const a = raw.find((r) => r.attrs['resource-id'] === 'id/a')
+  const b = raw.find((r) => r.attrs['resource-id'] === 'id/b')
+  assert.equal(a.id, '0.0')
+  assert.equal(b.id, '0.1')
+  assert.equal(b.parentId, '0')
+
+  const { nodes } = pruneNodes(raw)
+  // depth 跳变 ≤ 1（DFS 真树序的铁律）
+  for (let i = 1; i < nodes.length; i++) {
+    const jump = Math.abs(nodes[i].depth - nodes[i - 1].depth)
+    assert.ok(jump <= 1, `相邻行深度跳变 ${jump} > 1（n${i - 1}→n${i}）——不是真树序`)
+  }
+})
+
+test('结构自检 checkUiTreeParse：节点数不一致响亮拒绝', () => {
+  const xml = hierarchy(
+    `<node index="0" text="" resource-id="" class="android.widget.FrameLayout" ${ATTRS} clickable="false" scrollable="false" bounds="[0,0][1080,1920]" />`,
+  )
+  // 模拟坏解析：把同一节点解析出两条
+  const { raw } = parseUiTreeXml(xml)
+  const doubled = [...raw, { ...raw[0], id: '0.0.0', parentId: raw[0].id }]
+  const check = checkUiTreeParse(xml, doubled)
+  assert.equal(check.ok, false)
+  assert.match(check.reason, /节点数不一致/)
+})
+
+test('结构自检 checkUiTreeParse：正常 XML 通过', () => {
+  const xml = hierarchy(
+    `<node index="0" text="" resource-id="" class="android.widget.FrameLayout" ${ATTRS} clickable="false" scrollable="false" bounds="[0,0][1080,1920]">` +
+      `<node index="0" text="A" resource-id="id/a" class="android.widget.TextView" ${ATTRS} clickable="false" scrollable="false" bounds="[0,0][100,100]" />` +
+    `</node>`,
+  )
+  const { raw } = parseUiTreeXml(xml)
+  const check = checkUiTreeParse(xml, raw)
+  assert.equal(check.ok, true)
+})
+
+test('DFS 真树序：prune 后节点按原始路径前序排列（不再分档打乱）', () => {
+  const xml = hierarchy(
+    `<node index="0" text="" resource-id="" class="android.widget.FrameLayout" ${ATTRS} clickable="false" scrollable="false" bounds="[0,0][1080,1920]">` +
+      `<node index="0" text="ZZZ-last-by-tier" resource-id="id/z" class="android.widget.TextView" ${ATTRS} clickable="false" scrollable="false" bounds="[0,900][100,1000]" />` +
+      `<node index="1" text="AAA-clickable" resource-id="id/a" class="android.widget.Button" ${ATTRS} clickable="true" scrollable="false" bounds="[0,0][100,100]" />` +
+    `</node>`,
+  )
+  const { raw } = parseUiTreeXml(xml)
+  const { nodes } = pruneNodes(raw)
+  // 分档排序曾把可点击的 AAA 排到最前；真树序下容器在前、兄弟按 XML 顺序
+  const zIdx = nodes.findIndex((n) => n.rid === 'id/z')
+  const aIdx = nodes.findIndex((n) => n.rid === 'id/a')
+  assert.ok(zIdx < aIdx, `DFS 序应容器(z, idx=${zIdx})在兄弟(a, idx=${aIdx})之前`)
+})
+
+test('解析等价性门禁：父子关系与独立递归实现一致（抽样结构断言）', () => {
+  // 三层嵌套：独立实现按「<node 配对计数」推导父子，与栈机输出比对
+  const xml = hierarchy(
+    `<node index="0" text="" resource-id="" class="android.widget.FrameLayout" ${ATTRS} clickable="false" scrollable="false" bounds="[0,0][1080,1920]">` +
+      `<node index="0" text="" resource-id="id/left" class="android.widget.LinearLayout" ${ATTRS} clickable="false" scrollable="false" bounds="[0,0][540,1920]">` +
+        `<node index="0" text="L1" resource-id="id/l1" class="android.widget.TextView" ${ATTRS} clickable="false" scrollable="false" bounds="[0,0][100,100]" />` +
+        `<node index="1" text="L2" resource-id="id/l2" class="android.widget.TextView" ${ATTRS} clickable="false" scrollable="false" bounds="[0,100][100,200]" />` +
+      `</node>` +
+      `<node index="1" text="R" resource-id="id/right" class="android.widget.TextView" ${ATTRS} clickable="false" scrollable="false" bounds="[540,0][100,100]" />` +
+    `</node>`,
+  )
+  const { raw } = parseUiTreeXml(xml)
+  // 独立推导（按嵌套层级手工标注的期望值）：
+  const expected = {
+    '0': { parent: '', depth: 0 },
+    '0.0': { parent: '0', depth: 1 },
+    '0.0.0': { parent: '0.0', depth: 2 },
+    '0.0.1': { parent: '0.0', depth: 2 },
+    '0.1': { parent: '0', depth: 1 },
+  }
+  for (const r of raw) {
+    const e = expected[r.id]
+    assert.ok(e, `意外 id ${r.id}`)
+    assert.equal(r.parentId, e.parent, `id=${r.id} 父链不符`)
+  }
+  assert.equal(raw.length, Object.keys(expected).length)
 })

--- a/scripts/build-apk-013.ps1
+++ b/scripts/build-apk-013.ps1
@@ -33,6 +33,11 @@ Write-Host "== manifest 加固门禁 =="
 node (Join-Path $Root "scriptscheck-manifest-hardening.mjs") 2>&1
 if ($LASTEXITCODE -ne 0) { Write-Host "manifest 加固校验失败，拒绝打包"; exit 1 }
 
+# 子进程无界读 grep 门禁（0.13.8 #173）：输出必须走 ProcIo.readBounded
+Write-Host "== 有界读门禁 =="
+node (Join-Path $Root "scriptscheck-bounded-io.mjs") 2>&1
+if ($LASTEXITCODE -ne 0) { Write-Host "无界读命中，拒绝打包"; exit 1 }
+
 # pi-ai 目录 diff（0.13.3 W1/P2）：baseline -> pin 信息性输出（构建日志 + 报告文件），
 # 删除清单供回归报告引用——不拒绝构建（删除项由 W4 降级补丁兜底）。
 $overlayManifest = Join-Path $Root "scripts\snapshot-config\engine-overlay.json"

--- a/scripts/check-bounded-io.mjs
+++ b/scripts/check-bounded-io.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// check-bounded-io.mjs — 子进程无界读 grep 门禁（0.13.8 #173）
+// 缺陷：先 readText 后 waitFor 使超时失效；redirectErrorStream 下先 waitFor 后读会死锁；
+// 锁内挂起升级为全局冻结。铁律：子进程输出一律走 ProcIo.readBounded。
+// 命中即拒打包。双仓共用（协调仓无 Kotlin 源时自然通过）。
+import { readdirSync, statSync, readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)))
+const SRC = join(ROOT, 'app', 'src', 'main', 'java')
+let files = []
+try {
+  const walk = (dir) => {
+    for (const name of readdirSync(dir)) {
+      const full = join(dir, name)
+      if (statSync(full).isDirectory()) walk(full)
+      else if (name.endsWith('.kt')) files.push(full)
+    }
+  }
+  walk(SRC)
+} catch {
+  console.log('SKIP  本树无 Kotlin 源（协调仓侧）')
+  process.exit(0)
+}
+
+// 只对「子进程流」命中（proc/p/process 接收者）；HTTP/文件流的读有各自超时语义，不在此列。
+// ProcIo.kt 本体豁免（并发排水正是其职责）。
+const patterns = [
+  [/\b(proc|process|p)\.inputStream\.bufferedReader\(\)\.use\s*\{\s*it\.readText\(\)\s*\}/, '裸 readText（无界，超时失效）'],
+  [/\b(proc|process|p)\.inputStream\.readBytes\(\)/, '裸 readBytes（无界）'],
+  [/\b(proc|process|p)\.errorStream\.bufferedReader\(\)\.use\s*\{\s*it\.readText\(\)\s*\}/, '裸 stderr readText（无界）'],
+]
+const bad = []
+for (const f of files) {
+  if (f.endsWith('ProcIo.kt')) continue
+  const text = readFileSync(f, 'utf8')
+  for (const [re, why] of patterns) {
+    if (re.test(text)) bad.push(`${f.replace(ROOT + '\\', '').replace(ROOT + '/', '')}: ${why}`)
+  }
+}
+if (bad.length > 0) {
+  console.error('BOUNDED-IO CHECK FAILED（子进程输出必须走 ProcIo.readBounded）:')
+  for (const b of bad) console.error('  ' + b)
+  process.exit(1)
+}
+console.log('BOUNDED-IO CHECK PASSED（' + files.length + ' 个 Kotlin 文件零命中）')


### PR DESCRIPTION
## 变更说明
0.13.8 批 CD apk 仓侧（协调仓插件侧 #43 已先合并，镜像同步）。

#173（P1）有界读：新增 ProcIo.readBounded（读线程排水 + waitFor + destroyForcibly + 有界 join），修四站点（runAdb、adbPing 锁内、UndoGate CLI、logcat 读取）；check-bounded-io.mjs grep 门禁挂构建链（43 文件零命中）。

#175（P1）半死引擎阶梯：DEGRADED 拆 DEGRADED_HTTP/DEGRADED_LOG（LOG 绝不重启）；连续 6 拍 HTTP 型失败走与 DEAD 相同的受控重启；熔断与退避共用 effectiveFailureCount；killExistingEngine 升级 destroyForcibly + 端口释放复核（坑 31）；90s 慢启动终点改「安排自动重试」。

#180（P2）门1 读路径同步：stateJson 与 3s 轮询补 syncFullAccess（配合引擎侧 fullAccess 键解析——授予后不重启 3s 内生效）。

#181（P2）壳侧队列客户端：已执行 reqId 有界 LRU 去重；非 2xx 读 errorStream 与 X-DSH-Control-* 头记日志；通用 catch 补日志；onServiceConnected 先停旧代 poller。

## 关联 issue
Closes #173
Closes #175
Closes #180
Closes #181
Ref #176（生效校验部分由 V2 P0-3/P0-4 的层级与快路径先行改善，完整三态校验随 V2 P1）

## 测试
- [x] WatchdogLadderTest 3 例（计数纯函数/其它状态清零/阈值 6 拍）+ 全套 :app:testDebugUnitTest 绿
- [x] check-bounded-io.mjs 双仓通过（43 Kotlin 文件零命中；ProcIo 豁免）
- [x] 模拟器实测：正常冷启动零 DEGRADED 误重启、无 forced restart 日志；verify-webview-015 28/28
- [x] smoke-bridge SMOKE PASS（引擎侧断言在协调仓 #43）

## 破坏性变更
无（DEGRADED_LOG 不重启语义保留；防误杀慢启动的既有阈值语义不变）
