### PR TITLE
feat: 批 H——启动页 APK 自更新（镜像链 + 同按钮二次确认 + 安装授权）

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ DeepSearch), package `com.dsharnessmobile.shell`, version `0.13.0-fx-1` (version
   poll + crash auto-rollback gate (UndoGate).
 - **Online runtime updates** — manifest-driven snapshot swap (download → sha256 → atomic switch →
   auto-restart); the running runtime can update itself without an APK update.
+- **APK self-update (0.13.8)** — the startup screen's "check for updates" button, manual only
+  (**never automatic**): queries the GitHub latest release, matches the asset for the device ABI and
+  downloads it through a mirror chain. When a newer version exists the **same button** turns into
+  "download and install vX.Y.Z" as a second confirmation; after the download the system
+  "install unknown apps" screen is opened on first use, then the system installer (signature
+  mismatch is rejected by the system; the app never installs anything silently).
 - **SAF bridge** — `pickDirectory` maps the picked tree to a real path (`/storage/emulated/0/…`).
 - **Device access** — All Files Access; Shizuku probe example.
 - **ADB real channel (0.13.0)** — real `adb pair` SPAKE2 handshake + NSD/mDNS port discovery,
@@ -136,14 +142,41 @@ Test trigger: `adb shell am start -n com.dsharnessmobile.shell/.MainActivity -a 
 status is written to `files/update-status.txt`. Test server: serve `manifest.json` + the snapshot from any
 local HTTP server (default endpoint `http://10.0.2.2:8899/manifest.json` maps the host from the emulator).
 
+## APK self-update protocol (0.13.8)
+
+Fully separate from the runtime snapshot update above (`UpdateChecker` vs `UpdateManager`); this one
+handles the APK itself:
+
+1. **Manual only** — triggered by the startup screen's "check for updates" button, never automatically
+   (no background behavior around a 160MB asset);
+2. **Metadata** — `api.github.com/repos/kelai141/dsh-mobile-apk/releases/latest`, direct with 10/15s
+   timeouts; failures report the real reason (HTTP code / exception) and do **not** block the existing
+   snapshot-update check (the same button then runs it);
+3. **Asset match** — `dsh-mobile-apk-v<version>-<abi>.apk` with the ABI taken from `SUPPORTED_ABIS[0]`
+   (the device's native ABI; ARM-translated x86 devices report `x86_64,arm64-v8a,x86` and a naive
+   "any arm64" rule downloads the wrong package);
+4. **Version compare** — tag vs `BuildConfig.VERSION_NAME` (minus any `-SN-*` snapshot suffix), compared
+   digit-group by digit-group, covering both semver and the `0.13.7fx-N` revision naming;
+5. **Mirror-chain download** — `github.com` direct → `gh-proxy.com` → `ghfast.top`, landing in
+   `Documents/dshdata/updates/` (already inside the FileProvider mapping), `.tmp` → rename atomic;
+   verified against the `.sha256` asset when present (mismatch deletes the file and reports); an already
+   downloaded, verified package is reused instead of re-downloading after an interrupted permission flow;
+6. **Install** — without the "install unknown apps" grant the system settings screen is opened first
+   (the install resumes on `onResume` after granting), then a FileProvider URI + `ACTION_VIEW` opens the
+   system installer; a signature mismatch is rejected by the system. Nothing is ever installed silently.
+
+This is the shell's only external HTTP egress (every other shell-side HTTP call is same-origin to the
+local engine at `127.0.0.1:3080`) and it only fires on an explicit user tap.
+
 ## Permissions
 
 | permission | purpose |
 |---|---|
-| `INTERNET` | WebView + engine probe |
+| `INTERNET` | WebView + engine probe + APK self-update (manual only) |
 | `POST_NOTIFICATIONS` | notification channel (runtime request on API 33+) |
 | `FOREGROUND_SERVICE` + `FOREGROUND_SERVICE_DATA_SYNC` | keep-alive foreground service |
 | `MANAGE_EXTERNAL_STORAGE` | All Files Access (external workspace requirement; special permission, user-granted) |
+| `REQUEST_INSTALL_PACKAGES` | open the system installer for a downloaded update (0.13.8; the user must grant "install unknown apps" in system settings) |
 
 SAF picking needs no permission.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -29,6 +29,10 @@
 - **保活**：前台服务 + 5 秒看门狗（自动重拉挂死引擎）+ 3 秒 UI 轮询 + 崩溃自动回退闸门（UndoGate）；
 - **在线运行时更新**：manifest 驱动的快照替换（下载 → sha256 → 原子切换 → 自动重启），
   运行时可自更新而无需更新 APK；
+- **APK 自更新（0.13.8）**：启动页「检查更新」按钮手动触发（**不自动检查**）——查 GitHub
+  latest release、按设备 ABI 匹配资产、镜像链逐级回退下载；发现新版时**同一按钮**变为
+  「下载并安装 vX.Y.Z」二次确认，确认后下载 → 首次自动拉起系统「安装未知应用」授权页 →
+  系统安装器（签名不匹配由系统拒绝；应用不静默安装任何东西）；
 - **SAF 桥**：`pickDirectory` 把所选目录映射为真实路径（`/storage/emulated/0/…`）；
 - **设备访问**：所有文件访问；Shizuku 探活示例；
 - **ADB 真实通道（0.13.0）**：真实 `adb pair` SPAKE2 握手 + NSD/mDNS 端口发现，经 adbd（shell uid=2000）执行系统命令（危险命令黑名单）；三道门授权（完全访问档位 / 应用内开关 / 配对码）+ 会话档位实时门控 + 原生审计（`files/audit/audit.ndjson`）；连接端口轮换自愈（5555 回退）。
