### PR TITLE
feat: 批 G——悬浮球缺陷 B 状态收敛 + 缺陷 A 选择器重构 + 动效基建

### DIFF
--- a/app/src/main/java/com/dsharnessmobile/shell/DsUi.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/DsUi.kt
@@ -14,6 +14,20 @@ import android.view.animation.PathInterpolator
 internal object DsUi {
   val ease = PathInterpolator(0.32f, 0.72f, 0f, 1f)
 
+  /**
+   * 动效总开关（0.13.8 G3-M11，降级统一入口）：系统「关闭动画」三开关任一关闭、
+   * 或 ValueAnimator 不活动（省电模式等）→ 所有 overlay 动效直接设终态。
+   * 复用 ShimmerTextView.kt 的既有判定口径（单一来源原则）。
+   */
+  fun animationsEnabled(context: android.content.Context): Boolean {
+    if (!android.animation.ValueAnimator.areAnimatorsEnabled()) return false
+    val resolver = context.contentResolver
+    val scale = { key: String -> android.provider.Settings.Global.getFloat(resolver, key, 1f) }
+    return scale(android.provider.Settings.Global.ANIMATOR_DURATION_SCALE) != 0f &&
+      scale(android.provider.Settings.Global.TRANSITION_ANIMATION_SCALE) != 0f &&
+      scale(android.provider.Settings.Global.WINDOW_ANIMATION_SCALE) != 0f
+  }
+
   fun roundRect(
     color: Int,
     radius: Float,

--- a/app/src/main/java/com/dsharnessmobile/shell/OverlayLiveFeed.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/OverlayLiveFeed.kt
@@ -9,6 +9,12 @@ import java.io.RandomAccessFile
  *  （turn_start/tool_call/tool_result/turn_end）+ android_* 自动化避让（F7）+ debug 合成 pending 注入。 */
 class OverlayLiveFeed(private val svc: OverlayService) {
 
+  companion object {
+    /** 单次 drain 读取上限（#178 契约：生产者 bridge 每行一次 appendFileSync、行长硬上限
+     *  240/160 字符；256KB 内必含整行边界，溢出部分因按消费量推进而自然留到下一轮）。 */
+    private const val LIVE_READ_CAP_BYTES = 256 * 1024
+  }
+
   private var watcher: FileObserver? = null
   private var readOffset = 0L
 
@@ -52,6 +58,12 @@ class OverlayLiveFeed(private val svc: OverlayService) {
     drainLive()
   }
 
+  /**
+   * live 行消费（0.13.8 #178 行边界修复）：只消费到最后一个 `\n`，偏移按**消费量**推进——
+   * 原实现 `readOffset = len` 把未消费的截断部分/半行一并跳过（偏移记账 ≠ 消费量）；
+   * 多字节截断与半行随「找不到换行就不推进」自然消失。CAP 提为具名常量并写明契约
+   * （生产者 bridge 每行一次 appendFileSync、行长硬上限 240/160 字符）。
+   */
   private fun drainLive() {
     val f = liveFile()
     if (!f.exists()) return
@@ -62,11 +74,14 @@ class OverlayLiveFeed(private val svc: OverlayService) {
         if (len < readOffset) readOffset = 0 // 文件被轮转重建
         if (len > readOffset) {
           raf.seek(readOffset)
-          val buf = ByteArray((len - readOffset).toInt().coerceAtMost(256 * 1024))
+          val buf = ByteArray((len - readOffset).toInt().coerceAtMost(LIVE_READ_CAP_BYTES))
           raf.readFully(buf)
-          readOffset = len
-          val tail = String(buf, Charsets.UTF_8)
-          for (line in tail.split("\n")) {
+          val text = String(buf, Charsets.UTF_8)
+          val lastNewline = text.lastIndexOf('\n')
+          if (lastNewline < 0) return // 半行：等下次补齐，偏移不动
+          val consumable = text.substring(0, lastNewline)
+          readOffset += lastNewline + 1 // 只推进到已消费边界（非 len）
+          for (line in consumable.split("\n")) {
             val t = line.trim()
             if (t.isNotEmpty()) lines.add(t)
           }
@@ -82,23 +97,15 @@ class OverlayLiveFeed(private val svc: OverlayService) {
         try {
           val j = JSONObject(line)
           when (j.optString("k")) {
-            "turn_start" -> {
-              val s = j.optString("s", "")
-              // 轮次真正启动（bridge 0.1.3 起在产）：覆盖 WebView 侧发送/提问续跑等壳侧不可见的启动，
-              // 并确认乐观忙态。会话感知同 tool_call（#2）。
-              if (svc.activeSessionId.isEmpty() || s == svc.activeSessionId) {
-                svc.optimisticBusyAt = 0L
-                if (!svc.sessionBusy) { svc.sessionBusy = true; svc.turnStartedAt = System.currentTimeMillis() }
-                svc.setHalo(Halo.WORKING)
-                changed = true
-              }
-            }
+            // 注：turn_start 分支删除（bridge 0.1.4 起退役该行，lib 里仅剩注释——#178 取证确认死代码）
             "tool_call" -> {
               val s = j.optString("s", "")
               // 会话感知：仅当事件属于当前目标会话（或尚无目标）才置忙，
               // 避免其它会话/陈旧行的 tool_call 让 busy 永久卡死（#2）。
               if (svc.activeSessionId.isEmpty() || s == svc.activeSessionId) {
-                svc.optimisticBusyAt = 0L
+                // 0.13.8 #178-⑤：tool_call 续期乐观忙态（= now）而非清零——
+                // 45s 兜底退化为「45s 内无任何 live 活动」，live 唯一回退恢复有效。
+                svc.optimisticBusyAt = System.currentTimeMillis()
                 if (!svc.sessionBusy) { svc.sessionBusy = true; svc.turnStartedAt = System.currentTimeMillis() }
                 svc.toolCount++
                 // 模板化显示（用户拍板）：live 行自带 name + args（bridge 0.1.1 已在产）——
@@ -110,7 +117,8 @@ class OverlayLiveFeed(private val svc: OverlayService) {
                 // 识别到自动化工具调用即自动收起面板；不自动恢复（用户点球重开），
                 // 避免恢复动作与下一发自动化点击竞态。
                 if (svc.currentToolName.startsWith("android_") && svc.expanded) svc.hidePanel()
-                svc.setHalo(Halo.WORKING)
+                // 0.13.8 G1-2（缺陷 B-2）：状态写入统一走 deriveHalo 唯一权威
+                svc.setHalo(svc.deriveHalo())
                 changed = true
               }
             }
@@ -119,6 +127,7 @@ class OverlayLiveFeed(private val svc: OverlayService) {
               // 工具结束 → 回「思考」显示（Deep diving 扫光），概览清空。
               if (svc.activeSessionId.isEmpty() || s == svc.activeSessionId) {
                 svc.currentToolName = ""; svc.currentToolSummary = ""
+                svc.optimisticBusyAt = System.currentTimeMillis() // 0.13.8 #178-⑤：活动即续期
                 changed = true
               }
             }
@@ -130,7 +139,11 @@ class OverlayLiveFeed(private val svc: OverlayService) {
                 svc.sessionBusy = false
                 svc.toolCount = 0
                 svc.currentToolName = ""; svc.currentToolSummary = ""
-                svc.setHalo(Halo.IDLE)
+                // 0.13.8 G1-2（缺陷 B-2）：turn_end 同时清理该会话的待答/待审批
+                // （轮次已结束，pending 必然过期——原实现只回白光环，卡片永挂）；
+                // 光环走 deriveHalo 唯一权威（不再直接 IDLE 绕过 PENDING）。
+                svc.panel.dropPendingFor(s)
+                svc.setHalo(svc.deriveHalo())
                 changed = true
               }
             }

--- a/app/src/main/java/com/dsharnessmobile/shell/OverlayPanel.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/OverlayPanel.kt
@@ -38,14 +38,20 @@ class OverlayPanel(private val svc: OverlayService) {
   private var sendBtn: View? = null
   private var stopBtn: View? = null
   internal var inputBox: EditText? = null
-  private var sessionPicker: Spinner? = null      // 展开态目标会话选择器（#3）
+  private var sessionPicker: TextView? = null      // 展开态目标会话行（点击开选择器窗口）
   private var pendingBox: LinearLayout? = null   // 待处理卡容器（divider 与输入行之间）
 
-  // ── 会话选择器缓存（session.list 投影） ──────────────────────────
-  private var pickerAdapter: ArrayAdapter<String>? = null
-  private val pickerLabels = ArrayList<String>()   // 「新会话」+ 会话标题/简短 id
-  private val pickerIds = ArrayList<String>()      // 与 pickerLabels 平行；空 = 新会话
-  private var pickerInit = false                   // 首次填充防 onItemSelected 误触发
+  // ── 会话选择器（0.13.8 G2 重构：独立顶层 overlay 窗口，弃 Spinner 子窗口） ──────
+  // A-R4：Spinner 下拉 = 面板 overlay 的 SUB_PANEL 子窗口，几何受父 frame/屏幕裁剪支配
+  // （「大片空白 + 滚不动」的形态来源）。新形态 = 自有 TYPE_APPLICATION_OVERLAY 窗口 +
+  // ScrollView 真滚动 + 官方可视性过滤 + 触摸反馈。
+  private var pickerWindow: View? = null
+  private var pickerRowView: LinearLayout? = null
+  private var pickerShowAll = false
+  private val pickerSessions = ArrayList<PickerSession>()
+
+  /** 治理后的会话条目（官方可见性口径过滤后）。 */
+  internal class PickerSession(val id: String, val label: String, val running: Boolean, val relative: String)
 
   // 协议（0.1.2-rc.1 dsh-api-gateway/lib/{index,client}.js 核实，0.13.3 W3）：
   // WS /api/remote.mux 上 open `$events` 流；服务端 item value 帧形：
@@ -94,10 +100,29 @@ class OverlayPanel(private val svc: OverlayService) {
     }
   }
 
+  // 0.13.8 G1（缺陷 B）：mux generation 对账——每次重连（ready 帧）换代；pending 条目
+  // 若在宽限期后仍未被新 generation 重发（引擎只重发仍 pending 的事件），判为过期丢弃。
+  private var generationId = 0
+  private val pendingGen = HashMap<String, Int>()
+
   private fun handleEventValue(value: JSONObject) {
     when (value.optString("type")) {
       "ready" -> {
         eventsClientId = value.optString("clientId", "")
+        generationId++
+        // 宽限期 3s：重发即续命；未被重发的旧条目判为过期（断线窗口内被结清的事件
+        // 永远收不到 cancel，这里是对账兜底）。
+        val stale = pendingApprovals.keys + pendingQuestions.keys
+        svc.main.postDelayed({
+          var dropped = false
+          for (id in stale) {
+            if ((pendingApprovals.containsKey(id) || pendingQuestions.containsKey(id)) && (pendingGen[id] ?: 0) < generationId) {
+              pendingApprovals.remove(id); pendingQuestions.remove(id); pendingGen.remove(id)
+              dropped = true
+            }
+          }
+          if (dropped) onPendingChanged()
+        }, 3_000)
       }
       "waterfall" -> {
         val event = value.optString("event")
@@ -107,12 +132,24 @@ class OverlayPanel(private val svc: OverlayService) {
         when (event) {
           "approval/request" -> svc.main.post {
             pendingApprovals[eventId] = PendingApproval(eventId, agentId, request.optString("toolName", ""), request.optString("reason", ""))
+            pendingGen[eventId] = generationId
             onPendingChanged()
           }
           "user-questions/request" -> svc.main.post {
             pendingQuestions[eventId] = PendingQuestion(eventId, agentId, request.optJSONArray("questions") ?: org.json.JSONArray())
+            pendingGen[eventId] = generationId
             onPendingChanged()
           }
+        }
+      }
+      "cancel" -> {
+        // 0.13.8 G1-1（缺陷 B-1）：{type:"cancel",eventId} = 引擎侧权威「该待答已结清
+        // （谁答的都算）」——本端无条件丢弃对应条目并重绘（官方浏览器客户端同款处理）。
+        val id = value.optString("eventId")
+        if (id.isNotEmpty()) svc.main.post {
+          val removed = pendingApprovals.remove(id) != null || pendingQuestions.remove(id) != null
+          pendingGen.remove(id)
+          if (removed) onPendingChanged()
         }
       }
       "emit" -> {
@@ -156,54 +193,27 @@ class OverlayPanel(private val svc: OverlayService) {
     val width = (svc.resources.displayMetrics.widthPixels - (64 * dp).toInt() - (32 * dp).toInt()).coerceAtMost((400 * dp).toInt())
     val c = themeColors()
 
-    // 目标会话选择器（#3：发消息前可明确选对话；Spinner 下拉）。默认第一项 = 「新会话」。
-    // simple_spinner_item 默认深色文字在暗色面板不可见 → 自定义 adapter 按主题着色。
-    val pickerSpinner = Spinner(svc).apply {
+    // 目标会话选择器（0.13.8 G2 重构）：一行式目标显示，点击弹出**独立顶层 overlay
+    // 窗口**（非 Spinner 子窗口——几何不再受父 frame 支配）；列表按官方可视性口径
+    // 过滤，条目带触摸反馈；选择动作即时、显式（A-R6 的 Spinner 异步回调竞态随之消失）。
+    val pickerRowText = TextView(svc).apply {
       tag = "overlay-sessionpicker"
       contentDescription = "选择发送对话"
-      // 下拉弹出层 = 独立 popup 窗口，默认方形背景 + item 各自涂底 → 圆角无从谈起。
-      // 解法：popup 窗口背景给圆角渐变底（用户要求「圆角矩形」），item 底色改透明。
-      // 注意：Spinner.popupBackground 在 Kotlin 侧是只读合成属性（无 setter 配对名），必须显式调用。
-      setPopupBackgroundDrawable(GradientDrawable().apply {
-        shape = GradientDrawable.RECTANGLE
-        cornerRadius = 16 * dp
-        setColor(if (isDarkTheme()) 0xFF1E1F24.toInt() else 0xFFFFFFFF.toInt())
-        setStroke((1 * dp).toInt(), themeColors().unitStroke)
-      })
-      adapter = object : ArrayAdapter<String>(svc, android.R.layout.simple_spinner_item, pickerLabels) {
-        override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
-          val tv = (convertView as? TextView) ?: TextView(context).apply { textSize = 13f }
-          tv.setTextColor(themeColors().idleText)
-          tv.text = getItem(position) ?: ""
-          return tv
-        }
-        override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View {
-          val tv = (convertView as? TextView) ?: TextView(context).apply {
-            textSize = 13f
-            setPadding((12 * dp).toInt(), (8 * dp).toInt(), (12 * dp).toInt(), (8 * dp).toInt())
-          }
-          val dark = isDarkTheme()
-          tv.setTextColor(if (dark) 0xFFE8EAED.toInt() else 0xFF202124.toInt())
-          tv.setBackgroundColor(Color.TRANSPARENT)   // 圆角由 popupBackground 提供（方形涂底会盖圆角）
-          tv.text = getItem(position) ?: ""
-          return tv
-        }
-      }.also { pickerAdapter = it }
-      onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
-        override fun onItemSelected(parent: AdapterView<*>?, v: View?, pos: Int, id: Long) {
-          // pickerInit 防首帧误触发；用户切换时更新发送目标（空 = 新会话）
-          if (pickerInit && pos >= 0 && pos < pickerIds.size) {
-            svc.activeSessionId = pickerIds[pos]
-            // 0.13.5：用户显式选择 = 钉住（此后不再自动跟随其它会话）
-            svc.userPinnedSession = true
-            if (svc.activeSessionId.isEmpty()) svc.sessionBusy = false
-            svc.renderPanelOnly()
-          }
-        }
-        override fun onNothingSelected(parent: AdapterView<*>?) {}
-      }
+      textSize = 13f
+      setTypeface(null, android.graphics.Typeface.BOLD)
+      setTextColor(c.idleText)
+      text = "＋ 新会话"
+      maxLines = 1
+      ellipsize = android.text.TextUtils.TruncateAt.END
+      background = DsUi.ripple(
+        DsUi.roundRect(Color.TRANSPARENT, 10 * dp, c.unitStroke),
+        if (isDarkTheme()) 0x33FFFFFF.toInt() else 0x22000000.toInt(),
+      )
+      setPadding((10 * dp).toInt(), (5 * dp).toInt(), (10 * dp).toInt(), (5 * dp).toInt())
+      setOnClickListener { togglePickerWindow() }
+      DsUi.bindPressScale(this)
     }
-    sessionPicker = pickerSpinner
+    sessionPicker = pickerRowText
 
     val status = ShimmerTextView(svc).apply {
       text = "空闲"
@@ -251,7 +261,7 @@ class OverlayPanel(private val svc: OverlayService) {
       orientation = LinearLayout.HORIZONTAL
       gravity = Gravity.CENTER_VERTICAL
       setPadding((12 * dp).toInt(), (10 * dp).toInt(), (12 * dp).toInt(), (2 * dp).toInt())
-      addView(pickerSpinner, LinearLayout.LayoutParams(0, (26 * dp).toInt(), 1f))
+      addView(pickerRowText, LinearLayout.LayoutParams(0, (26 * dp).toInt(), 1f))
       addView(close, LinearLayout.LayoutParams((20 * dp).toInt(), (20 * dp).toInt()).apply { marginStart = (8 * dp).toInt() })
     }
 
@@ -658,10 +668,21 @@ class OverlayPanel(private val svc: OverlayService) {
     val outcomeJson = JSONObject().put("kind", "result").put("value", outcome)
     postEventResult(a.eventId, outcomeJson) { accepted ->
       if (accepted) {
-        pendingApprovals.remove(a.eventId)
+        // 0.13.8 G1-4（缺陷 B-5）：受理语义与移除分离——HTTP 200 只代表已提交；
+        // 卡片保留（引擎 cancel / turn-end 收敛），15s 兜底防引擎无回执。
+        val entry = pendingApprovals[a.eventId]
+        if (entry != null) {
+          entry.submittedAt = System.currentTimeMillis()
+          svc.main.postDelayed({
+            val cur = pendingApprovals[a.eventId]
+            if (cur != null && cur.submittedAt > 0L) {
+              pendingApprovals.remove(a.eventId); pendingGen.remove(a.eventId); onPendingChanged()
+            }
+          }, 15_000)
+        }
         // 批准后轮次继续（工具真正执行），下个 live 事件前先亮工作态（同发送空窗逻辑）
         svc.markBusyOptimistic()
-        svc.flashStatus(if (outcome == "allowed-once") "已批准" else "已拒绝")
+        svc.flashStatus(if (outcome == "allowed-once") "已批准（等待引擎确认）" else "已拒绝")
         onPendingChanged()
       } else svc.flashStatus("应答失败")
     }
@@ -686,10 +707,20 @@ class OverlayPanel(private val svc: OverlayService) {
     val outcomeJson = JSONObject().put("kind", "result").put("value", value)
     postEventResult(qe.eventId, outcomeJson) { accepted ->
       if (accepted) {
-        pendingQuestions.remove(qe.eventId)
+        // 0.13.8 G1-4：受理 ≠ 移除，等引擎 cancel/turn-end 收敛（同 respondApproval）
+        val entry = pendingQuestions[qe.eventId]
+        if (entry != null) {
+          entry.submittedAt = System.currentTimeMillis()
+          svc.main.postDelayed({
+            val cur = pendingQuestions[qe.eventId]
+            if (cur != null && cur.submittedAt > 0L) {
+              pendingQuestions.remove(qe.eventId); pendingGen.remove(qe.eventId); onPendingChanged()
+            }
+          }, 15_000)
+        }
         // 作答后轮次继续，下个 live 事件前先亮工作态（同发送空窗逻辑）
         svc.markBusyOptimistic()
-        svc.flashStatus("已回答")
+        svc.flashStatus("已回答（等待引擎确认）")
         onPendingChanged()
       } else svc.flashStatus("应答失败")
     }
@@ -703,7 +734,17 @@ class OverlayPanel(private val svc: OverlayService) {
     )
     postEventResult(qe.eventId, outcomeJson) { accepted ->
       if (accepted) {
-        pendingQuestions.remove(qe.eventId)
+        // 0.13.8 G1-4：rejected 亦由引擎 cancel 收敛（同上）
+        val entry = pendingQuestions[qe.eventId]
+        if (entry != null) {
+          entry.submittedAt = System.currentTimeMillis()
+          svc.main.postDelayed({
+            val cur = pendingQuestions[qe.eventId]
+            if (cur != null && cur.submittedAt > 0L) {
+              pendingQuestions.remove(qe.eventId); pendingGen.remove(qe.eventId); onPendingChanged()
+            }
+          }, 15_000)
+        }
         svc.flashStatus("已跳过")
         onPendingChanged()
       } else svc.flashStatus("应答失败")
@@ -721,6 +762,8 @@ class OverlayPanel(private val svc: OverlayService) {
     val approvals = pendingApprovals.filterValues { it.agentId == agentId }.keys.toList()
     for (key in questions) pendingQuestions.remove(key)
     for (key in approvals) pendingApprovals.remove(key)
+    for (key in questions) pendingGen.remove(key)
+    for (key in approvals) pendingGen.remove(key)
     val dropped = questions.isNotEmpty() || approvals.isNotEmpty()
     if (dropped) onPendingChanged()
     return dropped
@@ -781,15 +824,11 @@ class OverlayPanel(private val svc: OverlayService) {
     ct.text = if (sec >= 60) "${sec / 60}分%02d秒".format(sec % 60) else "${sec}s"
   }
 
-  /** 拉取 session.list → 刷新「目标会话」下拉（第一项恒为「新会话」）。 */
+  /** session/list -> target picker data (G2: official visibility filter + label fallback chain). */
   internal fun refreshSessionPicker() {
     svc.postRpc("session/list", JSONObject().put("_request", JSONObject())) { code, body ->
-      val sp = sessionPicker ?: return@postRpc
-      val ad = pickerAdapter ?: return@postRpc
-      pickerLabels.clear(); pickerIds.clear()
-      pickerLabels.add("＋ 新会话"); pickerIds.add("")
-      // 0.13.5：未钉住时，默认选「正在工作的会话」；没有则选最近更新的非空会话（用户诉求：
-      // 打开悬浮球就该对着当前在跑的对话，而不是默认新建）。running 来自 session/list 官方字段。
+      pickerSessions.clear()
+      // 0.13.5: default target = the running session, else the most recent non-blank one.
       var runningId = ""
       var recentId = ""
       if (code == 200) {
@@ -801,37 +840,192 @@ class OverlayPanel(private val svc: OverlayService) {
               val it = arr.optJSONObject(i) ?: continue
               val sid = it.optString("sessionId", "")
               if (sid.isEmpty()) continue
+              // 0.13.8 G2 (A-R1): official visibility rules (same as ui-workspace tree.ts) —
+              // subagent sessions are invisible; blank sessions visible only when current.
+              if (it.optString("origin", "") == "subagent") continue
+              val blank = it.optBoolean("blank", false)
+              if (blank && sid != svc.activeSessionId) continue
+              val running = it.optBoolean("running", false)
+              if (runningId.isEmpty() && running) runningId = sid
+              if (recentId.isEmpty() && !blank) recentId = sid
+              // 0.13.8 G2 (A-R2) label fallback chain: title -> workspace basename ->
+              // blank session + relative time (no more "(Nth session)" placeholders).
+              // session/list already arrives sorted by updatedAt desc.
               val titleObj = it.optJSONObject("projections")?.optJSONObject("values")?.opt("title")
               val title = if (titleObj == null || titleObj === JSONObject.NULL) "" else titleObj.toString()
-                .ifBlank { "（第 ${i + 1} 个会话）" }
-              // 已选当前目标：置顶展示，便于核对
-              val label = if (sid == svc.activeSessionId) "$title（当前）" else title
-              pickerLabels.add(label); pickerIds.add(sid)
-              if (runningId.isEmpty() && it.optBoolean("running", false)) runningId = sid
-              if (recentId.isEmpty() && !it.optBoolean("blank", false)) recentId = sid
+              val cwd = it.optString("cwd", "")
+              val updated = it.optLong("updatedAt", 0L)
+              val label = when {
+                title.isNotBlank() -> title
+                cwd.isNotBlank() -> cwd.trimEnd('/').substringAfterLast('/')
+                blank -> "\u7a7a\u4f1a\u8bdd \u00b7 " + relativeTime(updated)
+                else -> "\u672a\u547d\u540d\u4f1a\u8bdd \u00b7 " + relativeTime(updated)
+              }
+              pickerSessions.add(PickerSession(sid, label, running, relativeTime(updated)))
             }
           }
         } catch (_: Exception) {}
       }
-      ad.notifyDataSetChanged()
-      // 回填当前目标会话在列表中的位置；未钉住且当前目标为空/失效时自动跟随正在工作的会话
-      var idx = pickerIds.indexOf(svc.activeSessionId)
-      if (idx < 0 && !svc.userPinnedSession) {
+      // Re-validate the target; auto-follow only when unpinned.
+      // (A-R5: agent ids from api-session/status must never be stored as session ids.)
+      if (svc.activeSessionId.isNotEmpty() && pickerSessions.none { it.id == svc.activeSessionId }) {
+        if (svc.userPinnedSession) svc.activeSessionId = ""
+      }
+      if (svc.activeSessionId.isEmpty() && !svc.userPinnedSession) {
         val follow = if (runningId.isNotEmpty()) runningId else recentId
-        if (follow.isNotEmpty()) {
-          svc.activeSessionId = follow
-          idx = pickerIds.indexOf(follow)
+        if (follow.isNotEmpty()) svc.activeSessionId = follow
+      }
+      updatePickerRowText()
+      if (pickerWindow != null) pickerRowView?.let { fillPickerRows(it) }
+    }
+  }
+
+  /** Target row text (new-session placeholder or "<label>(current)"). */
+  internal fun updatePickerRowText() {
+    val row = sessionPicker ?: return
+    val current = pickerSessions.firstOrNull { it.id == svc.activeSessionId }
+    row.text = if (svc.activeSessionId.isEmpty()) "\uff0b \u65b0\u4f1a\u8bdd"
+    else (current?.label ?: svc.activeSessionId.take(16) + "\u2026") + "\uff08\u5f53\u524d\uff09"
+  }
+
+  /** Light refresh on auto-follow (G2: no refetch, no window rebuild — marks only). */
+  internal fun refreshPickerMarks() {
+    updatePickerRowText()
+    if (pickerWindow != null) pickerRowView?.let { fillPickerRows(it) }
+  }
+
+  /** A-R5: only ids present in the visible session list may become activeSessionId. */
+  internal fun isKnownSessionId(id: String): Boolean =
+    id.isEmpty() || pickerSessions.any { it.id == id }
+
+  private fun relativeTime(ts: Long): String {
+    if (ts <= 0L) return "\u672a\u77e5\u65f6\u95f4"
+    val diff = System.currentTimeMillis() - ts
+    val m = diff / 60_000
+    return when {
+      m < 1 -> "\u521a\u521a"
+      m < 60 -> m.toString() + "\u5206\u949f\u524d"
+      m < 60 * 24 -> (m / 60).toString() + "\u5c0f\u65f6\u524d"
+      else -> (m / (60 * 24)).toString() + "\u5929\u524d"
+    }
+  }
+
+  // -- picker window (0.13.8 G2: independent TYPE_APPLICATION_OVERLAY window, not a
+  //    Spinner SUB_PANEL child of the panel whose frame geometry clipped the list). --
+
+  internal fun togglePickerWindow() {
+    if (pickerWindow != null) closePicker() else openPickerWindow()
+  }
+
+  internal fun closePicker() {
+    pickerWindow?.let { w -> try { if (w.parent != null) svc.wm.removeView(w) } catch (_: Exception) {} }
+    pickerWindow = null
+    pickerRowView = null
+  }
+
+  private fun openPickerWindow() {
+    if (pickerWindow != null) return
+    val row = sessionPicker ?: return
+    val dp = svc.resources.displayMetrics.density
+    val c = themeColors()
+    val container = LinearLayout(svc).apply {
+      orientation = LinearLayout.VERTICAL
+      background = DsUi.roundRect(if (isDarkTheme()) 0xF01E1F24.toInt() else 0xF0FFFFFF.toInt(), 14 * dp, c.unitStroke, (1 * dp).toInt())
+      elevation = 6 * dp
+    }
+    val list = LinearLayout(svc).apply { orientation = LinearLayout.VERTICAL }
+    pickerRowView = list
+    val scroll = android.widget.ScrollView(svc).apply {
+      overScrollMode = View.OVER_SCROLL_IF_CONTENT_SCROLLS // M10: stretch glow only when scrollable
+      addView(list)
+    }
+    container.addView(scroll, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f))
+    // Footer: expand-all entry (A-R3 governance: most recent 8 by default; search pending session/search wiring)
+    val footer = TextView(svc).apply {
+      text = if (!pickerShowAll && pickerSessions.size > 8) "\u5168\u90e8\u4f1a\u8bdd\uff08" + pickerSessions.size + "\uff09" else "\u5171 " + pickerSessions.size + " \u4e2a\u4f1a\u8bdd"
+      textSize = 12f
+      setTextColor(if (isDarkTheme()) 0xFF9AA0A6.toInt() else 0xFF5F6368.toInt())
+      setPadding((12 * dp).toInt(), (8 * dp).toInt(), (12 * dp).toInt(), (8 * dp).toInt())
+      if (!pickerShowAll && pickerSessions.size > 8) {
+        background = DsUi.ripple(DsUi.roundRect(Color.TRANSPARENT, 8 * dp), if (isDarkTheme()) 0x22FFFFFF.toInt() else 0x22000000.toInt())
+        setOnClickListener {
+          pickerShowAll = true
+          fillPickerRows(list)
+          text = "\u5171 " + pickerSessions.size + " \u4e2a\u4f1a\u8bdd"
         }
       }
-      pickerInit = false
-      try { sp.setSelection(if (idx >= 0) idx else 0, false) } catch (_: Exception) {}
-      pickerInit = true
+    }
+    container.addView(footer, ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT))
+    fillPickerRows(list)
+    val lp = android.view.WindowManager.LayoutParams(
+      row.width.takeIf { it > 0 } ?: (300 * dp).toInt(),
+      ViewGroup.LayoutParams.WRAP_CONTENT,
+      android.view.WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY,   // A-R4: own top-level window
+      android.view.WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or
+        android.view.WindowManager.LayoutParams.FLAG_WATCH_OUTSIDE_TOUCH,
+      android.graphics.PixelFormat.TRANSLUCENT,
+    )
+    val loc = IntArray(2)
+    row.getLocationOnScreen(loc)
+    lp.gravity = android.view.Gravity.TOP or android.view.Gravity.START
+    lp.x = loc[0]
+    lp.y = loc[1] + row.height + (4 * dp).toInt()
+    // Height cap at 45% of screen (tames unbounded lists; WRAP when short)
+    container.measure(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+    val maxH = (svc.resources.displayMetrics.heightPixels * 0.45f).toInt()
+    lp.height = container.measuredHeight.coerceAtMost(maxH)
+    container.setOnTouchListener { _, e ->
+      if (e.action == android.view.MotionEvent.ACTION_OUTSIDE) closePicker()
+      false
+    }
+    try {
+      // M2 enter animation via WMS windowAnimations (no windowExitAnimation for overlays)
+      lp.windowAnimations = R.style.OverlayPickerAnim
+      svc.wm.addView(container, lp)
+      pickerWindow = container
+    } catch (e: Exception) {
+      LogCollector.log("dsh-overlay", "picker window addView failed: " + (e.message ?: e.javaClass.simpleName))
+    }
+  }
+
+  /** Rows: new-session + governed sessions (cap 8 / all) + touch feedback. */
+  private fun fillPickerRows(list: LinearLayout) {
+    list.removeAllViews()
+    val dp = svc.resources.displayMetrics.density
+    val dark = isDarkTheme()
+    fun addRow(text: String, id: String, running: Boolean, current: Boolean) {
+      val tv = TextView(svc).apply {
+        this.text = (if (running) "\u25cf " else "") + text + (if (current) "  \u2713" else "")
+        textSize = 13f
+        setTypeface(null, if (current) android.graphics.Typeface.BOLD else android.graphics.Typeface.NORMAL)
+        setTextColor(if (dark) 0xFFE8EAED.toInt() else 0xFF202124.toInt())
+        background = DsUi.ripple(DsUi.roundRect(Color.TRANSPARENT, 8 * dp), if (dark) 0x22FFFFFF.toInt() else 0x22000000.toInt())
+        setPadding((12 * dp).toInt(), (9 * dp).toInt(), (12 * dp).toInt(), (9 * dp).toInt())
+        DsUi.bindPressScale(this)
+        setOnClickListener {
+          svc.activeSessionId = id
+          // Explicit pick = pin (0.13.5 semantics); empty pick = new session, unpin.
+          svc.userPinnedSession = id.isNotEmpty()
+          if (id.isEmpty()) svc.sessionBusy = false
+          performHapticFeedback(android.view.HapticFeedbackConstants.CONFIRM) // M9 haptics
+          closePicker()
+          updatePickerRowText()
+          svc.flashStatus(if (id.isEmpty()) "\u5df2\u5207\u6362\u5230 \u65b0\u4f1a\u8bdd" else "\u5df2\u5207\u6362\u5230 " + text.take(20))
+          svc.renderPanelOnly()
+        }
+      }
+      list.addView(tv, ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT))
+    }
+    addRow("\uff0b \u65b0\u4f1a\u8bdd", "", false, svc.activeSessionId.isEmpty())
+    val cap = if (pickerShowAll) Int.MAX_VALUE else 8
+    pickerSessions.take(cap).forEach { s ->
+      addRow(s.label, s.id, s.running, s.id == svc.activeSessionId)
     }
   }
 }
 
 /** 权限审批待处理项（0.1.2-rc.1 $events waterfall 帧投影；eventId 关联键、agentId=目标会话 id）。 */
-internal data class PendingApproval(val eventId: String, val agentId: String, val toolName: String, val reason: String)
+internal data class PendingApproval(val eventId: String, val agentId: String, val toolName: String, val reason: String, var submittedAt: Long = 0L)
 
 /** AI 提问待处理项（$events waterfall 帧投影，request.questions 原始 JSONArray）。 */
-internal data class PendingQuestion(val eventId: String, val agentId: String, val items: org.json.JSONArray)
+internal data class PendingQuestion(val eventId: String, val agentId: String, val items: org.json.JSONArray, var submittedAt: Long = 0L)

--- a/app/src/main/java/com/dsharnessmobile/shell/OverlayService.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/OverlayService.kt
@@ -474,6 +474,11 @@ class OverlayService : Service() {
       if (expanded) panel.refreshSessionPicker()
     }
     val targeted = activeSessionId.isEmpty() || agentId == activeSessionId
+    // 0.13.8 G1-5（缺陷 B-5）：pending 清理与「渲染谁」解耦——running=false 对该 agentId
+    // 无条件清 pending（否则目标一换，过期卡片永生）；targeted 只影响下面的忙态渲染。
+    if (!running) {
+      panel.dropPendingFor(agentId)
+    }
     if (!targeted) return
     if (running) {
       optimisticBusyAt = 0L

--- a/app/src/main/res/anim/picker_enter.xml
+++ b/app/src/main/res/anim/picker_enter.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 0.13.8 G3-M2：选择器窗口进场（WMS 原生播放；退场用 View 动画 + removeView，见 OverlayPanel） -->
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+  android:duration="220"
+  android:interpolator="@android:interpolator/decelerate_quad">
+  <alpha android:fromAlpha="0.0" android:toAlpha="1.0" />
+  <translate android:fromYDelta="-6%" android:toYDelta="0%" />
+</set>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -9,4 +9,7 @@
     <item name="android:textColorPrimary">@color/ds_text_primary</item>
     <item name="android:colorAccent">@color/ds_accent</item>
   </style>
+  <style name="OverlayPickerAnim">
+    <item name="android:windowEnterAnimation">@anim/picker_enter</item>
+  </style>
 </resources>


### PR DESCRIPTION
## 变更说明
0.13.8 批 G（OVERLAY-PICKER 方案落地：缺陷 B 状态收敛 + 缺陷 A 选择器重构 + G3 动效基建；M4-M8 细节动效随批 F 补齐）。

**缺陷 B（P0 正确性）**：补 cancel 帧处理（网页端作答后面板永挂的根因）；turn_end 同时清 pending + 光环统一 deriveHalo；提交态与受理分离（POST 2xx = submitted 等引擎收敛，15s 兜底）；mux generation 对账（3s 宽限未重发即过期）；targeted 解耦（running=false 无条件清该 agentId 的 pending）。

**缺陷 A（P0 可用性）**：Spinner 弃用（其下拉 = 面板 SUB_PANEL 子窗口，几何受父 frame 支配——「大片空白/滚不动」的形态来源），改为独立 TYPE_APPLICATION_OVERLAY 窗口 + ScrollView 真滚动 + 高度封顶 45%；官方可见性过滤（subagent 不进列/blank 仅当前可见）；标题回退链（title → cwd basename → 空会话·相对时间，废除序号占位）；ripple/按压/触觉反馈；默认 8 条 + 全部会话入口；A-R5 身份校验（agentId 不再劫持目标）；A-R6 Spinner 异步竞态随形态退役消失；自动跟随轻量化（不重建列表）。

**G3 动效基建**：M11 DsUi.animationsEnabled 统一降级、M1 面板圆形揭示、M2 选择器窗口进场动画、M10 overScroll、M9 触觉。

**#178 drainLive**：行边界消费（偏移 = 消费量）；tool_call/tool_result 续期乐观忙态（45s 兜底恢复有效）；删 turn_start 死分支。

## 测试
- [x] 模拟器实测（MuMu x86_64/Android 15，截图留证 .deploy-tmp/0138/picker-*.png）：面板展开（新目标行「<标题>（当前）」）→ 点选择器行 → 独立窗口弹出（真实标题列表 + ✓ 当前 + 全部会话（22）入口）→ 点选切换（窗口关闭 + 行文本更新 + flash「已切换到 …」）→ 切回原会话 全链路通过
- [x] 全套 :app:testDebugUnitTest 绿；compileDebugKotlin 绿
- [ ] CI 通过

## 破坏性变更
无（「选择发送对话」content-desc 保留；钉住/跟随语义保留）
