### PR TITLE
feat: 批 F3——P2 收口（两级披露 + 通道路由块 + 协议协商）+ spill 挂载结论修正

### DIFF
--- a/docs/AGENTS/gotchas.md
+++ b/docs/AGENTS/gotchas.md
@@ -142,3 +142,26 @@
     能力门 = 引擎级三道门 + 会话档位实时 resolve；`tier` 降级为部署视图字段
     （AdbAuthSection 的「已授权」改按三道门，linux-env 的 adbTier 文案标注「档位视图」）。
     铁律：门禁判定只允许「设备全局事实 + 会话实时档位」，任何部署常量进判定即缺陷。
+
+69. **往 profile patch 挂「上游已挂」的包 = 整棵插件树加载失败（0.13.8 批 F/P2-14 实锤）**：
+    按设计文档把 `@deepseek-ai/dsh-spill-local` + `dsh-spill-policy` 以 `- insert:` 挂进
+    `scripts/profile-web.cordis.patch.yml` 后，设备上引擎起不来，日志真因：
+    `dsh: plugin tree failed to load: failed to apply loader entry include (cordis:include):
+    duplicate loader entry id: spill-local`。即**上游 host 组合默认已经挂了 spill 子系统**
+    （所以「已装未挂」的推断是错的——overlay manifest 只说明包在快照里，不代表没挂）。
+    代价是整棵树加载失败，不是单插件降级。铁律：新增 `- insert:` 前先确认 row id 在上游
+    组合/预置里不存在；挂载失败先看 duplicate id，再谈配置。
+70. **profile patch 的合并语义是「按 id 只增不删」——错误的 row 会永久留在设备上（0.13.8 实锤）**：
+    坑 69 的 spill 行写进 `home/.dsh/profiles/web/cordis.patch.yml` 后，**改回代码 + 重装 APK
+    + 重解压快照都没能删掉它**（实测：重装后该文件仍是旧的含 spill 版本，引擎持续起不来）。
+    根因是快照事务的 profiles 分区合并对 `cordis.patch.yml` 按 id 合并（0.13.8 B345 批
+    `SnapshotTransaction.mergePatchYamlById`），设计目的是保住用户手改，代价是**我们自己也删不掉
+    已注入的行**。恢复路径（已实测）：`adb shell` 删/改
+    `<files>/home/.dsh/profiles/web/cordis.patch.yml`（注意不要留 root 属主备份文件，见坑 71），
+    或清应用数据。**发布含义**：0.13.8 之后若需要下线某条已注入 row，老设备上删不掉——
+    必须在合并语义上给「上游注入行以 staged 为准」留口子（已登记 known-gaps）。
+71. **profiles 目录里放 root 属主文件 → 引擎 watcher EACCES 崩溃（0.13.8 调试时踩到）**：
+    用 `adb shell cp`（root）在 `home/.dsh/profiles/web/` 下留了 `cordis.patch.yml.bak-spill`，
+    引擎对 profiles 目录做 `watch`，读不到该文件 → `syscall: 'watch', code: 'EACCES'` 直接崩，
+    表现为「引擎启动失败」而日志里没有任何插件错误。铁律：调试期在 profiles 目录里造文件
+    必须 `chown u0_a53:u0_a53` 或立刻删除（应用 uid 见 `dumpsys package`）。

--- a/docs/AGENTS/known-gaps.md
+++ b/docs/AGENTS/known-gaps.md
@@ -19,3 +19,18 @@
 - **单窗口截屏**（API 34 `takeScreenshotOfWindow`）与多窗口选择（`getWindows()`）未接。
 - **API <30 设备**：无障碍截屏不可用（`takeScreenshot` 需要 API 30），仍需 ADB `screencap`；`GLOBAL_ACTION_TAKE_SCREENSHOT`(28) 只存相册不回传数据。
 - **arm64 真机验证**：无障碍通道目前仅在 x86_64 模拟器验证（无 arm64 设备在线）。
+
+## 0.13.8 批 F 收尾登记（2026-09-12）
+
+- **API 33+「无障碍输入法」（E6d）无法实现**：`javap` 校验 android-36 的 `android.jar`，
+  `AccessibilityNodeInfo` 无 `INPUT_METHOD_EDITOR` 相关符号，设计文档设想的路径在当前 SDK
+  上不存在。`ACTION_SET_TEXT` 不被接受的场景由 ADB-IME 通道（`AdbKeyboardService`）承担。
+- **截图回落 ADB 的触发路径未在设备上跑通**：本机 API 35 无障碍截屏可用，回落分支只能在
+  API<30 设备上真实触发（ADB `screencap` 本身已多次实测）。
+- **profile patch 合并语义「按 id 只增不删」**（坑 70）：我们注入的 row 一旦写进设备
+  `home/.dsh/profiles/web/cordis.patch.yml` 就**删不掉**（改代码 + 重装 + 重解压都不生效）。
+  影响：0.13.8 之后若要下线已注入 row，需要在 `SnapshotTransaction.mergePatchYamlById` 上给
+  「上游注入行以 staged 为准」留口子（当前无标记区分「我们注入的」与「用户手改的」，
+  实现前先设计标记方式，勿草率改成覆盖语义——那会吃掉用户手改）。
+- **悬浮球动效 M4–M8 未做**（G3 余项）：待答卡位移渐隐 / 状态行 TextSwitcher / 琥珀呼吸 /
+  PENDING 脉冲。M1/M2/M9/M10/M11 与降级门（`DsUi.animationsEnabled`）已在 #191 落地。

--- a/plugins/dsh-android-bridge/package.json
+++ b/plugins/dsh-android-bridge/package.json
@@ -25,25 +25,25 @@
   "private": true,
   "scripts": {
     "build": "tsc -p . && tsc -p tsconfig.client.json --noEmit && node build-client.mjs",
-    "typecheck": "tsc -p . --noEmit && tsc -p tsconfig.client.json --noEmit"
+    "typecheck": "tsc -p . --noEmit && tsc -p tsconfig.client.json --noEmit",
+    "test": "npm run build && node --test test/control.test.mjs test/protocol-negotiation.test.mjs"
   },
