### PR TITLE
feat: 批 E（V2 P1 前五项）——skill 播种修复 + gen 语义 + 建树预算 + 心跳解耦 + 长按

### DIFF
--- a/app/src/main/java/com/dsharnessmobile/shell/ControlPoller.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/ControlPoller.kt
@@ -41,6 +41,7 @@ class ControlPoller(private val service: DeviceControlService) {
 
   private val running = AtomicBoolean(false)
   private var thread: Thread? = null
+  private var heartbeatThread: Thread? = null
   private val executed = object : LinkedHashMap<String, Boolean>(EXECUTED_LRU_CAPACITY, 0.75f, true) {
     override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Boolean>): Boolean = size > EXECUTED_LRU_CAPACITY
   }
@@ -51,12 +52,29 @@ class ControlPoller(private val service: DeviceControlService) {
       it.isDaemon = true
       it.start()
     }
+    // 0.13.8 E3（V2 D2）：心跳与执行解耦——原实现心跳只在轮询循环里刷新，慢建树
+    // 会把「服务在忙」误判成「掉线」并翻转 ADB 通道。独立心跳线程 2s 一拍，
+    // 与动作执行完全并行；busy 态对引擎保持可见（ready/busy 语义）。
+    heartbeatThread = Thread({
+      while (running.get()) {
+        try {
+          DeviceControlService.heartbeat(service)
+        } catch (_: Throwable) {
+        }
+        sleep(2_000)
+      }
+    }, "dsh-a11y-heartbeat").also {
+      it.isDaemon = true
+      it.start()
+    }
   }
 
   fun stop() {
     running.set(false)
     thread?.interrupt()
     thread = null
+    heartbeatThread?.interrupt()
+    heartbeatThread = null
   }
 
   private fun loop() {
@@ -74,8 +92,7 @@ class ControlPoller(private val service: DeviceControlService) {
           continue
         }
         backoff = IDLE_BACKOFF_MS
-        // 心跳：证明「服务活着 + 轮询在跑」——引擎侧只认新鲜心跳，避免僵尸 a11yEnabled
-        DeviceControlService.heartbeat(service)
+        // 心跳由独立线程维护（E3 解耦）；轮询本身也顺带证明通道活着（lastTakeAt）
         val request = poll.optJSONObject("req") ?: continue
         execute(token, request)
       } catch (interrupted: InterruptedException) {

--- a/app/src/main/java/com/dsharnessmobile/shell/DeviceControlService.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/DeviceControlService.kt
@@ -46,6 +46,8 @@ class DeviceControlService : AccessibilityService() {
      *  prefs 里的 a11yEnabled 会变成「僵尸 true」；引擎侧只认新鲜心跳。 */
     const val KEY_HEARTBEAT = "controlHeartbeat"
     private const val MAX_NODES = 4000
+    /** 0.13.8 E2：建树时间预算（ms）——超过返回部分树 + truncated 标注。 */
+    private const val TREE_BUDGET_MS = 3_000L
     private const val MAX_DEPTH = 40
     private const val TOKEN_BYTES = 18
 
@@ -258,17 +260,22 @@ class DeviceControlService : AccessibilityService() {
 
   /** 最近一次快照：路径 → 节点/边界。节点对象不跨快照使用（页面变化即失效）。 */
   private class Snapshot(
-    val gen: Int,
+    // 0.13.8 E4：gen 用秒级时间戳播种（Long）——服务重连后计数从 0 回绕曾让旧缓存
+    // 「假新鲜」（同一 gen 判定通过 → 按失效快照点击）。时间戳单调，杜绝回绕。
+    val gen: Long,
     val rotation: Int,
     val width: Int,
     val height: Int,
     val nodes: LinkedHashMap<String, AccessibilityNodeInfo>,
     val bounds: HashMap<String, Rect>,
+    // 0.13.8 E2：建树时间预算触发 → 部分树 + 显式标注（宁可标注过的半棵树，不给一句超时）
+    val truncated: Boolean = false,
   )
 
   private val lock = Any()
   private var snapshot: Snapshot? = null
-  private val generation = AtomicInteger(0)
+  // 0.13.8 E4：秒级时间戳播种（Long，单调不回绕）
+  private val generation = java.util.concurrent.atomic.AtomicLong(System.currentTimeMillis() / 1000)
   /** issue #127 一次性迁移标记：旧截图目录 files/control-shots 只清一次。 */
   private val legacyShotDirCleaned = java.util.concurrent.atomic.AtomicBoolean(false)
   @Volatile
@@ -278,6 +285,11 @@ class DeviceControlService : AccessibilityService() {
   private var lastInvalidateAt = 0L
 
   private var poller: ControlPoller? = null
+
+  /** 0.13.8 E4：服务代次（onServiceConnected 递增；诊断用——重连后缓存全部作废的观测点）。 */
+  @Volatile
+  var serviceEpoch: Int = 0
+    private set
 
   /** 主线程 Handler：无障碍 API 的回调都在主线程（takeScreenshot 需要 Executor）。 */
   private val mainHandler = android.os.Handler(android.os.Looper.getMainLooper())
@@ -344,8 +356,17 @@ class DeviceControlService : AccessibilityService() {
       val nodes = LinkedHashMap<String, AccessibilityNodeInfo>()
       val bounds = HashMap<String, Rect>()
       var count = 0
+      // 0.13.8 E2：建树时间预算（3s）——超预算返回部分树并显式标注 truncated，
+      // 宁可给一棵标注过的半棵树，也不给一句超时（V2 §4.1）。
+      var truncated = false
+      val deadline = android.os.SystemClock.uptimeMillis() + TREE_BUDGET_MS
       fun walk(node: AccessibilityNodeInfo?, path: String, depth: Int) {
         if (node == null || depth > MAX_DEPTH || count >= MAX_NODES) return
+        if (!truncated && android.os.SystemClock.uptimeMillis() > deadline) {
+          truncated = true
+          return
+        }
+        if (truncated) return
         val rect = Rect()
         node.getBoundsInScreen(rect)
         if (rect.width() > 0 && rect.height() > 0) {
@@ -359,7 +380,7 @@ class DeviceControlService : AccessibilityService() {
       }
       walk(root, "", 0)
       val metrics = screenSize()
-      val fresh = Snapshot(generation.incrementAndGet(), rotation(), metrics.first, metrics.second, nodes, bounds)
+      val fresh = Snapshot(generation.incrementAndGet(), rotation(), metrics.first, metrics.second, nodes, bounds, truncated)
       snapshot = fresh
       invalidated = false
       return fresh
@@ -409,6 +430,7 @@ class DeviceControlService : AccessibilityService() {
     return when (op) {
       "snapshot" -> handleSnapshot()
       "click" -> handleClick(args)
+      "longClick" -> handleLongClick(args)
       "setText" -> handleSetText(args)
       "scroll" -> handleScroll(args)
       "global" -> handleGlobal(args)
@@ -593,12 +615,21 @@ class DeviceControlService : AccessibilityService() {
       .put("nodes", nodes)
   }
 
-  /** 校验 gen（页面已变化时失败关闭）并返回目标节点。 */
+  /** 校验 gen（页面已变化时失败关闭）并返回目标节点。0.13.8 E4：-1 自愈重建 + Long gen。 */
   private fun requireFresh(args: JSONObject): JSONObject? {
-    val requested = if (args.has("gen")) args.optInt("gen", -1) else -1
+    val requested = if (args.has("gen")) args.optLong("gen", -1L) else -1L
     if (requested >= 0) {
-      val current = synchronized(lock) { snapshot?.gen ?: -1 }
-      if (current != requested) return error("控件清单已过期（gen=$requested，当前=$current）——请重新 android_ui_dump")
+      var current = synchronized(lock) { snapshot?.gen ?: -1L }
+      if (current == -1L) {
+        // 0.13.8 E4（V2 §4.4）：「无快照」≠「过期」——当场重建，路径仍在就继续执行；
+        // 原实现两者混为一谈且唯一补救恰是会超时的 dump → 死锁。
+        val rebuilt = buildSnapshot(force = true)
+        if (rebuilt == null) return error("无可用快照且当场重建失败（无障碍服务可能未连接）——请稍后重试或检查设备控制服务")
+        current = rebuilt.gen
+      }
+      if (current != requested) {
+        return error("控件清单已过期（gen=$requested，当前=$current）——界面已变化，请重新 android_ui_dump；不要按旧引用猜测性点击")
+      }
     }
     return null
   }
@@ -633,6 +664,64 @@ class DeviceControlService : AccessibilityService() {
       val x = (args.optDouble("nx") * metrics.first).toFloat()
       val y = (args.optDouble("ny") * metrics.second).toFloat()
       return tapAt(x, y, "gesture-norm")
+    }
+    return error("需要 path 或 nx/ny")
+  }
+
+  /** 手势长按（0.13.8 E6）：路径不移动、时长 durationMs——区别于 tapAt 的 60ms 点按。 */
+  private fun pressAt(x: Float, y: Float, durationMs: Long, via: String): JSONObject {
+    val path = Path().apply { moveTo(x, y) }
+    val gesture = GestureDescription.Builder()
+      .addStroke(GestureDescription.StrokeDescription(path, 0, durationMs))
+      .build()
+    val latch = java.util.concurrent.CountDownLatch(1)
+    var ok = false
+    val dispatched = dispatchGesture(gesture, object : GestureResultCallback() {
+      override fun onCompleted(description: GestureDescription?) { ok = true; latch.countDown() }
+      override fun onCancelled(description: GestureDescription?) { latch.countDown() }
+    }, null)
+    if (!dispatched) return error("手势派发失败（无障碍服务未就绪）")
+    latch.await(durationMs + 2_000, java.util.concurrent.TimeUnit.MILLISECONDS)
+    return if (ok) JSONObject().put("clicked", "($x,$y)").put("via", via).put("durationMs", durationMs)
+      .put("x", x.toDouble()).put("y", y.toDouble())
+    else error("手势长按未完成（被系统取消）")
+  }
+
+  /**
+   * 长按（0.13.8 E6，V2 §4.2「长按三条通道全缺」修复的 a11y 支）：
+   * 优先 ACTION_LONG_CLICK（沿父链找可长按祖先），失败/不可点回退手势按住 durationMs
+   * （通用长按形态；传 durationMs 可覆盖，300-3000ms 钳制）。
+   */
+  private fun handleLongClick(args: JSONObject): JSONObject {
+    requireFresh(args)?.let { return it }
+    val durationMs = args.optLong("durationMs", 600L).coerceIn(300L, 3_000L)
+    val path = args.optString("path", "")
+    if (path.isNotEmpty()) {
+      var node = nodeAtPath(path) ?: return error("路径 $path 已不存在（页面已变化）——请重新 android_ui_dump")
+      var hops = 0
+      while (hops < 12) {
+        if (node.isLongClickable) break
+        node = node.parent ?: break
+        hops++
+      }
+      if (node.isLongClickable) {
+        val ok = node.performAction(AccessibilityNodeInfo.ACTION_LONG_CLICK)
+        if (ok) {
+          val rect = Rect()
+          node.getBoundsInScreen(rect)
+          return JSONObject().put("clicked", path).put("via", "ACTION_LONG_CLICK")
+            .put("x", rect.exactCenterX().toDouble()).put("y", rect.exactCenterY().toDouble())
+        }
+      }
+      val rect = Rect()
+      node.getBoundsInScreen(rect)
+      return pressAt(rect.exactCenterX(), rect.exactCenterY(), durationMs, "gesture-longclick")
+    }
+    if (args.has("nx") && args.has("ny")) {
+      val metrics = screenSize()
+      val x = (args.optDouble("nx") * metrics.first).toFloat()
+      val y = (args.optDouble("ny") * metrics.second).toFloat()
+      return pressAt(x, y, durationMs, "gesture-norm-longclick")
     }
     return error("需要 path 或 nx/ny")
   }

--- a/app/src/main/java/com/dsharnessmobile/shell/EngineManager.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/EngineManager.kt
@@ -358,6 +358,29 @@ class EngineManager(private val context: Context, private val pickToken: String?
         skillFile.writeText(PHONE_CONTROL_SKILL)
         Log.i(TAG, "phone-control SKILL refreshed")
       }
+      // 0.13.8 #130/V2 P1-11：标准组合的 skill-filesystem 行没有 config——预设自带的
+      // skills 目录不在任何被扫描的 skill 根里，phone-control 的 SKILL 从未被加载
+      // （与缺 frontmatter 并列的两处缺陷之一）。结构化后处理：照抄上游 cordis 预设的
+      // 写法注入 customSkillDirs（指向本预设 skills/ 目录，baseUrl 相对解析）；
+      // 已注入则跳过（幂等）。置于 preset.yml 早退之前——存量用户的升级路径也覆盖。
+      val composition = File(dir, "agent.cordis.yml")
+      if (composition.exists()) {
+        val text = composition.readText()
+        if (text.contains("- id: skill-filesystem") && !text.contains("customSkillDirs")) {
+          val anchor = "- id: skill-filesystem\n  name: '@deepseek-ai/dsh-skill-filesystem'"
+          val injected = anchor + "\n" +
+            "  config:\n" +
+            "    customSkillDirs:\n" +
+            "      - !!js \"process.getBuiltinModule('node:url').fileURLToPath(new URL('skills/', baseUrl))\""
+          val patched = text.replace(anchor, injected)
+          if (patched != text) {
+            composition.writeText(patched)
+            Log.i(TAG, "phone-control preset: customSkillDirs injected into skill-filesystem row")
+          } else {
+            Log.w(TAG, "phone-control preset: skill-filesystem anchor not found; customSkillDirs not injected")
+          }
+        }
+      }
       if (File(dir, "preset.yml").exists()) return
       val shipped = File(
         context.filesDir,
@@ -1118,6 +1141,10 @@ class EngineManager(private val context: Context, private val pickToken: String?
      * （无障碍/DOM 优先、先验前台、按 ref 而非盲点坐标、动作后必校验、输入单次注入并回读）。
      */
     private val PHONE_CONTROL_SKILL = """
+---
+name: phone-control
+description: 手机操控纪律：无障碍语义树优先、ref 语义点击/输入、动作后必校验、禁止盲点坐标与绕路。
+---
 # 手机操控流程（DSH 设备控制）
 
 ## 固定顺序

--- a/plugins/dsh-android-manage/src/index.ts
+++ b/plugins/dsh-android-manage/src/index.ts
@@ -824,16 +824,18 @@ function tools(ctx: Context, priv: PrivilegeFace) {
   const uiClick = defineTool({
     name: 'android_ui_click',
     description:
-      '语义点击：按 android_ui_dump 清单中的引用点按控件（解析 bounds 中心 → input tap，AI 不猜像素）。' +
+      '语义点击/长按：按 android_ui_dump 清单中的引用点按控件（解析 bounds 中心 → input tap，AI 不猜像素）。' +
       '引用格式：id:n3 / text:设置（精确文本）/ desc:… / rid:…；裸数字按 id。' +
       '控件树不可用时可用 nx/ny 归一化坐标兜底：相对设备物理屏幕（0-1），' +
       '由截图像素换算 nx=像素x/截图宽、ny=像素y/截图高——工具层负责映射到物理分辨率，模型无需手工乘缩放系数。' +
       '目标不可点自动回退最近可点祖先；不在最近 dump 中返回引导（页面已变请重新 dump）。' +
-      '需 ADB 授权 + 会话档位 danger-full-access；每次调用审计。',
+      '长按：传 longClick:true（0.13.8 新增，无障碍 ACTION_LONG_CLICK 优先、手势按住 600ms 兜底）。' +
+      '需设备控制授权（无障碍或 ADB 三道门）+ 会话档位 danger-full-access；每次调用审计。',
     parameters: {
       ref: { type: 'string', description: '控件引用（id:n3 或 text:精确文本 等；与 nx/ny 二选一）' },
       nx: { type: 'number', description: '归一化 X（0-1，相对物理屏宽；= 截图内像素 x ÷ 截图宽）——无 ref 时使用' },
       ny: { type: 'number', description: '归一化 Y（0-1，相对物理屏高；= 截图内像素 y ÷ 截图高）——无 ref 时使用' },
+      longClick: { type: 'boolean', description: 'true = 长按（ACTION_LONG_CLICK 优先，手势按住 600ms 兜底）' },
     },
     output: {
       schema: {
@@ -854,7 +856,9 @@ function tools(ctx: Context, priv: PrivilegeFace) {
         { type: 'text', text: String(v.text ?? '') },
       ],
     },
-    execute: async ({ ref, nx, ny }: { ref?: string; nx?: number; ny?: number }, exec) => {
+    execute: async ({ ref, nx, ny, longClick }: { ref?: string; nx?: number; ny?: number; longClick?: boolean }, exec) => {
+      // 0.13.8 E6：长按走壳侧 longClick op（ACTION_LONG_CLICK 优先 + 手势按住兜底）
+      const clickOp = longClick === true ? 'longClick' : 'click'
       const a = guard('ui_click', { ref, nx, ny }, exec as { agent?: { session?: unknown } })
       if (!a.ok) return { ok: false, denied: true, text: a.guidance }
       const useRef = typeof ref === 'string' && ref.trim().length > 0
@@ -913,7 +917,7 @@ function tools(ctx: Context, priv: PrivilegeFace) {
           const orig = origPathOf(node.id)
           if (!orig) return { ok: false, denied: false, text: '无障碍通道需要节点原始路径——请重新 android_ui_dump' }
           payload.path = orig
-          const r = await a11yExec('click', payload)
+          const r = await a11yExec(clickOp, payload)
           if (!r.ok) return { ok: false, denied: false, text: '无障碍点击失败：' + r.error }
           const clicked = (r.data ?? {}) as { x?: number; y?: number; via?: string }
           const verdict = await verifyClick(uiCache?.gen, exec as ExecLike)
@@ -927,7 +931,7 @@ function tools(ctx: Context, priv: PrivilegeFace) {
         }
         payload.nx = nx
         payload.ny = ny
-        const r = await a11yExec('click', payload)
+        const r = await a11yExec(clickOp, payload)
         if (!r.ok) return { ok: false, denied: false, text: '无障碍点击失败：' + r.error }
         const clicked = (r.data ?? {}) as { x?: number; y?: number; via?: string }
         const verdict = await verifyClick(uiCache?.gen, exec as ExecLike)
@@ -974,7 +978,7 @@ function tools(ctx: Context, priv: PrivilegeFace) {
           payload.nx = nx
           payload.ny = ny
         }
-        const r = await a11yExec('click', payload)
+        const r = await a11yExec(clickOp, payload)
         if (!r.ok) return { ok: false, denied: false, text: '无障碍点击失败：' + r.error }
         return {
           ok: true,


### PR DESCRIPTION
## 变更说明
0.13.8 批 E（A11Y V2 P1 前五项；E1 协议 V2 编解码器与 E6 余项随批 F 继续）：

- **E5 skill 播种修复**（= #130 D-1/D-2，坑 D1 致命缺陷）：SKILL.md 补 YAML frontmatter（加载器强制 name/description，缺失即 skill 从未加载——0.13.6 起的静默失效）；agent.cordis.yml 的 skill-filesystem 行注入 config.customSkillDirs（照抄上游 cordis 预设 baseUrl 写法）；置于 preset.yml 早退之前，存量用户升级路径同样生效
- **E4 gen 语义修正**（V2 §4.4/§3.2）：generation 秒级时间戳播种（AtomicLong 单调不回绕，修复服务重连后旧缓存「假新鲜」）；onServiceConnected 递增 serviceEpoch 并作废旧快照；requireFresh 区分「无快照」（-1 当场重建继续执行，消除 dump 超时死锁）与「真过期」（报差异指引）
- **E2 建树时间预算**（V2 §4.1）：3s 预算超时返回部分树 + truncated 显式标注；handleState 输出 truncated
- **E3 心跳解耦**（V2 D2）：ControlPoller 独立心跳线程 2s 一拍——慢建树不再把「服务在忙」误判「掉线」翻转 ADB 通道
- **E6a 长按**（V2 §4.2）：壳侧 longClick op（ACTION_LONG_CLICK 沿父链优先 + 手势按住 600ms 兜底）；android_ui_click 加 longClick 参数三处派发

## 关联 issue
Ref #130（skill 播种部分在本批闭环）
Ref V2 方案 docs/A11Y-CONTROL-REDESIGN-V2.md §12 P1

## 测试
- [x] 全套 :app:testDebugUnitTest 绿；manage ui-tree 10/10；SMOKE PASS
- [x] 模拟器实测（MuMu x86_64/Android 15）：SKILL.md 首行 frontmatter 在场；customSkillDirs 注入成功（存量升级路径验证）；verify-webview-015 28/28；正常启动无 DEGRADED 误重启
- [ ] CI 通过

## 破坏性变更
有（按 0.13.8 计划）：gen 从 Int 改为秒级时间戳 Long（旧 gen 引用一次性失效，模型需重新 dump——语义即「升级后界面状态以新 dump 为准」）。