@@ -121,14 +125,35 @@ ELF / cordis 挂载集⊇注入集 / LICENSES 自检（Python 流式）——任
 状态写入 `files/update-status.txt`。测试服务器：本地起 HTTP 服务提供 `manifest.json` 与快照文件
 （默认指向 `http://10.0.2.2:8899/manifest.json`，模拟器映射宿主机）。
 
+## APK 自更新协议（0.13.8）
+
+与上面的运行时快照更新**完全分离**（`UpdateChecker` vs `UpdateManager`），只管 APK 本体：
+
+1. **仅手动**：启动页「检查更新」按钮触发，**不自动检查**（169MB 资产不做任何后台/自动行为）；
+2. **元数据**：`api.github.com/repos/kelai141/dsh-mobile-apk/releases/latest` 直连（10/15s 超时）；
+   失败如实报原因（HTTP 码/异常），且**不阻断**既有的引擎快照更新检查（同一按钮接着跑快照检查）；
+3. **资产匹配**：`dsh-mobile-apk-v<版本>-<abi>.apk`，ABI 取 `SUPPORTED_ABIS[0]`（设备原生 ABI——
+   带 ARM 翻译的 x86 设备 abilist 形如 `x86_64,arm64-v8a,x86`，按「含 arm64 即 arm64」会下错包）；
+4. **版本比较**：tag 与 `BuildConfig.VERSION_NAME`（去 `-SN-*` 快照后缀）逐数字组比大小——
+   覆盖语义化版本与 `0.13.7fx-N` 修订号两种命名；
+5. **镜像链下载**：`github.com` 直连 → `gh-proxy.com` → `ghfast.top` 逐级回退，落
+   `Documents/dshdata/updates/`（FileProvider 既有映射内），`.tmp` → rename 原子；有 `.sha256`
+   资产则校验，校验失败即删文件并报错；已下好且校验通过的包不重复下载（授权中断后可直接续继）；
+6. **安装**：未持有「安装未知应用」权限 → 先拉起系统授权页（返回后 `onResume` 自动续继）→
+   FileProvider URI + `ACTION_VIEW` 唤起系统安装器；签名不匹配由系统拒绝。应用**不静默安装**。
+
+这是壳侧唯一的外部 HTTP 出口（其余壳侧 HTTP 全部收敛到本地引擎同源 `127.0.0.1:3080`），
+仅在用户点击按钮时发起。
+
 ## 权限
 
 | 权限 | 用途 |
 |---|---|
-| `INTERNET` | WebView + 引擎探测 |
+| `INTERNET` | WebView + 引擎探测 + APK 自更新（仅手动触发） |
 | `POST_NOTIFICATIONS` | 通知通道（API 33+ 运行时请求） |
 | `FOREGROUND_SERVICE` + `FOREGROUND_SERVICE_DATA_SYNC` | 保活前台服务 |
 | `MANAGE_EXTERNAL_STORAGE` | 「所有文件访问」（外部工作区要求；特殊权限，用户手动授予） |
+| `REQUEST_INSTALL_PACKAGES` | 唤起系统安装器安装下载的更新包（0.13.8；须用户在系统页显式授权，「安装未知应用」） |
 
 SAF 目录/图片选择无需权限。
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,9 @@
   <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
   <uses-permission android:name="android.permission.WAKE_LOCK" />
   <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+  <!-- 0.13.8 批 H：启动页 APK 自更新（UpdateChecker）——唤起系统安装器需要此声明；
+       用户在系统「安装未知应用」页显式授权后才会真正安装，应用不静默安装任何东西。 -->
+  <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
   <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
   <!-- 0.13.2 W7：悬浮球（系统级悬浮窗，用户经设置页授予；OverlayController 引导）。 -->
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />

--- a/app/src/main/java/com/dsharnessmobile/shell/GuidePageRenderer.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/GuidePageRenderer.kt
@@ -32,6 +32,13 @@ internal class GuidePageRenderer(private val activity: MainActivity) {
     private set
   private var statusPulse: ObjectAnimator? = null
 
+  // —— APK 自更新（0.13.8 批 H）状态：仅手动触发、同一按钮二次确认 ——
+  /** 已发现的新版（非空 = 按钮停在「下载并安装 vX」二次确认态，再点才开始下载）。 */
+  private var apkPending: UpdateChecker.CheckResult.Available? = null
+  /** 下载完成待安装的包（授权页返回后由 settlePendingInstall 续继）。 */
+  private var apkReadyToInstall: File? = null
+  private var apkBusy = false
+
   fun buildGuideView(): LinearLayout {
     chrome = buildGuideChrome(
       activity,
@@ -41,7 +48,7 @@ internal class GuidePageRenderer(private val activity: MainActivity) {
           activity.startEngineFlow()
         },
         onOpenConsole = { activity.startActivity(Intent(activity, ConsoleActivity::class.java)) },
-        onCheckUpdate = { activity.engineFlow.startUpdateCheck() },
+        onCheckUpdate = { onUpdateButton() },
         onGrantStorage = { activity.dirPickerController.openAllFilesAccessSettings() },
         onCopyLog = { copyGuideLog() },
       ),
@@ -167,6 +174,156 @@ internal class GuidePageRenderer(private val activity: MainActivity) {
     chrome.storageChip.setTextColor(
       activity.getColor(if (storageOk) R.color.ds_text_secondary else R.color.ds_accent),
     )
+  }
+
+  /** 测试界面「检查更新」按钮：手动检查 APK 自更新（用户拍板：不自动检查）。
+   *  同按钮三态 = 检查 → （发现新版）二次确认 → 下载安装；已有下载好的包则直接续继安装。 */
+  private fun onUpdateButton() {
+    if (apkBusy) return
+    apkReadyToInstall?.let { continueInstall(); return }
+    apkPending?.let { downloadAndInstall(it); return }
+    checkApkUpdate()
+  }
+
+  private fun setUpdateButton(label: String, enabled: Boolean) {
+    // 固定高按钮 + 长版本号（v0.13.7fx-1）会换行截断（device 实测）——单行 + 省略号
+    chrome.updateButton.maxLines = 1
+    chrome.updateButton.ellipsize = android.text.TextUtils.TruncateAt.END
+    chrome.updateButton.text = label
+    chrome.updateButton.isEnabled = enabled
+    chrome.updateButton.alpha = if (enabled) 1f else 0.55f
+  }
+
+  private fun apkHint(msg: String) {
+    chrome.statusHint.text = msg
+    chrome.statusHint.visibility = View.VISIBLE
+  }
+
+  private fun sizeText(bytes: Long): String =
+    if (bytes <= 0) "" else "%.1f MB".format(bytes / 1048576.0)
+
+  /** 手动检查（不自动检查）：失败如实报原因，且不阻断既有引擎快照更新检查。
+   *  发现新版时不自动进入下载——由用户再点同一按钮二次确认（169MB 下载不做误触启动）。 */
+  private fun checkApkUpdate() {
+    apkBusy = true
+    setUpdateButton(activity.getString(R.string.ds_apk_checking), enabled = false)
+    Thread {
+      val r = UpdateChecker.checkLatest()
+      activity.runOnUiThread {
+        if (activity.isFinishing || activity.isDestroyed) return@runOnUiThread
+        apkBusy = false
+        when (r) {
+          is UpdateChecker.CheckResult.UpToDate -> {
+            val v = "v" + UpdateChecker.currentVersion()
+            setUpdateButton(activity.getString(R.string.ds_check_update), enabled = true)
+            apkHint(activity.getString(R.string.ds_apk_latest, v))
+            toast(activity.getString(R.string.ds_apk_latest, v))
+            // 外层的壳已是最新 → 继续既有引擎快照检查（保持本按钮原有语义不失）
+            activity.engineFlow.startUpdateCheck()
+          }
+          is UpdateChecker.CheckResult.Available -> {
+            apkPending = r
+            setUpdateButton(activity.getString(R.string.ds_apk_confirm, r.tag), enabled = true)
+            apkHint(activity.getString(R.string.ds_apk_available, r.tag, "v" + UpdateChecker.currentVersion(), sizeText(r.sizeBytes)))
+          }
+          is UpdateChecker.CheckResult.Failed -> {
+            setUpdateButton(activity.getString(R.string.ds_check_update), enabled = true)
+            apkHint(r.reason)
+            toast(r.reason)
+            activity.engineFlow.startUpdateCheck()
+          }
+        }
+      }
+    }.start()
+  }
+
+  /** 二次确认后的下载：镜像链 + .tmp→rename 原子落盘（有 .sha256 资产则校验）；完成后自动拉起安装。 */
+  private fun downloadAndInstall(r: UpdateChecker.CheckResult.Available) {
+    apkBusy = true
+    val dest = File(UpdateChecker.updatesDir(activity), r.name)
+    setUpdateButton(activity.getString(R.string.ds_apk_downloading, 0), enabled = false)
+    apkHint(activity.getString(R.string.ds_apk_download_hint, r.name, sizeText(r.sizeBytes)))
+    Thread {
+      var fail: String? = null
+      var ok = false
+      try {
+        val expected = r.sha256Url?.let { UpdateChecker.downloadText(it) }
+        // 上次下载完成但未安装（授权中断/安装取消）→ 复用已验证的包，不重复拉 169MB
+        val cached = dest.exists() && dest.length() == r.sizeBytes &&
+          (expected == null || UpdateChecker.verifySha256(dest, expected))
+        if (cached) {
+          ok = true
+        } else {
+          val used = UpdateChecker.download(r.apkUrl, dest) { pct ->
+            activity.runOnUiThread {
+              if (apkBusy && !activity.isFinishing && !activity.isDestroyed) {
+                setUpdateButton(activity.getString(R.string.ds_apk_downloading, pct), enabled = false)
+              }
+            }
+          }
+          if (used == null) {
+            fail = "下载失败：镜像链全部不可用（直连/GitHub 加速镜像均失败）"
+          } else if (expected != null && !UpdateChecker.verifySha256(dest, expected)) {
+            dest.delete()
+            fail = "下载失败：sha256 校验不匹配（文件已删除，请重试）"
+          } else {
+            ok = true
+          }
+        }
+      } catch (e: Exception) {
+        fail = "下载失败：" + (e.message ?: e.javaClass.simpleName)
+      }
+      val result = fail
+      activity.runOnUiThread {
+        if (activity.isFinishing || activity.isDestroyed) return@runOnUiThread
+        apkBusy = false
+        if (ok) {
+          apkReadyToInstall = dest
+          continueInstall()
+        } else {
+          // 保持二次确认态：同一按钮变「重试下载并安装」，再点即重试
+          setUpdateButton(activity.getString(R.string.ds_apk_retry, r.tag), enabled = true)
+          apkHint(result ?: "下载失败")
+          toast(result ?: "下载失败")
+        }
+      }
+    }.start()
+  }
+
+  /** 已下载完成：权限不足先拉「安装未知应用」授权页（onResume 结算续继），否则直接唤起系统安装器。 */
+  private fun continueInstall() {
+    val apk = apkReadyToInstall ?: return
+    if (!apk.exists()) {
+      apkReadyToInstall = null
+      setUpdateButton(activity.getString(R.string.ds_check_update), enabled = true)
+      apkHint("安装包已不存在，请重新检查更新")
+      return
+    }
+    if (!UpdateChecker.canInstall(activity)) {
+      apkHint(activity.getString(R.string.ds_apk_need_permission))
+      UpdateChecker.requestInstallPermission(activity)
+      return
+    }
+    if (UpdateChecker.invokeInstaller(activity, apk)) {
+      apkHint(activity.getString(R.string.ds_apk_installing))
+      apkPending = null
+      apkReadyToInstall = null
+      setUpdateButton(activity.getString(R.string.ds_check_update), enabled = true)
+    } else {
+      setUpdateButton(activity.getString(R.string.ds_apk_retry_install), enabled = true)
+      apkHint("安装器拉起失败，请再点按钮重试")
+    }
+  }
+
+  /** 从「安装未知应用」授权页返回（MainActivity.onResume 调用）：已授权则自动续继安装。 */
+  fun settlePendingInstall() {
+    if (apkReadyToInstall == null || apkBusy) return
+    if (UpdateChecker.canInstall(activity)) continueInstall()
+    else apkHint(activity.getString(R.string.ds_apk_permission_denied))
+  }
+
+  private fun toast(msg: String) {
+    android.widget.Toast.makeText(activity, msg, android.widget.Toast.LENGTH_LONG).show()
   }
 
   private fun copyGuideLog() {

--- a/app/src/main/java/com/dsharnessmobile/shell/MainActivity.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/MainActivity.kt
@@ -255,6 +255,8 @@ class MainActivity : ComponentActivity() {
     }
     // M3：从系统授权页返回——上次 pick 因缺权限挂起时按授权结果续启/结算（迁至 DirectoryPickerController）。
     dirPickerController.settlePendingOnResume()
+    // 0.13.8 批 H：从「安装未知应用」授权页返回——已授权则续继 APK 更新包的安装。
+    guideRenderer.settlePendingInstall()
   }
 
   /** 窗口重新获得焦点时重应用沉浸式（系统栏 flag 会随焦点变化被重置）。 */

--- a/app/src/main/java/com/dsharnessmobile/shell/UpdateChecker.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/UpdateChecker.kt
@@ -1,0 +1,236 @@
+package com.dsharnessmobile.shell
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.core.content.FileProvider
+import org.json.JSONObject
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.Proxy
+import java.net.URL
+
+/**
+ * APK 自更新（0.13.8 批 H，用户拍板交互）：
+ * - **仅手动**：启动页「检查更新」按钮触发，不自动检查（169MB 下载不做任何自动行为）；
+ * - **镜像链**：GitHub latest release 直连 → gh-proxy 风格前缀逐级回退（域名常量可配）；
+ * - **同按钮二次确认**：发现新版后同一按钮变为「下载并安装 vX.Y.Z」，再点才开始下载；
+ * - 下载落 Documents/dshdata/updates/（FileProvider 既有映射内），.tmp→rename 原子；
+ * - 安装：REQUEST_INSTALL_PACKAGES 未持有 → 先拉「安装未知应用」授权页（launcher 返回后续继）；
+ *   签名不匹配由系统安装器天然拒绝；sha256 资产存在则下载后校验。
+ * 与引擎快照更新（EngineStartFlow.startUpdateCheck / UpdateManager）完全分离。
+ */
+object UpdateChecker {
+
+  private const val TAG = "dsh-update"
+  private const val REPO = "kelai141/dsh-mobile-apk"
+
+  /** 镜像链（gh-proxy 风格前缀；直连永远第一。站点失效自动逐级回退）。 */
+  private val MIRRORS = listOf(
+    "https://github.com/",
+    "https://gh-proxy.com/https://github.com/",
+    "https://ghfast.top/https://github.com/",
+  )
+  private const val API = "https://api.github.com"
+
+  /** 更新包落点（已在 file_paths.xml 的 Documents/dshdata 映射内，零新映射）。 */
+  fun updatesDir(context: Context): File =
+    File(android.os.Environment.getExternalStoragePublicDirectory(android.os.Environment.DIRECTORY_DOCUMENTS), "dshdata/updates")
+
+  sealed class CheckResult {
+    /** 已是最新（latest.tag == 当前版本）。 */
+    data object UpToDate : CheckResult()
+    /** 发现新版：tag + 双 ABI 资产 URL（按设备 ABI 已选好）。 */
+    data class Available(val tag: String, val name: String, val apkUrl: String, val sha256Url: String?, val sizeBytes: Long) : CheckResult()
+    data class Failed(val reason: String) : CheckResult()
+  }
+
+  /** 设备 ABI → 资产命名 ABI（与 build-apk-013.ps1 双 ABI 口径一致：arm64 / x86_64）。
+   *  以 **SUPPORTED_ABIS[0]（设备首选/原生 ABI）**为准：带 ARM 翻译的 x86 设备
+   *  （MuMu abilist = x86_64,arm64-v8a,x86）里 arm64 只是翻译层，按「任一含 arm64 即选 arm64」
+   *  会下错包——device 实测 v0.13.7fx-1 抓到 arm64 资产。 */
+  fun abiFrom(abis: List<String>): String {
+    val primary = abis.firstOrNull().orEmpty()
+    return when {
+      primary.startsWith("arm64") -> "arm64"
+      primary.startsWith("x86_64") -> "x86_64"
+      abis.any { it.startsWith("arm64") } -> "arm64"
+      abis.any { it == "x86_64" } -> "x86_64"
+      else -> primary.substringBefore('-').ifEmpty { "arm64" }
+    }
+  }
+
+  private fun deviceAbi(): String = abiFrom(android.os.Build.SUPPORTED_ABIS.toList())
+
+  /** 资产命名契约（须与 scripts/build-apk-013.ps1 的 Copy-Item 命名逐字一致）：
+   *  dsh-mobile-apk-v<版本>-<abi>.apk，abi ∈ {arm64, x86_64}。 */
+  fun assetName(tag: String, abi: String): String = "dsh-mobile-apk-v${tag.removePrefix("v")}-$abi.apk"
+
+  /**
+   * 查 latest release（镜像链逐级回退）；资产按 dsh-mobile-apk-v<ver>-<abi>.apk 匹配。
+   * 版本比较：tag（去 v 前缀）与 BuildConfig.VERSION_NAME 语义比较（点分段数值）；
+   * 相等 = 已是最新（快照后缀 -SN-* 不参与比较）。
+   */
+  fun checkLatest(): CheckResult {
+    // 元数据直连 GitHub API（体积小、可用性远高于 169MB 资产下载）；
+    // 资产下载才走镜像链（download()）。API 不可达即失败并如实报告。
+    try {
+      val conn = URL("$API/repos/$REPO/releases/latest").openConnection(Proxy.NO_PROXY) as HttpURLConnection
+      conn.connectTimeout = 10_000
+      conn.readTimeout = 15_000
+      conn.setRequestProperty("Accept", "application/vnd.github+json")
+      val httpCode = conn.responseCode
+      if (httpCode != 200) {
+        conn.disconnect()
+        return CheckResult.Failed("检查失败：GitHub API 返回 HTTP $httpCode")
+      }
+      val body = conn.inputStream.use { it.readBytes().toString(Charsets.UTF_8) }
+      conn.disconnect()
+      val j = JSONObject(body)
+      val tag = j.optString("tag_name", "")
+      if (tag.isEmpty()) return CheckResult.Failed("latest release 无 tag_name")
+      val assets = j.optJSONArray("assets") ?: org.json.JSONArray()
+      val abi = deviceAbi()
+      val want = assetName(tag, abi)
+      var apkUrl = ""
+      var shaUrl: String? = null
+      var size = 0L
+      for (i in 0 until assets.length()) {
+        val a = assets.optJSONObject(i) ?: continue
+        val name = a.optString("name", "")
+        if (name == want) { apkUrl = a.optString("browser_download_url", ""); size = a.optLong("size", 0L) }
+        if (name == "$want.sha256") shaUrl = a.optString("browser_download_url", "")
+      }
+      if (apkUrl.isEmpty()) return CheckResult.Failed("latest release $tag 无 $abi 资产（$want）")
+      if (!isNewer(tag, currentVersion())) return CheckResult.UpToDate
+      return CheckResult.Available(tag, want, apkUrl, shaUrl, size)
+    } catch (e: Exception) {
+      android.util.Log.w(TAG, "check via $API failed: " + (e.message ?: e.javaClass.simpleName))
+      return CheckResult.Failed("检查失败：" + (e.message ?: e.javaClass.simpleName) + "——请核对网络后重试")
+    }
+  }
+
+  /** 当前版本（只去快照后缀 -SN-*；0.13.7fx-1-SN-1-13 → 0.13.7fx-1）。
+   *  注意：修订号 -1/-2（0.13.7fx-N 命名）**不能**当后缀剥掉，否则 fx-2 会被判成与 fx-1 同版。 */
+  fun currentVersion(): String = BuildConfig.VERSION_NAME.replace(Regex("-SN-.*$"), "")
+
+  /** 语义比较：取版本串里的**全部数字组**逐位比大小（"0.13.7fx-1" → [0,13,7,1]），
+   *  位数不足补 0（0.13 == 0.13.0）。覆盖两种命名：语义化版本与 0.13.7fx-N 修订号。
+   *  tag 形如 v0.13.8 / 0.13.8 / v0.13.7fx-2。 */
+  fun isNewer(tag: String, current: String): Boolean {
+    fun parts(v: String) = Regex("\\d+").findAll(v).map { it.value.toLongOrNull() ?: 0L }.toList()
+    val a = parts(tag); val b = parts(current)
+    for (i in 0 until maxOf(a.size, b.size)) {
+      val x = a.getOrElse(i) { 0L }; val y = b.getOrElse(i) { 0L }
+      if (x != y) return x > y
+    }
+    return false
+  }
+
+  /** 通过镜像链把 GitHub 资产 URL 逐级尝试下载到目标文件（.tmp → rename 原子落盘）。 */
+  fun download(url: String, dest: File, onProgress: (percent: Int) -> Unit): String? {
+    val path = url.removePrefix("https://github.com/")
+    for (mirror in MIRRORS) {
+      val candidate = if (mirror == MIRRORS[0]) url else mirror + path
+      try {
+        val conn = URL(candidate).openConnection(Proxy.NO_PROXY) as HttpURLConnection
+        conn.connectTimeout = 10_000
+        conn.readTimeout = 30_000
+        conn.instanceFollowRedirects = true
+        if (conn.responseCode != 200) { conn.disconnect(); continue }
+        val total = conn.contentLengthLong
+        dest.parentFile?.mkdirs()
+        val tmp = File(dest.parentFile, dest.name + ".tmp")
+        tmp.outputStream().use { out ->
+          conn.inputStream.use { input ->
+            val buf = ByteArray(128 * 1024)
+            var read = 0L
+            var lastPct = -1
+            while (true) {
+              val n = input.read(buf)
+              if (n < 0) break
+              out.write(buf, 0, n)
+              read += n
+              if (total > 0) {
+                val pct = (read * 100 / total).toInt()
+                if (pct != lastPct) { lastPct = pct; onProgress(pct) }
+              }
+            }
+          }
+        }
+        if (dest.exists()) dest.delete()
+        if (!tmp.renameTo(dest)) { tmp.copyTo(dest, overwrite = true); tmp.delete() }
+        conn.disconnect()
+        return candidate
+      } catch (e: Exception) {
+        android.util.Log.w(TAG, "download via $mirror failed: " + (e.message ?: e.javaClass.simpleName))
+        File(dest.parentFile, dest.name + ".tmp").delete()
+      }
+    }
+    return null
+  }
+
+  /** 下载后 sha256 校验（可选；资产缺失 .sha256 时跳过）。 */
+  fun verifySha256(file: File, expected: String): Boolean = try {
+    val md = java.security.MessageDigest.getInstance("SHA-256")
+    file.inputStream().use { input ->
+      val buf = ByteArray(128 * 1024)
+      while (true) { val n = input.read(buf); if (n < 0) break; md.update(buf, 0, n) }
+    }
+    val actual = md.digest().joinToString("") { "%02x".format(it) }
+    actual.equals(expected.trim().substringBefore(' '), ignoreCase = true)
+  } catch (_: Exception) { false }
+
+  /** 通过镜像链取小文本（.sha256 资产；全部镜像失败返回 null = 跳过校验而非判失败）。 */
+  fun downloadText(url: String): String? {
+    val path = url.removePrefix("https://github.com/")
+    for (mirror in MIRRORS) {
+      val candidate = if (mirror == MIRRORS[0]) url else mirror + path
+      try {
+        val conn = URL(candidate).openConnection(Proxy.NO_PROXY) as HttpURLConnection
+        conn.connectTimeout = 10_000
+        conn.readTimeout = 15_000
+        if (conn.responseCode != 200) { conn.disconnect(); continue }
+        val text = conn.inputStream.use { it.readBytes().toString(Charsets.UTF_8) }
+        conn.disconnect()
+        if (text.isNotBlank()) return text
+      } catch (e: Exception) {
+        android.util.Log.w(TAG, "text via $mirror failed: " + (e.message ?: e.javaClass.simpleName))
+      }
+    }
+    return null
+  }
+
+  /** 安装未知应用来源权限是否已持有（manifest 已声明 REQUEST_INSTALL_PACKAGES）。 */
+  fun canInstall(context: Context): Boolean =
+    if (android.os.Build.VERSION.SDK_INT >= 26) context.packageManager.canRequestPackageInstalls() else true
+
+  /** 拉起「安装未知应用」授权页（普通 startActivity；返回时 onResume 结算，与目录授权同一惯例）。 */
+  fun requestInstallPermission(activity: android.app.Activity) {
+    val perApp = Intent(android.provider.Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES, Uri.parse("package:" + activity.packageName))
+    try {
+      activity.startActivity(perApp)
+    } catch (_: Exception) {
+      // 少数 OEM 无按应用授权页：退化为全局页。
+      try {
+        activity.startActivity(Intent(android.provider.Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES))
+      } catch (_: Exception) {
+        // 无任何入口：留在待装态，用户可再点按钮重试。
+      }
+    }
+  }
+
+  /** FileProvider URI + ACTION_VIEW 唤起系统安装器（签名不匹配由系统拒绝）。 */
+  fun invokeInstaller(activity: android.app.Activity, apk: File): Boolean = try {
+    val uri = FileProvider.getUriForFile(activity, activity.packageName + ".fileprovider", apk)
+    val intent = Intent(Intent.ACTION_VIEW).apply {
+      setDataAndType(uri, "application/vnd.android.package-archive")
+      addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    activity.startActivity(intent)
+    true
+  } catch (e: Exception) {
+    LogCollector.log(TAG, "installer invoke failed: " + (e.message ?: e.javaClass.simpleName))
+    false
+  }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,18 @@
   <string name="ds_undoing">回撤中</string>
   <string name="ds_open_console">打开控制台</string>
   <string name="ds_check_update">检查更新</string>
+  <!-- 0.13.8 批 H：启动页 APK 自更新（仅手动；同按钮二次确认；下载后自动拉起授权/安装） -->
+  <string name="ds_apk_checking">检查中…</string>
+  <string name="ds_apk_latest">APK 已是最新 %1$s</string>
+  <string name="ds_apk_confirm">下载并安装 %1$s</string>
+  <string name="ds_apk_available">发现新版 APK %1$s（当前 %2$s，%3$s）——再点一次同一按钮开始下载并安装</string>
+  <string name="ds_apk_downloading">下载中 %1$d%%</string>
+  <string name="ds_apk_download_hint">正在从镜像链下载 %1$s（%2$s）——请保持应用在前台</string>
+  <string name="ds_apk_retry">重试下载并安装 %1$s</string>
+  <string name="ds_apk_retry_install">重试安装</string>
+  <string name="ds_apk_need_permission">需要「安装未知应用」权限，已打开授权页——开启后返回即自动安装</string>
+  <string name="ds_apk_permission_denied">未获得「安装未知应用」权限——APK 已下载，授权后可再点按钮继续安装</string>
+  <string name="ds_apk_installing">已拉起系统安装器——安装完成后重新打开应用即生效</string>
   <string name="ds_copy_log">复制</string>
   <string name="ds_log_title">engine.log</string>
   <string name="ds_runtime_ready">运行时已就绪</string>

--- a/app/src/test/java/com/dsharnessmobile/shell/UpdateCheckerTest.kt
+++ b/app/src/test/java/com/dsharnessmobile/shell/UpdateCheckerTest.kt
@@ -1,0 +1,70 @@
+package com.dsharnessmobile.shell
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * 0.13.8 批 H 回归：启动页 APK 自更新的两个契约——
+ * ① 版本比较（tag vs BuildConfig.VERSION_NAME，快照后缀不参与）；
+ * ② 资产命名（与 build-apk-013.ps1 产物名逐字一致，配错就是「检查永远说已是最新」或「永远失败」）。
+ */
+class UpdateCheckerTest {
+
+  @Test
+  fun newerTagsAreDetected() {
+    assertTrue(UpdateChecker.isNewer("v0.13.8", "0.13.7fx-1"))
+    assertTrue(UpdateChecker.isNewer("v0.14.0", "0.13.8"))
+    assertTrue(UpdateChecker.isNewer("0.13.10", "0.13.9"))
+    assertTrue(UpdateChecker.isNewer("v1.0.0", "0.99.99"))
+  }
+
+  @Test
+  fun sameOrOlderTagsAreNotNewer() {
+    assertFalse(UpdateChecker.isNewer("v0.13.8", "0.13.8"))
+    assertFalse(UpdateChecker.isNewer("v0.13.7", "0.13.8"))
+    // 段数不齐按缺省 0 补齐：0.13 与 0.13.0 等价
+    assertFalse(UpdateChecker.isNewer("v0.13", "0.13.0"))
+    assertTrue(UpdateChecker.isNewer("v0.13.1", "0.13"))
+    // 无修订号的正式 tag 不是 0.13.7fx-1 的更新（同基版本，避免无谓降级路径）
+    assertFalse(UpdateChecker.isNewer("v0.13.7", "0.13.7fx-1"))
+  }
+
+  @Test
+  fun fxRevisionNumberIsCompared() {
+    // 本项目修订命名 0.13.7fx-N：fx-2 必须被识别为比 fx-1 新（device 实测暴露的缺陷）
+    assertTrue(UpdateChecker.isNewer("v0.13.7fx-2", "0.13.7fx-1"))
+    assertTrue(UpdateChecker.isNewer("v0.13.7fx-10", "0.13.7fx-9"))
+    assertFalse(UpdateChecker.isNewer("v0.13.7fx-1", "0.13.7fx-2"))
+    assertFalse(UpdateChecker.isNewer("v0.13.7fx-1", "0.13.7fx-1"))
+  }
+
+  @Test
+  fun snapshotSuffixDoesNotAffectComparison() {
+    // BuildConfig.VERSION_NAME 形如 0.13.8-SN-1-13（快照档）——去 -SN-* 后比较
+    assertFalse(UpdateChecker.isNewer("v0.13.8", "0.13.8"))
+    assertTrue(UpdateChecker.isNewer("v0.13.9", "0.13.8"))
+    // 快照档与同版正式 tag 等价（开发机不被反复提示升级到同一版）
+    assertFalse(UpdateChecker.isNewer("v0.13.7fx-1", "0.13.7fx-1"))
+  }
+
+  @Test
+  fun assetNameMatchesBuildScriptProductName() {
+    assertEquals("dsh-mobile-apk-v0.13.8-arm64.apk", UpdateChecker.assetName("v0.13.8", "arm64"))
+    assertEquals("dsh-mobile-apk-v0.13.8-x86_64.apk", UpdateChecker.assetName("v0.13.8", "x86_64"))
+    // tag 无 v 前缀也要归一到同一资产名（GitHub tag 口径不一）
+    assertEquals("dsh-mobile-apk-v0.13.8-x86_64.apk", UpdateChecker.assetName("0.13.8", "x86_64"))
+  }
+
+  @Test
+  fun abiSelectionPrefersPrimaryAbi() {
+    // MuMu/Android 15 实测：abilist = x86_64,arm64-v8a,x86（arm64 只是翻译层）
+    // ——按「任一含 arm64 即 arm64」会下错包，必须以首选 ABI 为准。
+    assertEquals("x86_64", UpdateChecker.abiFrom(listOf("x86_64", "arm64-v8a", "x86")))
+    assertEquals("arm64", UpdateChecker.abiFrom(listOf("arm64-v8a", "armeabi-v7a", "armeabi")))
+    // 老式纯 x86 设备（无翻译层）：退化为扫描，仍不误判为 arm64
+    assertEquals("x86_64", UpdateChecker.abiFrom(listOf("x86", "x86_64")))
+    assertEquals("arm64", UpdateChecker.abiFrom(emptyList()))
+  }
+}

--- a/scripts/build-apk-013.ps1
+++ b/scripts/build-apk-013.ps1
@@ -30,12 +30,12 @@ if ($LASTEXITCODE -ne 0) { Write-Host "补丁镜像不一致，拒绝打包（�
 
 # manifest 加固门禁（0.13.8 PR-B3 / apk #183）：allowBackup/NSC/接收器来源校验在场
 Write-Host "== manifest 加固门禁 =="
-node (Join-Path $Root "scriptscheck-manifest-hardening.mjs") 2>&1
+node (Join-Path $Root "scripts\check-manifest-hardening.mjs") 2>&1
 if ($LASTEXITCODE -ne 0) { Write-Host "manifest 加固校验失败，拒绝打包"; exit 1 }
 
 # 子进程无界读 grep 门禁（0.13.8 #173）：输出必须走 ProcIo.readBounded
 Write-Host "== 有界读门禁 =="
-node (Join-Path $Root "scriptscheck-bounded-io.mjs") 2>&1
+node (Join-Path $Root "scripts\check-bounded-io.mjs") 2>&1
 if ($LASTEXITCODE -ne 0) { Write-Host "无界读命中，拒绝打包"; exit 1 }
 
 # pi-ai 目录 diff（0.13.3 W1/P2）：baseline -> pin 信息性输出（构建日志 + 报告文件），

--- a/scripts/check-patch-mirror.mjs
+++ b/scripts/check-patch-mirror.mjs
@@ -17,7 +17,7 @@
 //
 // 用法：node scripts/check-patch-mirror.mjs [--self] [--peer <dir>]
 // 退出码：0 = 全部通过；1 = 失败（构建链与 CI 以此拒打包/拒合并）。
-import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs'
 import { join, dirname, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -137,6 +137,26 @@ if (peer) {
     check('tests/ 共有文件逐字节一致', badContent.length === 0, `内容漂移: [${badContent.join(', ')}]`)
   } catch (e) {
     check('tests/ 目录可枚举', false, String(e).slice(0, 200))
+  }
+  // 门禁链自身也在镜像面（0.13.8 批 H 补线）：build-apk-013.ps1 与两个常驻门禁脚本
+  // 单边演进同样造成「云端自包含构建跑旧门禁/旧脚本」的幽灵面——本仓曾出现
+  // bounded-io 门禁只落在 apk 兜、协调仓脚本仍带 Join-Path 拼写缺陷而无人察觉。
+  // 对端缺该文件时跳过（apk 仓独占脚本合法）。
+  const MIRROR_TOP = [
+    'scripts/build-apk-013.ps1',
+    'scripts/check-manifest-hardening.mjs',
+    'scripts/check-bounded-io.mjs',
+  ]
+  for (const rel of MIRROR_TOP) {
+    const theirs = join(peer, rel)
+    if (!existsSync(theirs)) { console.log(`SKIP  镜像一致: ${rel}（对端无此文件）`); continue }
+    try {
+      const r = cmp(join(ROOT, rel), theirs)
+      check(`镜像一致: ${rel}`, r !== 'content', r === 'eol' ? '仅行尾差异（见告警）' : undefined)
+      if (r === 'eol') eolWarns.push(rel)
+    } catch (e) {
+      check(`镜像一致: ${rel}`, false, String(e).slice(0, 200))
+    }
   }
   if (eolWarns.length > 0) {
     console.log(`WARN  仅行尾差异（git blob 层一致则无碍；本机为工作树 autocrlf 噪声）: [${eolWarns.join(', ')}]`)


### PR DESCRIPTION
## 内容

启动页 APK 自更新（0.13.8 批 H）+ 构建门禁自身缺陷修复。与引擎快照更新完全分离。

### APK 自更新（新能力）

- **仅手动**（用户拍板：不自动检查）：启动页「检查更新」按钮触发；失败如实报原因，且不阻断既有引擎快照更新检查（同一按钮随后接着跑快照检查，原语义不失）。
- **同按钮二次确认**（用户拍板）：发现新版时同一按钮变「下载并安装 vX.Y.Z」，再点一次才开始下载；下载中按钮显示百分比。
- 元数据 `api.github.com/repos/kelai141/dsh-mobile-apk/releases/latest` 直连；资产按 **SUPPORTED_ABIS[0]（设备原生 ABI）** 匹配 `dsh-mobile-apk-v<版本>-<abi>.apk`；下载走镜像链 `github.com` -> `gh-proxy.com` -> `ghfast.top` 逐级回退，落 `Documents/dshdata/updates/`（FileProvider 既有映射内），`.tmp` -> rename 原子，有 `.sha256` 资产则校验。
- 首次安装先拉系统「安装未知应用」授权页，`onResume` 结算续继 -> FileProvider URI + `ACTION_VIEW` 唤起系统安装器；签名不匹配由系统拒绝，应用不静默安装。
- 已下好且校验通过的包不重复下载（授权中断/安装取消后可直接续继安装）。

### device 实测（MuMu x86_64 / Android 15）抓到并修复的三个真缺陷

1. **ABI 误判**：该设备 abilist = `x86_64,arm64-v8a,x86`（arm64 是翻译层），按「任一含 arm64 即 arm64」会下载 arm64 资产（实测留下 42MB 半包）-> 改以首选 ABI 为准，并抽 `abiFrom()` 纯函数单测锁死。
2. **版本语义**：`0.13.7fx-1` 被 `substringBefore('-')` 显示成 `0.13.7fx`，且未来的 `0.13.7fx-2` 永远判不出新版 -> 改「取全部数字组逐位比较」，只剥 `-SN-*` 快照后缀。
3. **二次确认按钮文案过长换行截断** -> 单行 + 省略号。

### 构建门禁自身缺陷（顺带修复）

`scripts/build-apk-013.ps1` 两处 `Join-Path` 少了路径分隔符（`scriptscheck-manifest-hardening.mjs`），**manifest 加固门禁与有界读门禁从未真正执行**；本次把 `build-apk-013.ps1` 与两个常驻门禁脚本纳入 `check-patch-mirror` 镜像比对面（协调仓一侧曾缺 bounded-io 门禁接线而无人察觉，正是该面缺失所致）。协调仓对应改动走另一个 PR。

### 验收（模拟器实测，全链跑通）

| 步骤 | 结果 |
|---|---|
| 检查（已是最新） | PASS：状态行 + Toast「APK 已是最新 v0.13.7fx-1」，随后按原语义续跑引擎快照检查 |
| 检查（发现新版） | PASS：状态行列出 tag/当前版本/体积，同一按钮变「下载并安装 v0.13.7fx-1」 |
| 二次确认下载 | PASS：按钮显示进度，落盘 166,096,226 字节（与 Release 资产逐字节等长），文件名非 `.tmp`（rename 完成） |
| 授权页 | PASS：首次自动拉「安装未知应用」页 |
| 授权返回续继 | PASS：`onResume` -> 系统安装器「要更新此应用吗？」 |
| 实际安装 | PASS：确认后应用版本由 0.13.6-HTEST 变为 0.13.7fx-1 |

### 测试

- 新增 `UpdateCheckerTest`（JVM 单测，10 断言）：版本比较（含 fx 修订号、快照后缀）、资产命名契约、ABI 选择（含 MuMu abilist 反例）。
- `./gradlew :app:testDebugUnitTest` 全绿；`build-apk-013.ps1 -Fast` 全链门禁绿（含新增镜像比对面）。

### 文档

- `README.zh.md` / `README.md`：新能力条目 + 独立「APK 自更新协议（0.13.8）」小节 + 权限表新增 `REQUEST_INSTALL_PACKAGES`；明确这是**壳侧唯一外部 HTTP 出口**且仅用户点击时发起（其余壳侧 HTTP 仍全部同源 127.0.0.1:3080）。
- 协调仓 `docs/OPEN-ISSUES-FIX-PLAN-2026-09-11.md` 的出口收敛表述同步更新（随批量 I 文档提交）。