### PR TITLE
feat: 批 F2——E6 能力补齐（全局动作面 getSystemActions 驱动 + 截图回落 ADB）

### DIFF
--- a/app/src/main/java/com/dsharnessmobile/shell/DeviceControlService.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/DeviceControlService.kt
@@ -818,6 +818,7 @@ class DeviceControlService : AccessibilityService() {
    * 代次变化或 invalidated=true 即界面确实变了。
    */
   private fun handleState(): JSONObject = JSONObject()
+    .put("globals", org.json.JSONArray(availableGlobalActions() as Collection<*>))
     .put("gen", synchronized(lock) { snapshot?.gen ?: -1 })
     .put("invalidated", invalidated)
     .put("enabled", true)
@@ -954,15 +955,33 @@ class DeviceControlService : AccessibilityService() {
     return walk(root, 0)
   }
 
+  /**
+   * 当前设备可用全局动作（目录与判定在 GlobalActionCatalog——纯函数、可单测）。
+   * 诊断面（state.globals）与失败回填共用。
+   */
+  fun availableGlobalActions(): List<String> =
+    GlobalActionCatalog.available(systemGlobalActionIds(), Build.VERSION.SDK_INT)
+
+  private fun systemGlobalActionIds(): Set<Int> = try {
+    getSystemActions()?.map { it.id }?.toSet() ?: emptySet()
+  } catch (_: Throwable) {
+    emptySet()
+  }
+
+  /** 全局动作（0.13.8 E6：getSystemActions 驱动；不可用时回可用清单，不静默失败）。 */
   private fun handleGlobal(args: JSONObject): JSONObject {
-    val action = when (args.optString("action", "")) {
-      "back" -> GLOBAL_ACTION_BACK
-      "home" -> GLOBAL_ACTION_HOME
-      "recents" -> GLOBAL_ACTION_RECENTS
-      "notifications" -> GLOBAL_ACTION_NOTIFICATIONS
-      else -> return error("未知全局动作")
+    val name = args.optString("action", "")
+    val available = availableGlobalActions()
+    val entry = GlobalActionCatalog.find(name)
+      ?: return error("未知全局动作 $name——可用：${available.joinToString(" / ")}")
+    if (!available.contains(entry.name)) {
+      return error(
+        "设备不支持全局动作 ${entry.name}" +
+          (if (Build.VERSION.SDK_INT < entry.minSdk) "（需要 Android API ${entry.minSdk}，本机 ${Build.VERSION.SDK_INT}）" else "（系统未报告该动作）") +
+          "——可用：${available.joinToString(" / ")}",
+      )
     }
-    val ok = performGlobalAction(action)
-    return if (ok) JSONObject().put("global", args.optString("action")) else error("全局动作被系统拒绝")
+    val ok = performGlobalAction(entry.id)
+    return if (ok) JSONObject().put("global", entry.name) else error("全局动作 ${entry.name} 被系统拒绝（执行返回 false）")
   }
 }

--- a/app/src/main/java/com/dsharnessmobile/shell/GlobalActionCatalog.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/GlobalActionCatalog.kt
@@ -1,0 +1,53 @@
+package com.dsharnessmobile.shell
+
+import android.accessibilityservice.AccessibilityService
+
+/**
+ * 全局动作目录（0.13.8 E6）——名称 ↔ 平台常量 ↔ 最低 API，**纯数据 + 纯函数**（可 JVM 单测）。
+ *
+ * 为什么单独一个文件：可用性判定必须能单测。原实现把 `when(action)` 硬编码在
+ * `AccessibilityService` 子类里，任何一条可用性规则都只能上真机试——而「工具说能做、
+ * 点了没反应」正是最难查的一类失败，恰恰需要离线断言把它钉住。
+ *
+ * 可用性由 `getSystemActions()` 驱动：系统报不出来的动作不执行、也不宣传。
+ */
+object GlobalActionCatalog {
+
+  /** 一条全局动作：`name` 是工具面用的名字，`id` 是平台常量，`minSdk` 是引入版本。 */
+  class Entry(val name: String, val id: Int, val minSdk: Int, val core: Boolean = false)
+
+  /**
+   * 目录表。`core = true` 的四条（back/home/recents/notifications）在所有 Android 上都存在，
+   * 恒放行——不能让一个不可靠的 `getSystemActions()` 结果把它们砍掉（防回归）。
+   */
+  val TABLE: List<Entry> = listOf(
+    Entry("back", AccessibilityService.GLOBAL_ACTION_BACK, 1, core = true),
+    Entry("home", AccessibilityService.GLOBAL_ACTION_HOME, 1, core = true),
+    Entry("recents", AccessibilityService.GLOBAL_ACTION_RECENTS, 1, core = true),
+    Entry("notifications", AccessibilityService.GLOBAL_ACTION_NOTIFICATIONS, 1, core = true),
+    Entry("quickSettings", AccessibilityService.GLOBAL_ACTION_QUICK_SETTINGS, 1),
+    Entry("powerDialog", AccessibilityService.GLOBAL_ACTION_POWER_DIALOG, 1),
+    Entry("toggleSplitScreen", AccessibilityService.GLOBAL_ACTION_TOGGLE_SPLIT_SCREEN, 24),
+    Entry("lockScreen", AccessibilityService.GLOBAL_ACTION_LOCK_SCREEN, 28),
+    Entry("takeScreenshot", AccessibilityService.GLOBAL_ACTION_TAKE_SCREENSHOT, 28),
+    Entry("menu", AccessibilityService.GLOBAL_ACTION_MENU, 31),
+    Entry("mediaPlayPause", AccessibilityService.GLOBAL_ACTION_MEDIA_PLAY_PAUSE, 31),
+    Entry("dismissNotificationShade", AccessibilityService.GLOBAL_ACTION_DISMISS_NOTIFICATION_SHADE, 31),
+    Entry("accessibilityShortcut", AccessibilityService.GLOBAL_ACTION_ACCESSIBILITY_SHORTCUT, 31),
+  )
+
+  /**
+   * 给定系统报出的动作 id 集合与 API 级别，返回可用动作名（顺序同目录表）。
+   *
+   * 规则（顺序即优先级）：
+   * ① 低于该动作的最低 API → 不可用；
+   * ② 核心四条 → 恒可用；
+   * ③ 其余：系统列表为空（部分 ROM 不报）时按 API 下限放行，非空时以系统列表为准。
+   */
+  fun available(ids: Set<Int>, sdk: Int): List<String> =
+    TABLE.filter { entry -> sdk >= entry.minSdk && (entry.core || ids.isEmpty() || ids.contains(entry.id)) }
+      .map { entry -> entry.name }
+
+  /** 按名称查条目（未知名称返回 null，由调用方回可读错误）。 */
+  fun find(name: String): Entry? = TABLE.firstOrNull { it.name == name }
+}

--- a/app/src/test/java/com/dsharnessmobile/shell/GlobalActionCatalogTest.kt
+++ b/app/src/test/java/com/dsharnessmobile/shell/GlobalActionCatalogTest.kt
@@ -1,0 +1,73 @@
+package com.dsharnessmobile.shell
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * 全局动作可用性判定（0.13.8 E6）——把「工具说能做、点了没反应」这类最难查的失败钉在离线断言里。
+ *
+ * 判定输入是 `getSystemActions()` 报出的 id 集合与 API 级别；核心四条必须恒在
+ * （ROM 不报也不能砍），高版本动作按 API 下限与系统报告双门放行。
+ */
+class GlobalActionCatalogTest {
+
+  /** 从目录里取回动作 id（测试不硬编码平台常量值，避免与 SDK 常量脱钩）。 */
+  private fun idOf(name: String): Int {
+    val e = GlobalActionCatalog.find(name)
+    assertNotNull("目录缺少 $name", e)
+    return e!!.id
+  }
+
+  @Test
+  fun coreActionsAreAlwaysAvailable() {
+    // 系统什么都不报（部分 ROM 如此）+ 现代 API：核心四条必须在
+    val avail = GlobalActionCatalog.available(emptySet(), 35)
+    for (name in listOf("back", "home", "recents", "notifications")) {
+      assertTrue("核心动作 $name 不应被系统列表砍掉", avail.contains(name))
+    }
+    // 系统报告一个与核心无关的集合：核心四条仍必须保留（防「getSystemActions 口径不合」回归）
+    val avail2 = GlobalActionCatalog.available(setOf(idOf("quickSettings")), 35)
+    assertTrue(avail2.contains("back"))
+    assertTrue(avail2.contains("home"))
+  }
+
+  @Test
+  fun unsupportedBySystemIsExcluded() {
+    // 系统只报 quickSettings → 高版本动作（menu/lockScreen 等）不得对外宣传
+    val avail = GlobalActionCatalog.available(setOf(idOf("quickSettings")), 35)
+    assertTrue(avail.contains("quickSettings"))
+    assertFalse("系统未报告的动作不得宣传", avail.contains("menu"))
+    assertFalse(avail.contains("lockScreen"))
+    // 空列表 = ROM 不报，按 API 下限放行（此时 menu 可用）
+    val romSilent = GlobalActionCatalog.available(emptySet(), 35)
+    assertTrue(romSilent.contains("menu"))
+  }
+
+  @Test
+  fun minApiGateHolds() {
+    // API 26（Android 8）：lockScreen/takeScreenshot 需要 28 → 不可用；quickSettings 可用
+    val api26 = GlobalActionCatalog.available(emptySet(), 26)
+    assertFalse(api26.contains("lockScreen"))
+    assertFalse(api26.contains("takeScreenshot"))
+    assertTrue(api26.contains("quickSettings"))
+    // API 28：放行锁屏与截图；menu（31）仍不可用
+    val api28 = GlobalActionCatalog.available(emptySet(), 28)
+    assertTrue(api28.contains("lockScreen"))
+    assertTrue(api28.contains("takeScreenshot"))
+    assertFalse(api28.contains("menu"))
+    // API 31：全表放行
+    val api31 = GlobalActionCatalog.available(GlobalActionCatalog.TABLE.map { it.id }.toSet(), 31)
+    assertEquals(GlobalActionCatalog.TABLE.size, api31.size)
+  }
+
+  @Test
+  fun unknownActionIsRejected() {
+    assertNull(GlobalActionCatalog.find("reboot"))
+    assertNull(GlobalActionCatalog.find(""))
+    assertNotNull(GlobalActionCatalog.find("takeScreenshot"))
+  }
+}

--- a/plugins/dsh-android-manage/src/index.ts
+++ b/plugins/dsh-android-manage/src/index.ts
@@ -291,18 +291,36 @@ function tools(ctx: Context, priv: PrivilegeFace) {
       const a = guard('screenshot', { textRedact }, exec as { agent?: { session?: unknown } })
       if (!a.ok) return { imagePath: '', denied: true, text: a.guidance }
       // 0.13.5 W4：无障碍截屏优先（API 30+ 的 AccessibilityService.takeScreenshot——不需要 ADB）
+      let adbNote = ''
       if (controlDecision('screenshot', exec as { agent?: { session?: unknown } }).backend === 'a11y') {
         const r = await a11yExec('screenshot', {}, 12_000)
-        if (!r.ok) return { imagePath: '', denied: false, text: '无障碍截屏失败：' + r.error }
-        const data = (r.data ?? {}) as { path?: string; width?: number; height?: number }
-        if (!data.path) return { imagePath: '', denied: false, text: '无障碍截屏未返回文件路径' }
-        return inlineShot(
-          data.path,
-          data.width ?? 0,
-          data.height ?? 0,
-          exec as ExecLike,
-          `无障碍通道，设备物理分辨率 ${data.width ?? '?'}x${data.height ?? '?'}`,
-        )
+        if (!r.ok) {
+          // 0.13.8 E6：无障碍截屏不可用（API<30 无 takeScreenshot / FLAG_SECURE 被拒 / 服务未就绪）
+          // → 回落 ADB screencap，而不是把「没有截图能力」当结论抛给模型。
+          if (priv.execAdbLine) {
+            adbNote = `（无障碍截屏不可用：${r.error}——已回落 ADB 通道）`
+          } else {
+            return {
+              imagePath: '', denied: false,
+              text: `无障碍截屏失败：${r.error}。ADB 通道未接通，无法回落——`
+                + '需要截图请先完成 ADB 授权（完全访问 → 允许访问开关 → 配对码），或用 android_ui_dump 读结构。',
+            }
+          }
+        } else {
+          const data = (r.data ?? {}) as { path?: string; width?: number; height?: number }
+          if (!data.path) {
+            if (!priv.execAdbLine) return { imagePath: '', denied: false, text: '无障碍截屏未返回文件路径，且 ADB 通道未接通（无法回落）' }
+            adbNote = '（无障碍截屏未返回文件路径——已回落 ADB 通道）'
+          } else {
+            return inlineShot(
+              data.path,
+              data.width ?? 0,
+              data.height ?? 0,
+              exec as ExecLike,
+              `无障碍通道，设备物理分辨率 ${data.width ?? '?'}x${data.height ?? '?'}`,
+            )
+          }
+        }
       }
       // 0.14 真实通道：adbd（shell uid）执行 screencap → adb pull 回引擎私有临时目录（app uid 可读）。
       if (!priv.execAdbLine) return { imagePath: '', denied: false, text: 'ADB 执行通道未接通（dsh-android-bridge 未提供 execAdbLine）' }
@@ -318,7 +336,7 @@ function tools(ctx: Context, priv: PrivilegeFace) {
         // F2 统一坐标系：回传物理分辨率锚点。模型侧读图可能降采样（maxDim 2048），
         // 严禁直接用截图像素坐标点击——归一化用 android_ui_click 的 nx/ny。
         const size = await screenSize()
-        return inlineShot(local, size.w, size.h, exec as ExecLike, `ADB 通道，设备物理分辨率 ${size.w}x${size.h}`)
+        return inlineShot(local, size.w, size.h, exec as ExecLike, `ADB 通道，设备物理分辨率 ${size.w}x${size.h}${adbNote}`)
       } catch (e) {
         return { imagePath: '', denied: false, text: '截图失败：' + String((e as Error).message) }
       }
@@ -1508,11 +1526,20 @@ function tools(ctx: Context, priv: PrivilegeFace) {
   const uiGlobal = defineTool({
     name: 'android_ui_global',
     description:
-      '【首选】系统级导航动作（无障碍通道，不需要 ADB）：back=返回上一级、home=回桌面、'
-      + 'recents=最近任务、notifications=下拉通知栏。卡在子菜单/弹窗/详情页出不来时，第一步就用 back。'
+      '【首选】系统级动作（无障碍通道，不需要 ADB）：back=返回上一级、home=回桌面、recents=最近任务、'
+      + 'notifications=下拉通知栏、quickSettings=快捷设置面板、toggleSplitScreen=分屏、powerDialog=关机菜单、'
+      + 'lockScreen=锁屏、takeScreenshot=系统截图、menu=菜单键、mediaPlayPause=播放/暂停、'
+      + 'dismissNotificationShade=收起通知栏、accessibilityShortcut=无障碍快捷方式。'
+      + '卡在子菜单/弹窗/详情页出不来时，第一步就用 back。'
+      + '设备实际可用的动作由系统 getSystemActions() 决定，不可用者返回可用清单（不会静默无效果）。'
       + '需设备控制授权（无障碍服务已开启即可）+ 会话档位 danger-full-access。',
     parameters: {
-      action: { type: 'string', required: true, enum: ['back', 'home', 'recents', 'notifications'], description: '要执行的全局动作' },
+      action: {
+        type: 'string', required: true,
+        enum: ['back', 'home', 'recents', 'notifications', 'quickSettings', 'toggleSplitScreen', 'powerDialog',
+          'lockScreen', 'takeScreenshot', 'menu', 'mediaPlayPause', 'dismissNotificationShade', 'accessibilityShortcut'],
+        description: '要执行的全局动作（可用集由系统决定，不可用会回可用清单）',
+      },
     },
     output: {
       schema: {
@@ -1530,8 +1557,10 @@ function tools(ctx: Context, priv: PrivilegeFace) {
     execute: async ({ action }: { action: string }, exec) => {
       const a = guard('ui_global', { action }, exec as { agent?: { session?: unknown } })
       if (!a.ok) return { ok: false, denied: true, action, text: a.guidance }
-      if (!['back', 'home', 'recents', 'notifications'].includes(action)) {
-        return { ok: false, denied: false, action, text: 'action 必须是 back / home / recents / notifications' }
+      const GLOBAL_ACTIONS = ['back', 'home', 'recents', 'notifications', 'quickSettings', 'toggleSplitScreen',
+        'powerDialog', 'lockScreen', 'takeScreenshot', 'menu', 'mediaPlayPause', 'dismissNotificationShade', 'accessibilityShortcut']
+      if (!GLOBAL_ACTIONS.includes(action)) {
+        return { ok: false, denied: false, action, text: `action 必须是 ${GLOBAL_ACTIONS.join(' / ')}` }
       }
       const r = await a11yExec('global', { action }, 6000)
       if (!r.ok) {


### PR DESCRIPTION
## 内容

0.13.8 批 F 的 E6 余项（长按已在批 E 落地）：把「能力补齐」清单里剩下的两项做完，第三项如实说明为什么做不了。

### 1. 全局动作面：由 getSystemActions() 驱动

原实现把动作硬编码成 4 条（back/home/recents/notifications），**其余系统支持的动作模型根本不知道存在**，工具描述也只宣传这 4 条。现在：

- 新增 `GlobalActionCatalog`（壳侧）：13 条动作的目录表（名称 / 平台常量 / 最低 API / 是否核心），可用性判定是**纯函数**（可离线单测）；
- 新增动作：`quickSettings`、`powerDialog`、`toggleSplitScreen`、`lockScreen`、`takeScreenshot`、`menu`、`mediaPlayPause`、`dismissNotificationShade`、`accessibilityShortcut`；
- 可用性三规则：① 低于最低 API 不可用；② 核心四条恒放行（防 ROM 不报列表把基础导航砍掉）；③ 其余以 `getSystemActions()` 为准，列表为空（部分 ROM 不报）时按 API 下限放行；
- 不可用时**不静默失败**：返回可读错误并附本机可用清单；`state.globals` 暴露可用集供诊断面消费。

### 2. 截图回落 ADB

无障碍截屏失败（API<30 没有 `takeScreenshot` / 窗口 `FLAG_SECURE` / 服务未就绪）此前**直接报错收场**——等于老设备没有截图能力。现在自动回落 ADB `screencap`，并在结果里注明回落原因；两条路都不通时才给「先完成 ADB 授权」的可执行指引。

### 3. API 33+ 无障碍输入法：未实现（如实说明）

`javap` 查 android-36 的 `android.jar`：`AccessibilityNodeInfo` **没有** `INPUT_METHOD_EDITOR` 相关符号，设计文档设想的这条路径在当前 SDK 上无法落地。文本输入在 `ACTION_SET_TEXT` 不被接受的场景已由 ADB-IME 通道（`AdbKeyboardService`，0.13.2 起）承担。已在 known-gaps 登记，不静默跳过。

### 设备实测（MuMu x86_64 / Android 15；假引擎驱动真壳，harness 见 #194）

| # | 触发 | 结果 |
|---|---|---|
| 1 | `state` | `globals` 返回 **11 条**（真实 `getSystemActions` 口径——本机 ROM 未报 `toggleSplitScreen` / `dismissNotificationShade`，故这两条确实不宣传） |
| 2 | `global{action:"reboot"}` | 可读错误 + 完整可用清单（不再静默无效果） |
| 3 | `global{action:"quickSettings"}` | 执行成功并回填 `{"ok":true,"global":"quickSettings"}`——该动作在旧硬编码表里会被判「未知全局动作」 |

### 单测

`GlobalActionCatalogTest` 4 例：核心动作恒在（含 ROM 不报列表的反例）、系统未报不宣传、最低 API 门（API 26/28/31 三档）、未知动作拒绝。

### 验证边界

- 已覆盖：可用性判定（离线单测）+ 设备侧真实 `getSystemActions` 口径 + 动作执行与回填。
- 未覆盖：回落 ADB 截图的**触发路径**——本机 API 35 无障碍截屏可用，回落分支只能在 API<30 设备上真实触发；该分支的 ADB 截图本身在 0.13.x 已多次实测。