### PR TITLE
feat: 批 G3 余项——悬浮球动效 M4-M8（入场/配色/文案/呼吸/脉冲）

### DIFF
--- a/app/src/main/java/com/dsharnessmobile/shell/OverlayHalo.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/OverlayHalo.kt
@@ -56,12 +56,17 @@ class OverlayHalo(private val svc: OverlayService) {
       val hv = svc.haloView ?: return@post
       val g = hv.background as? GradientDrawable ?: return@post
       setHaloColors(g, halo)
-      // 工作中光环缓脉动（spring 风格呼吸：AlphaAnimation 循环）
-      val anim = AlphaAnimation(1f, 0.7f).apply {
-        duration = 1100; repeatMode = AlphaAnimation.REVERSE; repeatCount = if (halo == Halo.WORKING) AlphaAnimation.INFINITE else 0
+      // 脉动：WORKING = 缓呼吸（spring 风格）；PENDING = 更快更深的琥珀脉（M8，0.13.8 G3 余项，
+      // 待答是「要人动手」的状态，脉动节奏刻意比工作态更急）。IDLE 静止。
+      // 统一受 DsUi.animationsEnabled 降级（系统关动画/省电模式 → 全部静止，不耗帧）。
+      val pulse = halo == Halo.WORKING || halo == Halo.PENDING
+      val anim = AlphaAnimation(1f, if (halo == Halo.PENDING) 0.55f else 0.7f).apply {
+        duration = if (halo == Halo.PENDING) 900 else 1100
+        repeatMode = AlphaAnimation.REVERSE
+        repeatCount = if (pulse) AlphaAnimation.INFINITE else 0
       }
       hv.animation = null
-      if (halo == Halo.WORKING) hv.startAnimation(anim)
+      if (pulse && DsUi.animationsEnabled(svc)) hv.startAnimation(anim) else hv.alpha = 1f
     }
   }
 

--- a/app/src/main/java/com/dsharnessmobile/shell/OverlayPanel.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/OverlayPanel.kt
@@ -413,6 +413,73 @@ class OverlayPanel(private val svc: OverlayService) {
   /** 渲染卡片（官方提问卡风格）：header 行（灰标签 + ✕ 关闭）、问题加粗、编号徽章选项行
    *  （label + 灰 description）、✎「输入你的答案」自定义行、页脚 ‹1/N› 翻页 + 跳过本题 + 下一题/提交。
    *  force=false 时防 live 流重绘打断输入焦点。 */
+  /**
+   * M4/M5/M6/M7（0.13.8 G3 余项）：悬浮球动效的四个落点，统一走 [DsUi.animationsEnabled]
+   * 降级——系统关动画/省电模式下全部退化为瞬时切换（不闪、不卡、不消耗帧）。
+   * 设计口径：位移与透明度只用短时（≤220ms）一次性动画；呼吸/脉冲用无限循环但**只作用于
+   * 单行状态文本与光环**，避免整面板反复重绘（低端机上那才真卡）。
+   */
+  private fun animationsOn(): Boolean = DsUi.animationsEnabled(svc)
+
+  /** M4：待答卡入场——位移 6dp + 渐显（禁用动画时直接显示）。 */
+  private fun animateCardIn(view: View) {
+    if (!animationsOn()) { view.alpha = 1f; view.translationY = 0f; return }
+    val rise = 6 * svc.resources.displayMetrics.density
+    view.animate().cancel()
+    view.alpha = 0f
+    view.translationY = rise
+    view.animate().alpha(1f).translationY(0f)
+      .setDuration(200L).setInterpolator(DsUi.ease).start()
+  }
+
+  /** M5：状态行配色在「空闲/工作/待答」之间平滑过渡（琥珀↔文本色），用 ArgbEvaluator 而非硬切。 */
+  private fun animateTextColor(tv: TextView, target: Int) {
+    val from = (tv.tag as? Int) ?: target
+    tv.tag = target
+    if (!animationsOn() || from == target) { tv.setTextColor(target); return }
+    android.animation.ValueAnimator.ofObject(
+      android.animation.ArgbEvaluator(), from, target,
+    ).apply {
+      duration = 220L
+      interpolator = DsUi.ease
+      addUpdateListener { tv.setTextColor(it.animatedValue as Int) }
+      start()
+    }
+  }
+
+  /** M6：状态行换文案——只在文案真的变了时做一次「淡出→换字→淡入」，避免每帧重排。 */
+  private fun setStatusText(tv: TextView, next: String) {
+    if (tv.text?.toString() == next) return
+    if (!animationsOn()) { tv.text = next; tv.alpha = 1f; return }
+    tv.animate().cancel()
+    tv.animate().alpha(0f).setDuration(90L).withEndAction {
+      tv.text = next
+      tv.animate().alpha(1f).setDuration(140L).start()
+    }.start()
+  }
+
+  /** M7：琥珀呼吸——待答（question/approval）期间状态行缓慢明暗（1.0↔0.55，1.2s 一次往返）。
+   *  动画实例挂在面板字段上（工程无 res id，故不用 View tag 键）。 */
+  private var statusBreathing: android.animation.ObjectAnimator? = null
+
+  private fun setAmberBreathing(tv: TextView, on: Boolean) {
+    if (on && animationsOn()) {
+      if (statusBreathing?.isRunning == true) return
+      statusBreathing = android.animation.ObjectAnimator.ofFloat(tv, View.ALPHA, 1f, 0.55f).apply {
+        duration = 1200L
+        repeatMode = android.animation.ValueAnimator.REVERSE
+        repeatCount = android.animation.ValueAnimator.INFINITE
+        interpolator = DsUi.ease
+        start()
+      }
+    } else if (statusBreathing != null) {
+      statusBreathing?.cancel()
+      statusBreathing = null
+      tv.animate().cancel()
+      tv.alpha = 1f
+    }
+  }
+
   private fun renderPendingCard(force: Boolean = false) {
     val box = pendingBox ?: return
     val cur = currentPending()
@@ -447,6 +514,7 @@ class OverlayPanel(private val svc: OverlayService) {
         setMargins(0, (6 * dp).toInt(), 0, 0)
       })
       box.visibility = View.VISIBLE
+      animateCardIn(box)
       return
     }
     val qe = cur.second as PendingQuestion