-  "dependencies": {},
   "peerDependencies": {
-    "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
     "@deepseek-ai/cordis": "4.0.1",
-    "@deepseek-ai/schemastery": "3.18.1",
     "@deepseek-ai/dsh-client-runtime": "^0.1.1-rc.2",
-    "@deepseek-ai/dsh-client-ui-slots": "^0.1.1-rc.2",
     "@deepseek-ai/dsh-client-ui-settings": "^0.1.1-rc.2",
+    "@deepseek-ai/dsh-client-ui-slots": "^0.1.1-rc.2",
+    "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
+    "@deepseek-ai/schemastery": "3.18.1",
     "react": "^18.2.0"
   },
   "devDependencies": {
-    "@deepseek-ai/dsh-tools": "0.1.1-rc.2",
     "@deepseek-ai/cordis": "4.0.1",
-    "@deepseek-ai/schemastery": "3.18.1",
     "@deepseek-ai/dsh-client-runtime": "0.1.1-rc.2",
-    "@deepseek-ai/dsh-client-ui-slots": "0.1.1-rc.2",
     "@deepseek-ai/dsh-client-ui-settings": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-client-ui-slots": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-tools": "0.1.1-rc.2",
+    "@deepseek-ai/schemastery": "3.18.1",
     "@types/node": "^24.0.0",
     "@types/react": "~18.3.1",
     "esbuild": "^0.25.0",

--- a/plugins/dsh-android-bridge/src/control-queue.ts
+++ b/plugins/dsh-android-bridge/src/control-queue.ts
@@ -33,6 +33,39 @@ interface PendingEntry {
 
 let seq = 0
 
+/** 引擎支持的协议版本上限（壳侧 `pv` 高于此值 = 壳比引擎新）。 */
+export const ENGINE_PROTOCOL_VERSION = 2
+
+export interface Negotiation {
+  ok: boolean
+  /** 壳侧声明的协议版本（未声明按 1 = V1 兼容路径）。 */
+  shell: number
+  engine: number
+  reason: string
+}
+
+/**
+ * 协议版本协商（0.13.8 P2-15；V2 §S4）：把「新壳 + 老引擎」变成一次**带指引的失败**，
+ * 而不是静默产出一棵空树。老壳不声明 `pv` → 按 V1 兼容路径放行（0.13.7 及以前的行为）。
+ */
+export function negotiateProtocol(shellPv: unknown): Negotiation {
+  const engine = ENGINE_PROTOCOL_VERSION
+  if (shellPv === undefined || shellPv === null) {
+    return { ok: true, shell: 1, engine, reason: '壳侧未声明协议版本——按 V1 兼容路径处理' }
+  }
+  const shell = Number(shellPv)
+  if (!Number.isFinite(shell) || shell < 1) {
+    return { ok: false, shell: 0, engine, reason: `壳侧协议版本非法（pv=${String(shellPv)}）` }
+  }
+  if (shell > engine) {
+    return {
+      ok: false, shell, engine,
+      reason: `壳侧协议 pv=${shell} 比引擎支持的 pv=${engine} 新——请更新引擎快照（android_ui_dump 会一直拿不到可信结果）`,
+    }
+  }
+  return { ok: true, shell, engine, reason: shell === engine ? `协议 pv=${shell} 一致` : `壳侧 pv=${shell} 走 V${shell} 兼容路径` }
+}
+
 export class ControlQueue {
   private pending?: PendingEntry
   private waiter?: () => void
@@ -40,6 +73,9 @@ export class ControlQueue {
   private lastResultAt = 0
   private served = 0
   private failed = 0
+  /** 0.13.8 P2-15：最近一次回填声明的协议版本与能力（诊断面展示 + 协商判定）。 */
+  private lastPv?: number
+  private lastCaps?: Record<string, unknown>
   /** 0.13.8 #181：在途标记——take 到 settle 之间二次取活必须被拒（防同一请求双执行）。 */
   private inFlight = false
 
@@ -53,8 +89,23 @@ export class ControlQueue {
     return this.pending ? 250 : 2000
   }
 
-  stats(): { waiting: boolean; served: number; failed: number; lastTakeAt: number; lastResultAt: number } {
-    return { waiting: this.waiting, served: this.served, failed: this.failed, lastTakeAt: this.lastTakeAt, lastResultAt: this.lastResultAt }
+  stats(): {
+    waiting: boolean; served: number; failed: number; lastTakeAt: number; lastResultAt: number
+    protocol: Negotiation; caps?: Record<string, unknown>
+  } {
+    return {
+      waiting: this.waiting, served: this.served, failed: this.failed,
+      lastTakeAt: this.lastTakeAt, lastResultAt: this.lastResultAt,
+      protocol: negotiateProtocol(this.lastPv), caps: this.lastCaps,
+    }
+  }
+
+  /** 记录壳侧声明的协议版本与能力（回填信封；诊断与协商共用）。 */
+  noteShell(pv: unknown, caps: unknown): Negotiation {
+    const negotiation = negotiateProtocol(pv)
+    this.lastPv = negotiation.shell
+    if (caps !== null && typeof caps === 'object' && !Array.isArray(caps)) this.lastCaps = caps as Record<string, unknown>
+    return negotiation
   }
 
   /**
@@ -286,6 +337,15 @@ export function registerControlRoutes(webServer: { register(route: unknown): voi
       const result: ControlResult = ok
         ? { ok: true, data: body.data }
         : { ok: false, error: typeof body.error === 'string' ? body.error : '设备控制失败（壳侧未给出原因）' }
+      // 0.13.8 P2-15：先做协议协商——壳比引擎新时明确失败并给升级指引，
+      // 不让模型看到一株「看起来正常」的空树（§S4.1 场景 3）。
+      const negotiation = queue.noteShell(body.pv, body.caps)
+      if (!negotiation.ok) {
+        logger?.warn?.(`control/result: 协议不兼容（壳 pv=${negotiation.shell} / 引擎 pv=${negotiation.engine}）`)
+        queue.settle(reqId, { ok: false, error: negotiation.reason })
+        sendJson(res, 422, { ok: false, code: 'schema_invalid', error: negotiation.reason })
+        return
+      }
       const accepted = queue.settle(reqId, result)
       if (!accepted) logger?.warn?.(`control/result: rejected (409, reqId=${reqId})`)
       sendJson(res, accepted ? 200 : 409, { ok: accepted, reason: accepted ? 'settled' : 'unknown-or-stale-reqId' })

--- a/plugins/dsh-android-bridge/src/index.ts
+++ b/plugins/dsh-android-bridge/src/index.ts
@@ -17,6 +17,7 @@ import { join, dirname } from 'node:path'
 import { Context } from '@deepseek-ai/cordis'
 import { defineTool, type JsonValue } from '@deepseek-ai/dsh-tools'
 import { decideControl, type ControlDecision, type ControlOp } from './control-policy.js'
+import { negotiateProtocol } from './control-queue.js'
 import {
   ControlQueue,
   controlTokenFrom,
@@ -434,7 +435,10 @@ export class AndroidPrivilegeService {
 
   /** 0.13.5 W4：队列统计（诊断用；不泄漏页面内容）。 */
   controlStats() {
-    return this.controlQueue?.stats() ?? { waiting: false, served: 0, failed: 0, lastTakeAt: 0, lastResultAt: 0 }
+    return this.controlQueue?.stats() ?? {
+      waiting: false, served: 0, failed: 0, lastTakeAt: 0, lastResultAt: 0,
+      protocol: negotiateProtocol(undefined), caps: undefined,
+    }
   }
 
   /**
@@ -545,6 +549,9 @@ export class AndroidPrivilegeService {
   }
 }
 
+/** 诊断面展示路由的常用操作（与工具面一一对应）。 */
+const ROUTE_OPS: ControlOp[] = ['snapshot', 'click', 'scroll', 'setText', 'screenshot', 'global']
+
 function tools(svc: AndroidPrivilegeService, shellFace?: { resolve?(spec: Record<string, unknown>): Record<string, unknown>; run(spec: Record<string, unknown>): Promise<Record<string, unknown>> }, controlTokenConfigured: () => boolean = () => false) {
   const statusTool = defineTool({
     name: 'android_privilege_status',
@@ -571,6 +578,8 @@ function tools(svc: AndroidPrivilegeService, shellFace?: { resolve?(spec: Record
           message: { type: 'string' },
           gates: { type: 'object', additionalProperties: true, description: '结构化授权事实（a11yEnabled/fullAccess/allowSwitch/paired/wirelessDebug/adbReady）' },
           control: { type: 'object', additionalProperties: true, description: '控制通道运行时状态（a11yEnabled/queue/tokenConfigured）' },
+          route: { type: 'object', additionalProperties: true, description: '每个常用操作走哪条通道/为什么/另一条缺什么（结构化路由）' },
+          shell: { type: 'object', additionalProperties: true, description: '壳侧声明的协议版本与能力（caps.ops/view/gz）与协商结论' },
         },
       },
       render: (_args, v: Record<string, unknown>) => {
@@ -590,17 +599,51 @@ function tools(svc: AndroidPrivilegeService, shellFace?: { resolve?(spec: Record
               : gates?.adbReady ? '结论：设备控制可用（走 ADB 通道，仅兜底）——下一步用 android_ui_dump（无障碍优先）或 android_ui_tree（ADB）'
                 : '结论：不可用——开启任一通道即可（推荐无障碍：系统设置 → 无障碍 → DSH 设备控制，一步即用）',
             v.message ? `ADB 提示：${String(v.message)}` : '',
+            (() => {
+              const shell = v.shell as { protocol?: { shell?: number; engine?: number; ok?: boolean; reason?: string }; caps?: { ops?: unknown[] } | null } | undefined
+              if (!shell?.protocol) return ''
+              const p = shell.protocol
+              const capsOps = Array.isArray(shell.caps?.ops) ? (shell.caps!.ops as unknown[]).length : 0
+              return `壳侧协议：pv=${String(p.shell)}（引擎支持 ${String(p.engine)}）${p.ok ? '' : ' —— 不兼容：' + String(p.reason)}`
+                + (capsOps > 0 ? ` · 声明能力 ${capsOps} 项` : ' · 未声明能力（老壳）')
+            })(),
+            '路由（dump/click/scroll/input/screenshot/global）：'
+              + Object.entries((v.route ?? {}) as Record<string, { backend?: string }>)
+                .map(([op, r]) => `${op}=${String(r?.backend ?? '?')}`).join(' '),
           ].filter((line) => line !== '').join('\n'),
         }]
       },
     },
-    execute: async () => {
+    execute: async (_args, exec) => {
       const st = svc.status()
+      const session = (exec as { agent?: { session?: unknown } } | undefined)?.agent?.session
+      // 0.13.8 P2-15：结构化 route 块——每个常用操作**走哪条通道、为什么、另一条缺什么**。
+      // 以前这些判断只存在于代码路径里，模型只能靠「失败后猜」。
+      const route: Record<string, unknown> = {}
+      const facts = svc.gateFacts()
+      for (const op of ROUTE_OPS) {
+        const d = svc.controlDecision(op, session)
+        const altAdb = facts.adbReady === true
+        const altA11y = svc.a11yEnabled()
+        route[op] = {
+          backend: d.backend,
+          reason: d.reason,
+          alternative: d.backend === 'a11y'
+            ? { backend: 'adb', available: altAdb, missing: altAdb ? null : '完整访问档位 / 应用内允许访问开关 / 无线调试配对' }
+            : { backend: 'a11y', available: altA11y, missing: altA11y ? null : '系统设置 → 无障碍 → 开启「DSH 设备控制」' },
+        }
+      }
+      const queue = svc.controlStats()
       return {
         ...st,
         deviceModel: svc.boundModel(),
         gates: svc.gateFacts() as unknown as Record<string, JsonValue>,
-        control: { a11yEnabled: svc.a11yEnabled(), queue: svc.controlStats(), tokenConfigured: controlTokenConfigured() },
+        route: route as unknown as Record<string, JsonValue>,
+        shell: {
+          protocol: queue.protocol as unknown as JsonValue,
+          caps: (queue.caps ?? null) as unknown as JsonValue,
+        },
+        control: { a11yEnabled: svc.a11yEnabled(), queue: queue as unknown as JsonValue, tokenConfigured: controlTokenConfigured() },
       }
     },
   })

--- a/plugins/dsh-android-bridge/test/protocol-negotiation.test.mjs
+++ b/plugins/dsh-android-bridge/test/protocol-negotiation.test.mjs
@@ -1,0 +1,34 @@
+// 协议版本协商（0.13.8 P2-15）：把「新壳 + 老引擎」变成一次带指引的失败
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { negotiateProtocol, ENGINE_PROTOCOL_VERSION } from '../lib/control-queue.js'
+
+test('老壳（未声明 pv）走 V1 兼容路径', () => {
+  const n = negotiateProtocol(undefined)
+  assert.equal(n.ok, true)
+  assert.equal(n.shell, 1)
+  assert.equal(n.engine, ENGINE_PROTOCOL_VERSION)
+  assert.match(n.reason, /V1 兼容/)
+  assert.equal(negotiateProtocol(null).ok, true, 'null 同样视为未声明')
+})
+
+test('同版本通过', () => {
+  const same = negotiateProtocol(ENGINE_PROTOCOL_VERSION)
+  assert.equal(same.ok, true)
+  assert.equal(same.shell, ENGINE_PROTOCOL_VERSION)
+  assert.match(same.reason, /一致/)
+})
+
+test('壳比引擎新：明确失败并给升级指引（不静默产出空树）', () => {
+  const newer = negotiateProtocol(ENGINE_PROTOCOL_VERSION + 1)
+  assert.equal(newer.ok, false)
+  assert.match(newer.reason, /比引擎支持的|更新引擎快照/)
+})
+
+test('非法版本号失败关闭', () => {
+  assert.equal(negotiateProtocol('abc').ok, false)
+  assert.equal(negotiateProtocol(0).ok, false)
+  assert.equal(negotiateProtocol(-1).ok, false)
+  assert.equal(negotiateProtocol({}).ok, false, '对象不是版本号')
+})

--- a/plugins/dsh-android-manage/package.json
+++ b/plugins/dsh-android-manage/package.json
@@ -15,7 +15,7 @@
   "private": true,
   "scripts": {
     "build": "tsc -p .",
-    "test": "npm run build && node --test test/ui-tree.test.mjs test/protocol-v2.test.mjs"
+    "test": "npm run build && node --test test/ui-tree.test.mjs test/protocol-v2.test.mjs test/detail-store.test.mjs"
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "4.0.1",

--- a/plugins/dsh-android-manage/src/detail-store.ts
+++ b/plugins/dsh-android-manage/src/detail-store.ts
@@ -1,0 +1,78 @@
+/**
+ * 明细存储（0.13.8 P2-13，两级披露的第二级）。
+ *
+ * 背景：`android_ui_dump` 的清单是**紧凑渲染**——一行一节点、只给定位所需字段。模型偶尔需要
+ * 更全的东西（完整文本、全部几何、祖先/子树关系），但把它塞进默认结果会让每次 dump 都变贵。
+ * 于是分两级：默认结果只留一句「全量明细在哪」，需要时用 `android_ui_detail` 按需取回。
+ *
+ * 落盘纪律（V2 §10）：**句柄必须确定性**——同一屏（同一结构指纹）恒得同一路径，不含时间戳、
+ * 不含随机 id、不含会话名。否则缓存失效点会随着每次调用移动，长任务里纯亏。
+ */
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import type { UiNode } from './ui-tree.js'
+
+/** 文件名前缀（与 dsh-tmp 里的其它临时产物区分；LRU 清理按此前缀）。 */
+export const DETAIL_PREFIX = 'ui-detail-'
+
+/** 确定性句柄 → 文件名（句柄里的异常字符剔除，保证可作文件名）。 */
+export function detailFileName(handle: string): string {
+  const safe = handle.replace(/[^A-Za-z0-9._-]/g, '')
+  return DETAIL_PREFIX + (safe === '' ? 'unknown' : safe) + '.jsonl'
+}
+
+/**
+ * 单行明细记录：把 `UiNode` 的全部字段摊平给模型（渲染里压缩过的 type/rid、坐标四元组等都在）。
+ * `extra` 放派生信息（如祖先链、子树范围）——按需传入，避免默认结果变胖。
+ */
+export function detailRecord(n: UiNode, extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: n.id,
+    depth: n.depth,
+    type: n.type,
+    text: n.text,
+    desc: n.desc,
+    rid: n.rid,
+    pkg: n.pkg,
+    windowId: n.windowId,
+    x: n.x,
+    y: n.y,
+    w: n.w,
+    h: n.h,
+    cx: n.cx,
+    cy: n.cy,
+    clickable: n.clickable,
+    scrollable: n.scrollable,
+    editable: n.editable,
+    checked: n.checked,
+    visible: n.visible,
+    parentId: n.parentId,
+    ...extra,
+  }
+}
+
+/**
+ * 写出明细文件（JSONL：首行 meta，其余一行一节点）。返回文件路径。
+ * 写入是幂等的：同一句柄重复写覆盖同一条路径（不给旧屏留下第二份副本）。
+ */
+export function writeDetailStore(
+  dir: string,
+  handle: string,
+  rows: Array<Record<string, unknown>>,
+  meta: Record<string, unknown>,
+): string {
+  mkdirSync(dir, { recursive: true })
+  const file = join(dir, detailFileName(handle))
+  const lines = [JSON.stringify({ meta: true, ...meta })]
+  for (const r of rows) lines.push(JSON.stringify(r))
+  writeFileSync(file, lines.join('\n') + '\n')
+  return file
+}
+
+/** 分页切片 + 诚实报告省略量（对齐上游 output-retention 的口径：丢了几个必须说清）。 */
+export function pageRows<T>(rows: T[], offset: number, limit: number): { page: T[]; offset: number; omitted: number } {
+  const off = Math.max(0, Math.floor(offset))
+  const lim = Math.max(1, Math.floor(limit))
+  const page = rows.slice(off, off + lim)
+  return { page, offset: off, omitted: Math.max(0, rows.length - off - page.length) }
+}

--- a/plugins/dsh-android-manage/src/index.ts
+++ b/plugins/dsh-android-manage/src/index.ts
@@ -27,6 +27,7 @@ import { join } from 'node:path'
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync } from 'node:fs'
 import { parseUiTreeXml, pruneNodes, resolveRef, findActionableAncestor, checkUiTreeParse, type UiNode, actionableAncestorV2, scopePoolV2 } from './ui-tree.js'
 import { cacheFromV2, decodeV2, isV2Payload, type V2Decoded } from './protocol-v2.js'
+import { detailRecord, pageRows, writeDetailStore } from './detail-store.js'
 
 /**
  * 0.13.8 #183：键盘广播来源校验 nonce 参数（壳侧 AdbKeyboardReceiver 私有文件，
@@ -291,18 +292,36 @@ function tools(ctx: Context, priv: PrivilegeFace) {
       const a = guard('screenshot', { textRedact }, exec as { agent?: { session?: unknown } })
       if (!a.ok) return { imagePath: '', denied: true, text: a.guidance }
       // 0.13.5 W4：无障碍截屏优先（API 30+ 的 AccessibilityService.takeScreenshot——不需要 ADB）
+      let adbNote = ''
       if (controlDecision('screenshot', exec as { agent?: { session?: unknown } }).backend === 'a11y') {
         const r = await a11yExec('screenshot', {}, 12_000)
-        if (!r.ok) return { imagePath: '', denied: false, text: '无障碍截屏失败：' + r.error }
-        const data = (r.data ?? {}) as { path?: string; width?: number; height?: number }
-        if (!data.path) return { imagePath: '', denied: false, text: '无障碍截屏未返回文件路径' }
-        return inlineShot(
-          data.path,
-          data.width ?? 0,
-          data.height ?? 0,
-          exec as ExecLike,
-          `无障碍通道，设备物理分辨率 ${data.width ?? '?'}x${data.height ?? '?'}`,
-        )
+        if (!r.ok) {
+          // 0.13.8 E6：无障碍截屏不可用（API<30 无 takeScreenshot / FLAG_SECURE 被拒 / 服务未就绪）
+          // → 回落 ADB screencap，而不是把「没有截图能力」当结论抛给模型。
+          if (priv.execAdbLine) {
+            adbNote = `（无障碍截屏不可用：${r.error}——已回落 ADB 通道）`
+          } else {
+            return {
+              imagePath: '', denied: false,
+              text: `无障碍截屏失败：${r.error}。ADB 通道未接通，无法回落——`
+                + '需要截图请先完成 ADB 授权（完全访问 → 允许访问开关 → 配对码），或用 android_ui_dump 读结构。',
+            }
+          }
+        } else {
+          const data = (r.data ?? {}) as { path?: string; width?: number; height?: number }
+          if (!data.path) {
+            if (!priv.execAdbLine) return { imagePath: '', denied: false, text: '无障碍截屏未返回文件路径，且 ADB 通道未接通（无法回落）' }
+            adbNote = '（无障碍截屏未返回文件路径——已回落 ADB 通道）'
+          } else {
+            return inlineShot(
+              data.path,
+              data.width ?? 0,
+              data.height ?? 0,
+              exec as ExecLike,
+              `无障碍通道，设备物理分辨率 ${data.width ?? '?'}x${data.height ?? '?'}`,
+            )
+          }
+        }
       }
       // 0.14 真实通道：adbd（shell uid）执行 screencap → adb pull 回引擎私有临时目录（app uid 可读）。
       if (!priv.execAdbLine) return { imagePath: '', denied: false, text: 'ADB 执行通道未接通（dsh-android-bridge 未提供 execAdbLine）' }
@@ -318,10 +337,89 @@ function tools(ctx: Context, priv: PrivilegeFace) {
         // F2 统一坐标系：回传物理分辨率锚点。模型侧读图可能降采样（maxDim 2048），
         // 严禁直接用截图像素坐标点击——归一化用 android_ui_click 的 nx/ny。
         const size = await screenSize()
-        return inlineShot(local, size.w, size.h, exec as ExecLike, `ADB 通道，设备物理分辨率 ${size.w}x${size.h}`)
+        return inlineShot(local, size.w, size.h, exec as ExecLike, `ADB 通道，设备物理分辨率 ${size.w}x${size.h}${adbNote}`)
       } catch (e) {
         return { imagePath: '', denied: false, text: '截图失败：' + String((e as Error).message) }
       }
+    },
+  })
+
+  const uiDetail = defineTool({
+    name: 'android_ui_detail',
+    description:
+      '【两级披露第二级】按需取回 dump 的全量明细：给 ref 取单个节点的逐字段记录（完整文本/几何/祖先，'
+      + '不受默认渲染压缩影响）；给 all=true 分页取整表（offset/limit，默认 60 行并如实报告省略量）。'
+      + '只在默认清单不够用时用——日常定位用 android_ui_dump。需先执行过 android_ui_dump。',
+    parameters: {
+      ref: { type: 'string', description: '节点引用（id:nN / text:… / desc:… / rid:…；与 all 二选一）' },
+      all: { type: 'boolean', description: 'true = 取整表分页（配 offset/limit）' },
+      offset: { type: 'number', description: '整表起始行（默认 0）' },
+      limit: { type: 'number', description: '整表每页行数（默认 60，上限 200）' },
+    },
+    output: {
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          ok: { type: 'boolean', required: true },
+          denied: { type: 'boolean' },
+          handle: { type: 'string' },
+          path: { type: 'string' },
+          node: { type: 'object', additionalProperties: true },
+          rows: { type: 'array', items: { type: 'object', additionalProperties: true } },
+          total: { type: 'number' },
+          offset: { type: 'number' },
+          omitted: { type: 'number' },
+          text: { type: 'string' },
+        },
+      },
+      render: (_args, v: Record<string, unknown>) => [{
+        type: 'text',
+        text: String(v.text ?? '') + (Array.isArray(v.rows) && v.rows.length > 0
+          ? '\n' + v.rows.map((r) => JSON.stringify(r)).join('\n')
+          : v.node ? '\n' + JSON.stringify(v.node) : ''),
+      }],
+    },
+    execute: async ({ ref, all, offset, limit }: { ref?: string; all?: boolean; offset?: number; limit?: number }, exec) => {
+      const a = guard('ui_detail', { ref, all }, exec as { agent?: { session?: unknown } })
+      if (!a.ok) return { ok: false, denied: true, text: a.guidance }
+      if (!uiCache || Date.now() - uiCache.ts > UI_CACHE_TTL) {
+        return { ok: false, denied: false, text: '没有最近的控件清单——请先 android_ui_dump，再按需取明细' }
+      }
+      const handle = detailHandle
+      const path = detailPath
+      if (ref !== undefined && ref.trim() !== '') {
+        const hit = resolveRef(uiCache.byId, uiCache.nodes, ref.trim(), scopePoolFor())
+        if (!hit.ok) return { ok: false, denied: false, handle, path, text: hit.error }
+        const idx = uiCache.nodes.findIndex((n) => n.id === hit.node.id)
+        const rows = uiCache.nodes
+        const extra: Record<string, unknown> = {}
+        const v2 = uiCache.v2
+        if (v2 && idx >= 0) {
+          const anc = v2.actionableAncestor[idx]
+          extra.actionableAncestor = anc >= 0 ? 'n' + anc : null
+          extra.subtree = { start: 'n' + idx, end: v2.subtreeEnd[idx] > idx ? 'n' + v2.subtreeEnd[idx] : null }
+        }
+        const parent = uiCache.nodes.find((n) => n.id === hit.node.parentId)
+        if (parent) extra.parentLabel = `${parent.type || 'View'}${parent.text ? ' text="' + parent.text.slice(0, 24) + '"' : ''}`
+        return {
+          ok: true, denied: false, handle, path, total: rows.length,
+          node: detailRecord(hit.node, extra) as unknown as Record<string, JsonValue>,
+          text: `明细 ${hit.node.id}（句柄 ${handle}${path ? '，离线 ' + path : ''}）`,
+        }
+      }
+      if (all === true) {
+        const lim = Math.min(Math.max(Number(limit ?? 60) || 60, 1), 200)
+        const { page, offset: off, omitted } = pageRows(uiCache.nodes, Number(offset ?? 0) || 0, lim)
+        return {
+          ok: true, denied: false, handle, path, rows: page.map((n) => detailRecord(n)) as unknown as Array<Record<string, JsonValue>>,
+          total: uiCache.nodes.length, offset: off, omitted,
+          text: `全量明细第 ${off}..${off + page.length - 1} 行 / 共 ${uiCache.nodes.length} 行`
+            + (omitted > 0 ? `（本页外还有 ${omitted} 行，请带 offset 继续）` : '')
+            + `；句柄 ${handle}${path ? '，离线可 read/grep：' + path : ''}`,
+        }
+      }
+      return { ok: false, denied: false, handle, path, text: '请给 ref（单节点）或 all=true（整表分页）' }
     },
   })
 
@@ -520,6 +618,41 @@ function tools(ctx: Context, priv: PrivilegeFace) {
   let uiCache:
     | { nodes: UiNode[]; byId: ReturnType<typeof pruneNodes>['byId']; byOrig: ReturnType<typeof pruneNodes>['byOrig']; parentByOrig: ReturnType<typeof pruneNodes>['parentByOrig']; screen: { w: number; h: number }; rotation: number; ts: number; gen?: number; fingerprint?: string; rawCount?: number; v2?: V2Decoded }
     | null = null
+
+  /** 明细文件目录（与截图/XML 同一个 dsh-tmp；LRU 按前缀清理，保留最近 20 份）。 */
+  const detailDir = (): string => pruneTmp('ui-detail-', 20)
+
+  /**
+   * 发布两级披露的第二级（0.13.8 P2-13）：把全量节点表按**确定性句柄**（结构指纹）落盘，
+   * 第一次调用给出一句「全量明细在哪」。节点数低于阈值时返回空提示——那种规模的清单
+   * 默认渲染已经够全，多说一句只是噪音。
+   */
+  const DETAIL_HINT_MIN_NODES = 60
+  const publishDetail = (
+    nodes: UiNode[],
+    meta: { gen: number; protocol: string; view: string; screen: { w: number; h: number }; rotation: number; rawCount: number },
+  ): { handle: string; path: string; hint: string } => {
+    const handle = treeFingerprint(nodes)
+    let path = ''
+    try {
+      path = writeDetailStore(detailDir(), handle, nodes.map((n) => detailRecord(n)), { ...meta, count: nodes.length, handle })
+    } catch {
+      // 落盘失败绝不影响主结果（与上游 spill 的取向一致：落盘是尽力而为）
+      return { handle, path: '', hint: '' }
+    }
+    detailHandle = handle
+    detailPath = path
+    if (nodes.length < DETAIL_HINT_MIN_NODES) return { handle, path, hint: '' }
+    return {
+      handle,
+      path,
+      hint: `\n全量明细（${nodes.length} 节点逐字段，含完整文本/几何/祖先，可按需或离线 read/grep）：android_ui_detail all=true（句柄 ${handle}）`,
+    }
+  }
+
+  /** 最近一次 dump 的明细句柄（两级披露取回时用；无 dump 时为空）。 */
+  let detailHandle = ''
+  let detailPath = ''
 
   /**
    * 0.13.8 P0-4：树结构指纹（FNV-1a）——「界面未变」快路径的判定依据。
@@ -793,17 +926,27 @@ function tools(ctx: Context, priv: PrivilegeFace) {
         const webHint = webNode
           ? `\n检测到 WebView 容器 ${webNode.id}：其内部控件在本通道不可见。若目标是 DSH 自有 Web UI，改用 android_web_dump（DOM 快照，毫秒级、按选择器精准命中）；第三方网页仍只能靠坐标。`
           : ''
+        const detail = publishDetail(pruned.nodes, {
+          gen: v2?.gen ?? data.gen ?? -1,
+          protocol: v2 ? 'v2' : 'v1',
+          view: v2?.view ?? 'all',
+          screen,
+          rotation: v2?.rotation ?? data.rotation ?? 0,
+          rawCount: pruned.rawCount,
+        })
         return {
           ok: true,
           denied: false,
           screen,
-          rotation: data.rotation ?? 0,
+          rotation: v2?.rotation ?? data.rotation ?? 0,
           count: pruned.nodes.length,
           rawCount: pruned.rawCount,
           nodes: pruned.nodes as unknown as JsonValue[],
+          detailHandle: detail.handle,
+          detailPath: detail.path,
           note: `无障碍通道（backend=a11y，协议 ${v2 ? 'V2 列式' : 'V1'}）：id 仅在最近一次 dump 内有效；页面变化后请重新 dump`,
           text: `控件清单（无障碍通道，未截断）：${pruned.nodes.length} 个节点（原始 ${pruned.rawCount}，剔除 ${pruned.rawCount - pruned.nodes.length} 个零尺寸/完全重复节点，屏幕 ${screen.w}x${screen.h}；前台 ${fg?.pkg ?? '?'}/${fg?.activity ?? '?'}）`
-            + warn + webHint,
+            + warn + webHint + detail.hint,
         }
       }
       if (!priv.execAdbLine) return { ok: false, denied: false, screen: { w: 0, h: 0 }, rotation: 0, count: 0, rawCount: 0, nodes: [], text: 'ADB 执行通道未接通（dsh-android-bridge 未提供 execAdbLine）' }
@@ -1508,11 +1651,20 @@ function tools(ctx: Context, priv: PrivilegeFace) {
   const uiGlobal = defineTool({
     name: 'android_ui_global',
     description:
-      '【首选】系统级导航动作（无障碍通道，不需要 ADB）：back=返回上一级、home=回桌面、'
-      + 'recents=最近任务、notifications=下拉通知栏。卡在子菜单/弹窗/详情页出不来时，第一步就用 back。'
+      '【首选】系统级动作（无障碍通道，不需要 ADB）：back=返回上一级、home=回桌面、recents=最近任务、'
+      + 'notifications=下拉通知栏、quickSettings=快捷设置面板、toggleSplitScreen=分屏、powerDialog=关机菜单、'
+      + 'lockScreen=锁屏、takeScreenshot=系统截图、menu=菜单键、mediaPlayPause=播放/暂停、'
+      + 'dismissNotificationShade=收起通知栏、accessibilityShortcut=无障碍快捷方式。'
+      + '卡在子菜单/弹窗/详情页出不来时，第一步就用 back。'
+      + '设备实际可用的动作由系统 getSystemActions() 决定，不可用者返回可用清单（不会静默无效果）。'
       + '需设备控制授权（无障碍服务已开启即可）+ 会话档位 danger-full-access。',
     parameters: {
-      action: { type: 'string', required: true, enum: ['back', 'home', 'recents', 'notifications'], description: '要执行的全局动作' },
+      action: {
+        type: 'string', required: true,
+        enum: ['back', 'home', 'recents', 'notifications', 'quickSettings', 'toggleSplitScreen', 'powerDialog',
+          'lockScreen', 'takeScreenshot', 'menu', 'mediaPlayPause', 'dismissNotificationShade', 'accessibilityShortcut'],
+        description: '要执行的全局动作（可用集由系统决定，不可用会回可用清单）',
+      },
     },
     output: {
       schema: {
@@ -1530,8 +1682,10 @@ function tools(ctx: Context, priv: PrivilegeFace) {
     execute: async ({ action }: { action: string }, exec) => {
       const a = guard('ui_global', { action }, exec as { agent?: { session?: unknown } })
       if (!a.ok) return { ok: false, denied: true, action, text: a.guidance }
-      if (!['back', 'home', 'recents', 'notifications'].includes(action)) {
-        return { ok: false, denied: false, action, text: 'action 必须是 back / home / recents / notifications' }
+      const GLOBAL_ACTIONS = ['back', 'home', 'recents', 'notifications', 'quickSettings', 'toggleSplitScreen',
+        'powerDialog', 'lockScreen', 'takeScreenshot', 'menu', 'mediaPlayPause', 'dismissNotificationShade', 'accessibilityShortcut']
+      if (!GLOBAL_ACTIONS.includes(action)) {
+        return { ok: false, denied: false, action, text: `action 必须是 ${GLOBAL_ACTIONS.join(' / ')}` }
       }
       const r = await a11yExec('global', { action }, 6000)
       if (!r.ok) {

--- a/plugins/dsh-android-manage/test/detail-store.test.mjs
+++ b/plugins/dsh-android-manage/test/detail-store.test.mjs
@@ -1,0 +1,37 @@
+// 两级披露的明细存储（0.13.8 P2-13）：句柄确定性与诚实分页
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { detailFileName, detailRecord, pageRows } from '../lib/detail-store.js'
+
+test('文件名：句柄确定性（无时间戳/随机 id，§10 纪律）', () => {
+  assert.equal(detailFileName('fp1a2b3c'), detailFileName('fp1a2b3c'), '同一句柄必须同一文件名')
+  assert.notEqual(detailFileName('fp1a2b3c'), detailFileName('fp1a2b3d'), '不同屏必须是不同文件')
+  assert.equal(detailFileName('fp/x\\y'), 'ui-detail-fpxy.jsonl', '异常字符剔除后仍可作文件名')
+  assert.equal(detailFileName(''), 'ui-detail-unknown.jsonl')
+})
+
+test('分页：切片正确 + 如实报告省略量', () => {
+  const rows = Array.from({ length: 25 }, (_, i) => i)
+  const p1 = pageRows(rows, 0, 10)
+  assert.deepEqual(p1.page, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+  assert.equal(p1.omitted, 15)
+  const p3 = pageRows(rows, 20, 10)
+  assert.deepEqual(p3.page, [20, 21, 22, 23, 24])
+  assert.equal(p3.omitted, 0)
+  assert.equal(pageRows(rows, 999, 10).page.length, 0, '越界返回空页而非抛异常')
+  assert.equal(pageRows(rows, -5, 0).page.length, 1, 'limit 下限 1（避免空页死循环）')
+})
+
+test('明细记录：字段齐全（第二级必须比默认渲染更全）', () => {
+  const node = {
+    id: 'n7', parentId: 'n3', text: '长文本', desc: 'd', rid: 'com.x:id/y', type: 'Button',
+    x: 1, y: 2, w: 3, h: 4, cx: 2, cy: 4, depth: 3, clickable: true, scrollable: false,
+    editable: false, checked: false, visible: true, pkg: 'com.x', windowId: '9',
+  }
+  const rec = detailRecord(node, { actionableAncestor: 'n2' })
+  for (const key of ['id', 'parentId', 'text', 'desc', 'rid', 'type', 'x', 'y', 'w', 'h', 'cx', 'cy',
+    'depth', 'clickable', 'scrollable', 'editable', 'checked', 'visible', 'pkg', 'windowId', 'actionableAncestor']) {
+    assert.ok(key in rec, '明细缺字段 ' + key)
+  }
+})

--- a/scripts/check-patch-mirror.mjs
+++ b/scripts/check-patch-mirror.mjs
@@ -148,6 +148,8 @@ if (peer) {
     'scripts/check-bounded-io.mjs',
     'scripts/check-protocol-v2.mjs',
     'scripts/gen-protocol-v2-fixture.mjs',
+    'scripts/profile-web.cordis.patch.yml',
+    'scripts/snapshot-config/engine-overlay.json',
   ]
   for (const rel of MIRROR_TOP) {
     const theirs = join(peer, rel)


### PR DESCRIPTION
## 内容

0.13.8 批 F 的 P2 收口：三项里两项落地，第三项**经设备实测判定无需做**，并因此暴露两个真缺陷（已登记坑位与 known-gaps）。

### P2-13 两级披露 + DetailStore（新工具 `android_ui_detail`）

- 默认 dump 仍是紧凑渲染；**节点数 ≥ 60 时**附一行「全量明细在哪」——句柄 = 结构指纹（**确定性**，无时间戳/随机 id，遵循 V2 §10「结果里不要放可变文本」）。
- `ref` → 单节点逐字段记录（完整文本/几何，另附 `actionableAncestor`、子树区间、父节点标签）；`all=true` → 整表分页（默认 60 行，上限 200，**如实报告省略量**，对齐上游 output-retention 的口径）。
- 明细落 `dsh-tmp/ui-detail-<句柄>.jsonl`（LRU 保留 20 份），可离线 `read`/`grep`；落盘失败绝不影响主结果。

### P2-15 通道诊断面：结构化 route 块 + 协议协商

- `android_privilege_status` 增加 `route`：每个常用操作（snapshot/click/scroll/setText/screenshot/global）**走哪条通道、为什么、另一条缺什么**——以前这些判断只存在于代码路径里，模型只能失败后猜。
- 新增 `shell` 块：壳侧声明的 `pv`/`caps` 与**协商结论**。
- `control-queue` 落地协商：老壳（无 `pv`）走 V1 兼容路径；**壳比引擎新 → 422 + 升级指引**（V2 §S4.1 场景 3：宁可明确失败，也不让模型看到一株「看起来正常」的空树）。

### P2-14 spill 挂载：实测判定无需做（结论修正）

按设计文档把 `spill-local` + `spill-policy` 挂进 `profile-web.cordis.patch.yml` 后，**设备上整棵插件树加载失败**：

```
dsh: plugin tree failed to load: failed to apply loader entry include (cordis:include):
  duplicate loader entry id: spill-local
```

即**上游 host 组合默认已经挂了 spill 子系统**——「已装未挂」是把 overlay manifest 的「包在快照里」误读成「没挂」。`dsh-output-retention` 本就是 spill-policy 依赖的库（README 明确「consumers import this library directly rather than loading it through cordis.yml」），不作为 row 挂载。挂载已回退，结论写回 V2 文档。

### 顺带暴露的两个真缺陷（已登记）

| 坑 | 内容 |
|---|---|
| 69 | 往 profile patch 挂上游已挂的包 → **整棵树**加载失败（不是单插件降级）。新增 `- insert:` 前必须先确认 row id 在上游组合里不存在 |
| 70 | **patch 合并语义「按 id 只增不删」**：错误 row 写进设备后，改回代码 + 重装 APK + 重解压快照**都删不掉**（实测持续起不来）→ 恢复路径与产品口子已入 known-gaps |
| 71 | profiles 目录里 root 属主文件 → 引擎 `watch` EACCES 崩溃，表现为「启动失败」但插件日志无错（调试时踩到） |

### 测试与门禁

- 新增 `detail-store.test.mjs`（3 例：句柄确定性、分页诚实性、字段齐全性）与 `protocol-negotiation.test.mjs`（4 例：老壳兼容/同版本/新壳拒绝/非法值）；两插件 `npm test` 全绿。
- 镜像比对面再扩两项：`scripts/profile-web.cordis.patch.yml`、`scripts/snapshot-config/engine-overlay.json`（两树各自构建都用到，单边演进同样静默）。

### 设备验证

1. spill 挂载的失败与恢复**都在设备上实测**：挂载 → 引擎起不来（duplicate id）→ 回退代码并重装 → 仍起不来（坑 70 的只增不删）→ 手工清理设备上的 patch 行 → 引擎恢复、WebUI 正常；
2. `route` 与协商块的**运行时**输出需要真实会话调用（无可用模型），已由单测覆盖纯函数部分，端到端留给发布前真机走查（如实说明）。