@@ -616,6 +684,7 @@ class OverlayPanel(private val svc: OverlayService) {
     }
     box.addView(foot, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT))
     box.visibility = View.VISIBLE
+    animateCardIn(box)
   }
 
   // ── 应答（0.13.3 W3：POST /api/$events/result，{clientId,eventId,outcome}）──
@@ -780,28 +849,35 @@ class OverlayPanel(private val svc: OverlayService) {
       statusText?.let {
         if (svc.pendingKind == "question") {
           (it as ShimmerTextView).setShimmering(false)
-          it.setTextColor(0xFFB8860B.toInt())
-          it.text = "等待你的回答…"
+          animateTextColor(it, 0xFFB8860B.toInt())
+          setStatusText(it, "等待你的回答…")
+          setAmberBreathing(it, true)
         } else if (svc.pendingKind == "approval") {
           (it as ShimmerTextView).setShimmering(false)
-          it.setTextColor(0xFFB8860B.toInt())
-          it.text = "等待权限审批…"
+          animateTextColor(it, 0xFFB8860B.toInt())
+          setStatusText(it, "等待权限审批…")
+          setAmberBreathing(it, true)
         } else if (svc.sessionBusy) {
+          setAmberBreathing(it, false)
           if (svc.currentToolName.isNotBlank()) {
             // 模板化（用户拍板）：调工具 → 工具类型 + 概览；思考 → Deep diving 扫光。
-            it.text = templateTool()
-              .replace("{tool}", svc.currentToolName)
-              .replace("{summary}", svc.currentToolSummary)
+            setStatusText(
+              it,
+              templateTool()
+                .replace("{tool}", svc.currentToolName)
+                .replace("{summary}", svc.currentToolSummary),
+            )
             (it as ShimmerTextView).setShimmering(false)
-            it.setTextColor(themeColors().idleText)
+            animateTextColor(it, themeColors().idleText)
           } else {
-            it.text = templateThinking()
+            setStatusText(it, templateThinking())
             (it as ShimmerTextView).setShimmering(true)
           }
         } else {
           (it as ShimmerTextView).setShimmering(false)
-          it.setTextColor(0xFF8A8F98.toInt())
-          it.text = if (svc.engineRunning) "空闲" else "引擎离线"
+          setAmberBreathing(it, false)
+          animateTextColor(it, 0xFF8A8F98.toInt())
+          setStatusText(it, if (svc.engineRunning) "空闲" else "引擎离线")
         }
       }
       toolChip?.let {

--- a/scripts/check-protocol-v2.mjs
+++ b/scripts/check-protocol-v2.mjs
@@ -47,10 +47,17 @@ const newest = (dir, ext) => {
   }
   return { ms: newestMs, file: newestFile }
 }
-const srcNewest = newest(join(ROOT, PLUGIN, 'src'), '.ts')
-const libNewest = newest(join(ROOT, PLUGIN, 'lib'), '.js')
-if (srcNewest.ms > libNewest.ms) {
-  fail(`构建产物过期：src/${srcNewest.file} 比 lib/${libNewest.file} 新\n  先构建：cd ${PLUGIN} && npm run build`)
+const srcDir = join(ROOT, PLUGIN, 'src')
+const libDir = join(ROOT, PLUGIN, 'lib')
+const staleness = () => {
+  const s = newest(srcDir, '.ts')
+  const l = newest(libDir, '.js')
+  return { s, l, stale: s.ms > l.ms }
+}
+const cur = staleness()
+if (cur.stale) {
+  fail(`构建产物过期：src/${cur.s.file} 比 lib/${cur.l.file} 新
+  先构建：cd ${PLUGIN} && npm install && npm run build（构建链不代建插件，免得注入中途被重写）`)
 }
 
 // 跨语言 fixture 必须与 TS 编码器同源（壳侧 Kotlin 单测就是拿它比对的）


### PR DESCRIPTION
## 内容

0.13.8 G3 收尾：悬浮球动效 M4–M8（M1/M2/M9/M10/M11 已在 #191）。四类动效**全部走 `DsUi.animationsEnabled` 降级**——系统关动画或省电模式下退化为瞬时切换（不闪、不卡、不耗帧）。

| 项 | 落点 | 做法 |
|---|---|---|
| M4 待答卡入场 | `renderPendingCard`（审批卡 + 提问卡两个分支） | 位移 6dp + 渐显，200ms |
| M5 配色过渡 | 状态行 | 空闲灰 / 工作中文本色 / 待答琥珀之间 ArgbEvaluator 220ms 过渡，不再硬切 |
| M6 文案切换 | 状态行 | 只在文案真的变了时「淡出 90ms → 换字 → 淡入 140ms」，避免每帧重排 |
| M7 琥珀呼吸 | 状态行（待答期间） | 1.0↔0.55 慢呼吸（1.2s 往返），退出待答立即停并复位 alpha |
| M8 PENDING 光环脉冲 | `OverlayHalo.setHalo` | 脉动从「仅 WORKING」扩到「WORKING 缓呼吸 + PENDING 更快更深（900ms / 0.55）」，IDLE 静止；顺带把原本无条件跑的 WORKING 脉动也纳入降级门 |

### 实现说明（两点取舍）

- **不用 TextSwitcher 控件**：状态行是既有 `ShimmerTextView`（承载思考态扫光），换成 TextSwitcher 会同时牵动扫光逻辑与布局。改为等价的「淡出→换字→淡入」助手，风险面小、效果一致。
- **呼吸动画实例挂面板字段而非 View tag**：本工程无 `res/values/ids.xml`，`R.id.*` 不存在（首次编译报 `Unresolved reference: id`，已改为字段持有）。

### 设备实测

- MuMu x86_64：Fast 档构建 + 覆盖安装 → 面板正常展开（截图见 PR 描述），状态行按新路径渲染（空闲态），logcat 无异常；
- **剩余验证项（如实说明）**：动效**手感**（时长/幅度是否舒适、待答呼吸是否过急）需要人眼走查——静态截图无法断言；真机 arm64 同样留发布前走查。

### 顺带修复

`check-protocol-v2.mjs` 的过期判定说明改为「构建链不代建插件」，并把 `npm install && npm run build` 写进指引：本轮实测发现门禁内**自动重建**会与注入/打包竞态（rebuild 与 gradle 读同一份 lib），所以刻意不做自愈，只做明确失败。