### PR TITLE
fix: @ 菜单勾选框同步/深色适配（镜像 0.2.6）+ 键盘空白带 #197 机制①（壳侧根治）

### DIFF
--- a/app/src/main/java/com/dsharnessmobile/shell/MainActivity.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/MainActivity.kt
@@ -176,6 +176,15 @@ class MainActivity : ComponentActivity() {
       webSystemTopInset = pxToCssPx(maxOf(bars.top, cutout.top), density)
       webSystemBottomInset = pxToCssPx(maxOf(bars.bottom, mandatoryGestures), density)
       webImeBottomInset = pxToCssPx(ime, density)
+      // #197（机制①）：edge-to-edge 下 WebView 的**布局尺寸从不随 IME 变化**（布局视口恒 800），
+      // 页面只把 frame 高度钉成 visualViewport.height → 输入框在布局里仍在页面底部，Chrome 按
+      // 「把它滚进可视区」平移视觉视口；页面随后缩短 frame，Chrome 不重算 → offsetTop 残留
+      // （实测 ime=371 ↔ vvTop=371），表现为键盘弹起后底部一大片空白。
+      // 修法：把 IME inset 施加到 WebView 自身的**布局尺寸**上（底 padding 收缩内容盒）——
+      // 布局视口真的变短，浏览器就没有可平移的余地，机制① 从根上消失；只推 CSS 变量做不到这点。
+      if (webViewReady) {
+        webView.setPadding(0, 0, 0, ime)
+      }
       scheduleWebInsetsPush()
       if (guideViewReady) {
         val gutter = resources.getDimensionPixelSize(R.dimen.ds_guide_gutter)

--- a/app/src/main/java/com/dsharnessmobile/shell/OverlayHalo.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/OverlayHalo.kt
@@ -56,12 +56,17 @@ class OverlayHalo(private val svc: OverlayService) {
       val hv = svc.haloView ?: return@post
       val g = hv.background as? GradientDrawable ?: return@post
       setHaloColors(g, halo)
-      // 工作中光环缓脉动（spring 风格呼吸：AlphaAnimation 循环）
-      val anim = AlphaAnimation(1f, 0.7f).apply {
-        duration = 1100; repeatMode = AlphaAnimation.REVERSE; repeatCount = if (halo == Halo.WORKING) AlphaAnimation.INFINITE else 0
+      // 脉动：WORKING = 缓呼吸（spring 风格）；PENDING = 更快更深的琥珀脉（M8，0.13.8 G3 余项，
+      // 待答是「要人动手」的状态，脉动节奏刻意比工作态更急）。IDLE 静止。
+      // 统一受 DsUi.animationsEnabled 降级（系统关动画/省电模式 → 全部静止，不耗帧）。
+      val pulse = halo == Halo.WORKING || halo == Halo.PENDING
+      val anim = AlphaAnimation(1f, if (halo == Halo.PENDING) 0.55f else 0.7f).apply {
+        duration = if (halo == Halo.PENDING) 900 else 1100
+        repeatMode = AlphaAnimation.REVERSE
+        repeatCount = if (pulse) AlphaAnimation.INFINITE else 0
       }
       hv.animation = null
-      if (halo == Halo.WORKING) hv.startAnimation(anim)
+      if (pulse && DsUi.animationsEnabled(svc)) hv.startAnimation(anim) else hv.alpha = 1f
     }
   }
 

--- a/app/src/main/java/com/dsharnessmobile/shell/OverlayPanel.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/OverlayPanel.kt
@@ -413,6 +413,73 @@ class OverlayPanel(private val svc: OverlayService) {
   /** 渲染卡片（官方提问卡风格）：header 行（灰标签 + ✕ 关闭）、问题加粗、编号徽章选项行
    *  （label + 灰 description）、✎「输入你的答案」自定义行、页脚 ‹1/N› 翻页 + 跳过本题 + 下一题/提交。
    *  force=false 时防 live 流重绘打断输入焦点。 */
+  /**
+   * M4/M5/M6/M7（0.13.8 G3 余项）：悬浮球动效的四个落点，统一走 [DsUi.animationsEnabled]
+   * 降级——系统关动画/省电模式下全部退化为瞬时切换（不闪、不卡、不消耗帧）。
+   * 设计口径：位移与透明度只用短时（≤220ms）一次性动画；呼吸/脉冲用无限循环但**只作用于
+   * 单行状态文本与光环**，避免整面板反复重绘（低端机上那才真卡）。
+   */
+  private fun animationsOn(): Boolean = DsUi.animationsEnabled(svc)
+
+  /** M4：待答卡入场——位移 6dp + 渐显（禁用动画时直接显示）。 */
+  private fun animateCardIn(view: View) {
+    if (!animationsOn()) { view.alpha = 1f; view.translationY = 0f; return }
+    val rise = 6 * svc.resources.displayMetrics.density
+    view.animate().cancel()
+    view.alpha = 0f
+    view.translationY = rise
+    view.animate().alpha(1f).translationY(0f)
+      .setDuration(200L).setInterpolator(DsUi.ease).start()
+  }
+
+  /** M5：状态行配色在「空闲/工作/待答」之间平滑过渡（琥珀↔文本色），用 ArgbEvaluator 而非硬切。 */
+  private fun animateTextColor(tv: TextView, target: Int) {
+    val from = (tv.tag as? Int) ?: target
+    tv.tag = target
+    if (!animationsOn() || from == target) { tv.setTextColor(target); return }
+    android.animation.ValueAnimator.ofObject(
+      android.animation.ArgbEvaluator(), from, target,
+    ).apply {
+      duration = 220L
+      interpolator = DsUi.ease
+      addUpdateListener { tv.setTextColor(it.animatedValue as Int) }
+      start()
+    }
+  }
+
+  /** M6：状态行换文案——只在文案真的变了时做一次「淡出→换字→淡入」，避免每帧重排。 */
+  private fun setStatusText(tv: TextView, next: String) {
+    if (tv.text?.toString() == next) return
+    if (!animationsOn()) { tv.text = next; tv.alpha = 1f; return }
+    tv.animate().cancel()
+    tv.animate().alpha(0f).setDuration(90L).withEndAction {
+      tv.text = next
+      tv.animate().alpha(1f).setDuration(140L).start()
+    }.start()
+  }
+
+  /** M7：琥珀呼吸——待答（question/approval）期间状态行缓慢明暗（1.0↔0.55，1.2s 一次往返）。
+   *  动画实例挂在面板字段上（工程无 res id，故不用 View tag 键）。 */
+  private var statusBreathing: android.animation.ObjectAnimator? = null
+
+  private fun setAmberBreathing(tv: TextView, on: Boolean) {
+    if (on && animationsOn()) {
+      if (statusBreathing?.isRunning == true) return
+      statusBreathing = android.animation.ObjectAnimator.ofFloat(tv, View.ALPHA, 1f, 0.55f).apply {
+        duration = 1200L
+        repeatMode = android.animation.ValueAnimator.REVERSE
+        repeatCount = android.animation.ValueAnimator.INFINITE
+        interpolator = DsUi.ease
+        start()
+      }
+    } else if (statusBreathing != null) {
+      statusBreathing?.cancel()
+      statusBreathing = null
+      tv.animate().cancel()
+      tv.alpha = 1f
+    }
+  }
+
   private fun renderPendingCard(force: Boolean = false) {
     val box = pendingBox ?: return
     val cur = currentPending()
@@ -447,6 +514,7 @@ class OverlayPanel(private val svc: OverlayService) {
         setMargins(0, (6 * dp).toInt(), 0, 0)
       })
       box.visibility = View.VISIBLE
+      animateCardIn(box)
       return
     }
     val qe = cur.second as PendingQuestion
@@ -616,6 +684,7 @@ class OverlayPanel(private val svc: OverlayService) {
     }
     box.addView(foot, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT))
     box.visibility = View.VISIBLE
+    animateCardIn(box)
   }
 
   // ── 应答（0.13.3 W3：POST /api/$events/result，{clientId,eventId,outcome}）──
@@ -780,28 +849,35 @@ class OverlayPanel(private val svc: OverlayService) {
       statusText?.let {
         if (svc.pendingKind == "question") {
           (it as ShimmerTextView).setShimmering(false)
-          it.setTextColor(0xFFB8860B.toInt())
-          it.text = "等待你的回答…"
+          animateTextColor(it, 0xFFB8860B.toInt())
+          setStatusText(it, "等待你的回答…")
+          setAmberBreathing(it, true)
         } else if (svc.pendingKind == "approval") {
           (it as ShimmerTextView).setShimmering(false)
-          it.setTextColor(0xFFB8860B.toInt())
-          it.text = "等待权限审批…"
+          animateTextColor(it, 0xFFB8860B.toInt())
+          setStatusText(it, "等待权限审批…")
+          setAmberBreathing(it, true)
         } else if (svc.sessionBusy) {
+          setAmberBreathing(it, false)
           if (svc.currentToolName.isNotBlank()) {
             // 模板化（用户拍板）：调工具 → 工具类型 + 概览；思考 → Deep diving 扫光。
-            it.text = templateTool()
-              .replace("{tool}", svc.currentToolName)
-              .replace("{summary}", svc.currentToolSummary)
+            setStatusText(
+              it,
+              templateTool()
+                .replace("{tool}", svc.currentToolName)
+                .replace("{summary}", svc.currentToolSummary),
+            )
             (it as ShimmerTextView).setShimmering(false)
-            it.setTextColor(themeColors().idleText)
+            animateTextColor(it, themeColors().idleText)
           } else {
-            it.text = templateThinking()
+            setStatusText(it, templateThinking())
             (it as ShimmerTextView).setShimmering(true)
           }
         } else {
           (it as ShimmerTextView).setShimmering(false)
-          it.setTextColor(0xFF8A8F98.toInt())
-          it.text = if (svc.engineRunning) "空闲" else "引擎离线"
+          setAmberBreathing(it, false)
+          animateTextColor(it, 0xFF8A8F98.toInt())
+          setStatusText(it, if (svc.engineRunning) "空闲" else "引擎离线")
         }
       }
       toolChip?.let {

--- a/dsh-client-ui-responsive/package.json
+++ b/dsh-client-ui-responsive/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dsh-android/dsh-client-ui-responsive",
   "description": "Client plugin: Android mobile adaptation layer over the upstream ui-layout frame (narrow drawer form, top-bar sidebar toggle, safe areas, native open-with wiring)",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",

--- a/dsh-client-ui-responsive/package.json
+++ b/dsh-client-ui-responsive/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dsh-android/dsh-client-ui-responsive",
   "description": "Client plugin: Android mobile adaptation layer over the upstream ui-layout frame (narrow drawer form, top-bar sidebar toggle, safe areas, native open-with wiring)",
-  "version": "0.2.3",
+  "version": "0.2.6",
   "type": "module",
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",

--- a/dsh-client-ui-responsive/package.json
+++ b/dsh-client-ui-responsive/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dsh-android/dsh-client-ui-responsive",
   "description": "Client plugin: Android mobile adaptation layer over the upstream ui-layout frame (narrow drawer form, top-bar sidebar toggle, safe areas, native open-with wiring)",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "module",
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",

--- a/dsh-client-ui-responsive/src/client/index.ts
+++ b/dsh-client-ui-responsive/src/client/index.ts
@@ -50,7 +50,7 @@ import { OpenInFileManagerAction } from './mobile/OpenInFileManagerAction.tsx'
 import { EXTERNAL_OPEN_ID, externalOpenDefinition } from './mobile/external-open-paths.ts'
 import { ExternalOpenTab } from './mobile/external-open.tsx'
 import { SettingsDocumentAction } from './mobile/settings-document.ts'
-import { ReferenceMenuEnhancer } from './mobile/reference-menu.ts'
+import { ReferenceMenuEnhancer, REFERENCE_BAR_CSS } from './mobile/reference-menu.ts'
 
 // Contract exports only (export-convergence rule): the plugin surface is
 // `apply` and `inject`; every component, marker, and helper stays internal.
@@ -279,6 +279,9 @@ export function apply(ctx: ClientContext): void {
     enhancer.attach()
     return () => { enhancer.detach() }
   }, 'ui-responsive: reference menu enhancer')
+  // 多选条与勾选框的样式（0.13.8 修复深色适配）：集中注入，含 hover/active/焦点态与
+  // prefers-color-scheme 暗色兜底（壳侧 ThemeBridge 已把该查询接到系统深浅色）。
+  ctx.effect(() => injectStyle('reference-bar', REFERENCE_BAR_CSS), 'ui-responsive: reference menu bar styles')
 
   // Settings "open configuration file" (apk #152): the upstream action hands the document to a
   // desktop text editor, which Android does not have; claim the click and open the settings

--- a/dsh-client-ui-responsive/src/client/keyboard-boundary.ts
+++ b/dsh-client-ui-responsive/src/client/keyboard-boundary.ts
@@ -29,9 +29,14 @@ export class KeyboardBoundary {
   private lastVv = 0
   /** 收敛代次（#197 机制②）：新事件打断旧的复算链，避免过期复算覆盖新状态。 */
   private settleGeneration = 0
+  /** 延迟复算的定时器句柄（detach 时清掉；jsdom 测试结束后残留回调会报错）。 */
+  private settleTimer: number | null = null
+  /** 已卸载标记：卸载后任何延迟回调都必须直接返回（宿主可能已销毁 window/document）。 */
+  private detached = false
 
   /** Watch visualViewport resize + the shell's IME inset variable. */
   attach(): void {
+    this.detached = false
     window.visualViewport?.addEventListener('resize', this.onViewportChange)
     // jsdom's matchMedia stub returns a bare object: tolerate it (the
     // visualViewport resize still drives the pin).
@@ -42,6 +47,11 @@ export class KeyboardBoundary {
 
   /** Remove listeners and restore the frame and seat styles. */
   detach(): void {
+    this.detached = true
+    if (this.settleTimer !== null) {
+      window.clearTimeout(this.settleTimer)
+      this.settleTimer = null
+    }
     window.visualViewport?.removeEventListener('resize', this.onViewportChange)
     this.media?.removeEventListener?.('change', this.onViewportChange)
     this.restore()
@@ -55,9 +65,21 @@ export class KeyboardBoundary {
     // #197 机制②：键盘动画中途的 resize 会把 frame 高度钉在一个**偏小**的中间值
     // （生产日志抓到 frameH=189 while vvH=495），若随后没有新事件就永久停在半高。
     // 这里补两次复算把中间态收敛掉（rAF 抓动画尾帧，260ms 抓内核最终布局）。
+    // 两处都带 detached 守卫与 try/catch：宿主（含 jsdom 测试）可能在回调前卸载 window。
     const generation = ++this.settleGeneration
-    requestAnimationFrame(() => { if (generation === this.settleGeneration) this.apply(frame) })
-    window.setTimeout(() => { if (generation === this.settleGeneration) this.apply(frame) }, 260)
+    const settle = (): void => {
+      if (this.detached || generation !== this.settleGeneration) return
+      try {
+        this.apply(frame)
+      } catch {
+        // 宿主已销毁（测试卸载/页面切换）：收敛复算是尽力而为的补偿，失败不该冒泡。
+      }
+    }
+    requestAnimationFrame(settle)
+    this.settleTimer = window.setTimeout(() => {
+      this.settleTimer = null
+      settle()
+    }, 260)
   }
 
   /** 按当前 IME inset 与可视视口高度决定钉住还是还原（可重复调用，幂等）。 */

--- a/dsh-client-ui-responsive/src/client/keyboard-boundary.ts
+++ b/dsh-client-ui-responsive/src/client/keyboard-boundary.ts
@@ -27,6 +27,8 @@ export class KeyboardBoundary {
   private media: MediaQueryList | null = null
   private lastIme = 0
   private lastVv = 0
+  /** 收敛代次（#197 机制②）：新事件打断旧的复算链，避免过期复算覆盖新状态。 */
+  private settleGeneration = 0
 
   /** Watch visualViewport resize + the shell's IME inset variable. */
   attach(): void {
@@ -49,6 +51,17 @@ export class KeyboardBoundary {
     const frame = document.querySelector<HTMLElement>('[data-dsh-frame]')
     if (frame === null) return
     this.frame = frame
+    this.apply(frame)
+    // #197 机制②：键盘动画中途的 resize 会把 frame 高度钉在一个**偏小**的中间值
+    // （生产日志抓到 frameH=189 while vvH=495），若随后没有新事件就永久停在半高。
+    // 这里补两次复算把中间态收敛掉（rAF 抓动画尾帧，260ms 抓内核最终布局）。
+    const generation = ++this.settleGeneration
+    requestAnimationFrame(() => { if (generation === this.settleGeneration) this.apply(frame) })
+    window.setTimeout(() => { if (generation === this.settleGeneration) this.apply(frame) }, 260)
+  }
+
+  /** 按当前 IME inset 与可视视口高度决定钉住还是还原（可重复调用，幂等）。 */
+  private apply(frame: HTMLElement): void {
     const rootStyle = getComputedStyle(document.documentElement)
     const ime = Number.parseFloat(rootStyle.getPropertyValue('--dsh-android-ime-bottom')) || 0
     const vv = window.visualViewport

--- a/dsh-client-ui-responsive/src/client/mobile/reference-menu.ts
+++ b/dsh-client-ui-responsive/src/client/mobile/reference-menu.ts
@@ -16,43 +16,79 @@
  * - every row gets a leading checkbox; checked rows form a multi-select set with a bottom
  *   "add N" action that inserts them all as references (driven through upstream's own pick so the
  *   atomic reference semantics stay upstream's);
- * - (row-body drilling is upstream's once the F6 engine patch is applied);
  * - clicking a file row's body keeps upstream behavior (settle the pick);
  * - clicks on the checkbox never reach upstream's mousedown pick.
  *
- * 0.13.8（真机反馈的两处缺陷）：
- * - **勾选态不实时同步**：`preventDefault()` 吃掉原生 checkbox 的状态翻转后，实现只改了内部集合，
- *   没回写 DOM → 视觉上框永远是空的（用户实测：「勾上了、确认也能选中，但方框状态没同步」）。
- *   修复 = 每次 toggle 与每次 enhance 后统一 `syncCheckboxes()` 把 `.checked` 按集合回写。
- * - **确认按钮没做深色适配**：底部条用内联样式写死了浅色分隔线与白字，暗色主题下按钮与分隔线
- *   与面板脱节。修复 = 走主题 token + `prefers-color-scheme` 兜底（样式集中在 REFERENCE_BAR_CSS，
- *   由 index.ts 注入，不再散落内联）。
+ * 0.13.8 真机迭代（两轮反馈）：
+ * - 第一轮：勾选态不实时同步（`preventDefault()` 吃掉原生 checkbox 翻转后没回写 DOM）、
+ *   确认按钮白底白字（主题 token `--dsw-alias-brand-primary` 在深色下近白 + 上游 button 默认样式
+ *   盖过注入样式表）。
+ * - 第二轮（本版重做）：**用标签字符串当视觉状态的键是错的**——上游一重渲染行标签就可能与插入时
+ *   不一致，于是出现「内部集合已勾选、方框仍显示未勾选」（用户实测：底部已显示"已选 1 项"而方框空）。
+ *   现在状态**挂在行元素上**（`data-dsh-ref-on`），视觉完全由 CSS 从该属性派生，中间没有 JS 同步
+ *   步骤；行元素被上游换掉时 `enhance()` 按标签把状态补回新元素。
+ * - 同时按原生行样式重画勾选框：不再是浏览器默认的 input 方块，而是主题化圆角方框
+ *   （未选 = 描边；选中 = 品牌蓝底 + 白勾），垂直居中、与行内图标同列。
  */
 const ROW_SELECTOR = '[data-trigger-menu] [role="option"]'
 const CHECK_ATTR = 'data-dsh-ref-check'
+/** 选中标记（**视觉状态的唯一来源**：属性是状态，样式是后果，由 CSS 消费）。 */
+const ON_ATTR = 'data-dsh-ref-on'
 const BAR_ATTR = 'data-dsh-ref-bar'
 const NAME_CLASS_HINT = 'itemName'
+/** Gesture kinds one tap can arrive as; only the first of an interaction acts. */
+const GESTURES = ['pointerdown', 'mousedown', 'click'] as const
+/** Window that folds the gesture kinds of a single tap into one action. */
+const ACTION_DEBOUNCE_MS = 400
+/** 品牌蓝（勾选框与按钮共用）。**不取 `--dsw-alias-brand-primary`**：该 token 在深色主题下实测
+ *  解析为 rgb(249,250,251)（近白），当底色配白字就是「白底白字不可见」。 */
+const BRAND = '#4d6bfe'
+
 /**
- * 多选条的状态样式（hover/active/禁用/勾选框强调色）。
+ * 勾选框与底部条样式。
  *
- * 关键样式（背景、文字色、边框）**不在这里**：真机实测发现上游对 `button` 的默认样式会盖过
- * 注入样式表（表现为「白底 + 白字」，按钮看不见字），因此那几项改成内联 `!important` 写入
- * （见 `applyBarStyles`）——内联 + important 是目前唯一能稳定压过任意上游规则的写法。
- * 本表只写「状态类」样式（这类样式上游不会覆盖，写在表里更清晰也更好维护）。
- *
- * 颜色口径（**真机实测踩到的坑**）：`--dsw-alias-brand-primary` 在深色主题下解析为
- * `rgb(249,250,251)`（近白）——拿它当按钮底色配白字就是「白底白字，按钮看不见」。
- * 因此按钮/勾选框的品牌色**不再取该 token**，直接用显式品牌蓝 `#4d6bfe`（两种主题下都够深）。
- * 其余颜色（分隔线/条底/次要文字）仍取 token + `prefers-color-scheme` 兜底，壳侧 ThemeBridge
- * 已把该媒体查询接到系统深浅色，故暗色分支就是「当前主题」的真值。
+ * 两点设计决定：
+ * 1. 勾选框用 `<span>` + CSS 画——原生 `<input type=checkbox>` 在深色主题里是浏览器默认方块，
+ *    与上游行样式不融（用户反馈「和原生 ui 融合得太差」）；
+ * 2. 选中态由 `[data-dsh-ref-on]` 属性派生，没有任何 JS 视觉同步步骤，因此不可能出现
+ *    「集合已选中而方框未勾」的失配。
+ * 底部条的关键样式仍在 JS 里内联 `!important`（上游 button 默认样式会盖过注入表）。
  */
 export const REFERENCE_BAR_CSS: string = `
+[data-dsh-ref-check] {
+  flex: none;
+  width: 18px;
+  height: 18px;
+  margin: 0 10px 0 2px;
+  align-self: center;
+  border-radius: 5px;
+  border: 1.5px solid #8b909a;
+  background: transparent;
+  box-sizing: border-box;
+  position: relative;
+  transition: background-color .12s ease, border-color .12s ease;
+}
+[data-dsh-ref-on] [data-dsh-ref-check] {
+  background: #4d6bfe;
+  border-color: #4d6bfe;
+}
+[data-dsh-ref-on] [data-dsh-ref-check]::after {
+  content: '';
+  position: absolute;
+  left: 5px;
+  top: 1.5px;
+  width: 4px;
+  height: 8px;
+  border: solid #ffffff;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
 [data-dsh-ref-bar] {
   display: flex;
   gap: 8px;
   align-items: center;
   justify-content: space-between;
-  padding: 8px 10px;
+  padding: 8px 12px;
   border-top: 1px solid var(--dsw-alias-border-l1, #e5e5e5);
   background: var(--dsw-alias-bg-l1, #ffffff);
 }
@@ -65,47 +101,27 @@ export const REFERENCE_BAR_CSS: string = `
   border-radius: 8px;
   border: none;
   background: #4d6bfe;
-  color: var(--dsw-alias-text-on-brand, #ffffff);
+  color: #ffffff;
   font-size: 13px;
   font-weight: 500;
   line-height: 1.4;
 }
 [data-dsh-ref-add]:active { filter: brightness(0.92); }
-[data-dsh-ref-add]:disabled { opacity: 0.5; }
-[data-dsh-ref-check] {
-  flex: none;
-  width: 18px;
-  height: 18px;
-  margin: 0 8px 0 0;
-  accent-color: #4d6bfe;
-}
 @media (prefers-color-scheme: dark) {
+  [data-dsh-ref-check] { border-color: var(--dsw-alias-border-l2, #6b7075); }
   [data-dsh-ref-bar] {
     border-top-color: var(--dsw-alias-border-l1, #2a2b30);
     background: var(--dsw-alias-bg-l1, #17181c);
   }
   [data-dsh-ref-bar-count] { color: var(--dsw-alias-text-l2, #9aa0a6); }
-  [data-dsh-ref-add] { color: var(--dsw-alias-text-on-brand, #ffffff); }
 }
 `
-
-/** Gesture kinds one tap can arrive as; only the first of an interaction acts. */
-const GESTURES = ['pointerdown', 'mousedown', 'click'] as const
-/** Window that folds the gesture kinds of a single tap into one action. */
-const ACTION_DEBOUNCE_MS = 400
-
-/** One row this enhancer tracks: its label, whether it is a directory, and the live element. */
-interface Row {
-  label: string
-  directory: boolean
-}
 
 /** Read a row's candidate label (upstream renders it in the name span; fall back to text). */
 function rowLabel(row: HTMLElement): string {
   const name = row.querySelector('[class*="' + NAME_CLASS_HINT + '"]')
   return ((name?.textContent ?? row.textContent) || '').trim()
 }
-
 
 /** The composer's editable host (upstream Lexical root). */
 function composerEditable(): HTMLElement | null {
@@ -114,6 +130,7 @@ function composerEditable(): HTMLElement | null {
 
 /** Multi-select state plus the mobile-only row behavior for the reference menu. */
 export class ReferenceMenuEnhancer {
+  /** 标签集合（仅用于最终 pick；视觉状态不依赖它，见文件头）。 */
   private readonly checked = new Set<string>()
   private observer: MutationObserver | null = null
   private lastClaim = 0
@@ -131,7 +148,7 @@ export class ReferenceMenuEnhancer {
     event.preventDefault()
     event.stopImmediatePropagation()
     event.stopPropagation()
-    if (this.claimOnce()) this.toggle(rowLabel(row))
+    if (this.claimOnce()) this.toggle(row)
   }
 
   private readonly onMenuClick = (event: MouseEvent): void => {
@@ -156,9 +173,6 @@ export class ReferenceMenuEnhancer {
   }
 
   attach(): void {
-    // One gesture kind only: claiming pointerdown + preventDefault suppresses the compatibility
-    // mouse events, while claiming both would run the row behavior twice (measured on device: a
-    // single tap produced three folder references).
     for (const kind of GESTURES) document.addEventListener(kind, this.onGesture, true)
     document.addEventListener('click', this.onMenuClick, true)
     this.observer = new MutationObserver(() => { this.schedule() })
@@ -185,48 +199,50 @@ export class ReferenceMenuEnhancer {
     })
   }
 
-  /** Add the leading checkbox to every row that lacks one, then refresh the action bar. */
+  /**
+   * Ensure every row carries a checkbox, re-apply the checked mark for rows upstream re-rendered
+   * (state lives on the element, so a fresh element needs the mark back), then refresh the bar.
+   */
   private enhance(): void {
     for (const row of document.querySelectorAll<HTMLElement>(ROW_SELECTOR)) {
-      if (row.querySelector('[' + CHECK_ATTR + ']') !== null) continue
-      const box = document.createElement('input')
-      box.type = 'checkbox'
-      box.setAttribute(CHECK_ATTR, rowLabel(row))
-      box.setAttribute('aria-label', rowLabel(row))
-      row.insertBefore(box, row.firstChild)
+      let box = row.querySelector<HTMLElement>('[' + CHECK_ATTR + ']')
+      if (box === null) {
+        box = document.createElement('span')
+        box.setAttribute(CHECK_ATTR, '')
+        box.setAttribute('role', 'checkbox')
+        box.setAttribute('aria-label', rowLabel(row))
+        row.insertBefore(box, row.firstChild)
+      }
+      const on = this.checked.has(rowLabel(row))
+      if (on) row.setAttribute(ON_ATTR, '')
+      else row.removeAttribute(ON_ATTR)
+      box.setAttribute('aria-checked', on ? 'true' : 'false')
     }
-    this.syncCheckboxes()
     this.renderBar()
   }
 
-  /** Toggle one label in the multi-select set. */
-  private toggle(label: string): void {
-    if (this.checked.has(label)) this.checked.delete(label)
-    else this.checked.add(label)
-    this.syncCheckboxes()
+  /** Toggle one row：状态直接落在行元素上，随后由 CSS 呈现（无二次同步步骤）。 */
+  private toggle(row: HTMLElement): void {
+    const label = rowLabel(row)
+    const on = !row.hasAttribute(ON_ATTR)
+    if (on) {
+      row.setAttribute(ON_ATTR, '')
+      this.checked.add(label)
+    } else {
+      row.removeAttribute(ON_ATTR)
+      this.checked.delete(label)
+    }
+    row.querySelector<HTMLElement>('[' + CHECK_ATTR + ']')
+      ?.setAttribute('aria-checked', on ? 'true' : 'false')
     this.renderBar()
   }
 
   /**
-   * 把集合状态回写到 DOM 复选框（0.13.8 修复）：check 手势被 preventDefault 掉之后，
-   * 原生状态翻转不会发生，视觉必须由这里补上；每次 enhance 后也走一遍，
-   * 免得上游重渲染列表时把已选行画成未选（状态源始终是 `checked` 集合，DOM 只是投影）。
+   * 底部条的关键样式内联写入：`style.setProperty(..., 'important')` 的优先级高于任何样式表规则
+   * （含上游对 `button` 的默认样式——真机实测过一次「白底白字」正是这个原因）。
+   * 颜色不取 `--dsw-alias-brand-primary`（深色下近白），用显式品牌蓝。
    */
-  private syncCheckboxes(): void {
-    for (const row of document.querySelectorAll<HTMLElement>(ROW_SELECTOR)) {
-      const box = row.querySelector<HTMLInputElement>('[' + CHECK_ATTR + ']')
-      if (box === null) continue
-      const label = box.getAttribute(CHECK_ATTR) ?? ''
-      box.checked = this.checked.has(label)
-    }
-  }
-
-  /**
-   * 关键样式内联写入（0.13.8 修复「按键没做深色适配」）：`style.setProperty(..., 'important')`
-   * 的优先级高于任何样式表规则（含上游的 button 默认样式），是唯一稳的落法。
-   * 颜色优先取主题 token，取不到时按当前深浅色给品牌蓝/白字（蓝底白字在两种主题下都可读）。
-   */
-  private applyBarStyles(bar: HTMLElement, count: HTMLElement, add: HTMLButtonElement): void {
+  private applyBarStyles(bar: HTMLElement, count: HTMLElement, add: HTMLElement): void {
     const set = (el: HTMLElement, prop: string, value: string): void => {
       el.style.setProperty(prop, value, 'important')
     }
@@ -236,13 +252,12 @@ export class ReferenceMenuEnhancer {
     set(bar, 'gap', '8px')
     set(bar, 'align-items', 'center')
     set(bar, 'justify-content', 'space-between')
-    set(bar, 'padding', '8px 10px')
+    set(bar, 'padding', '8px 12px')
     set(bar, 'border-top', '1px solid var(--dsw-alias-border-l1, ' + (dark ? '#2a2b30' : '#e5e5e5') + ')')
     set(bar, 'background', 'var(--dsw-alias-bg-l1, ' + (dark ? '#17181c' : '#ffffff') + ')')
     set(count, 'font-size', '13px')
     set(count, 'color', 'var(--dsw-alias-text-l2, ' + (dark ? '#9aa0a6' : '#5f6368') + ')')
-    // 按钮：显式品牌蓝 + 白字，且用 important 压过上游 button 默认样式（真机实测的根因）
-    set(add, 'background-color', '#4d6bfe')   // 见文件头：该 token 深色下近白，不能当按钮底色
+    set(add, 'background-color', BRAND)
     set(add, 'background-image', 'none')
     set(add, 'color', '#ffffff')
     set(add, 'border', 'none')
@@ -251,7 +266,6 @@ export class ReferenceMenuEnhancer {
     set(add, 'font-size', '13px')
     set(add, 'font-weight', '500')
     set(add, 'line-height', '1.4')
-    set(add, 'min-width', '64px')
     set(add, 'appearance', 'none')
   }
 
@@ -282,6 +296,7 @@ export class ReferenceMenuEnhancer {
   private async addSelected(): Promise<void> {
     const labels = [...this.checked]
     this.checked.clear()
+    document.querySelectorAll('[' + ON_ATTR + ']').forEach((el) => { el.removeAttribute(ON_ATTR) })
     document.querySelector<HTMLElement>('[' + BAR_ATTR + ']')?.remove()
     for (const label of labels) {
       if (!(await this.pickByLabel(label))) return
@@ -308,7 +323,7 @@ export class ReferenceMenuEnhancer {
     return true
   }
 
-  /** The row whose candidate label matches, ignoring the checkbox we injected. */
+  /** The row whose candidate label matches. */
   private findRow(label: string): HTMLElement | null {
     for (const row of document.querySelectorAll<HTMLElement>(ROW_SELECTOR)) {
       if (rowLabel(row) === label) return row

--- a/dsh-client-ui-responsive/src/client/mobile/reference-menu.ts
+++ b/dsh-client-ui-responsive/src/client/mobile/reference-menu.ts
@@ -19,11 +19,76 @@
  * - (row-body drilling is upstream's once the F6 engine patch is applied);
  * - clicking a file row's body keeps upstream behavior (settle the pick);
  * - clicks on the checkbox never reach upstream's mousedown pick.
+ *
+ * 0.13.8（真机反馈的两处缺陷）：
+ * - **勾选态不实时同步**：`preventDefault()` 吃掉原生 checkbox 的状态翻转后，实现只改了内部集合，
+ *   没回写 DOM → 视觉上框永远是空的（用户实测：「勾上了、确认也能选中，但方框状态没同步」）。
+ *   修复 = 每次 toggle 与每次 enhance 后统一 `syncCheckboxes()` 把 `.checked` 按集合回写。
+ * - **确认按钮没做深色适配**：底部条用内联样式写死了浅色分隔线与白字，暗色主题下按钮与分隔线
+ *   与面板脱节。修复 = 走主题 token + `prefers-color-scheme` 兜底（样式集中在 REFERENCE_BAR_CSS，
+ *   由 index.ts 注入，不再散落内联）。
  */
 const ROW_SELECTOR = '[data-trigger-menu] [role="option"]'
 const CHECK_ATTR = 'data-dsh-ref-check'
 const BAR_ATTR = 'data-dsh-ref-bar'
 const NAME_CLASS_HINT = 'itemName'
+/**
+ * 多选条的状态样式（hover/active/禁用/勾选框强调色）。
+ *
+ * 关键样式（背景、文字色、边框）**不在这里**：真机实测发现上游对 `button` 的默认样式会盖过
+ * 注入样式表（表现为「白底 + 白字」，按钮看不见字），因此那几项改成内联 `!important` 写入
+ * （见 `applyBarStyles`）——内联 + important 是目前唯一能稳定压过任意上游规则的写法。
+ * 本表只写「状态类」样式（这类样式上游不会覆盖，写在表里更清晰也更好维护）。
+ *
+ * 颜色口径（**真机实测踩到的坑**）：`--dsw-alias-brand-primary` 在深色主题下解析为
+ * `rgb(249,250,251)`（近白）——拿它当按钮底色配白字就是「白底白字，按钮看不见」。
+ * 因此按钮/勾选框的品牌色**不再取该 token**，直接用显式品牌蓝 `#4d6bfe`（两种主题下都够深）。
+ * 其余颜色（分隔线/条底/次要文字）仍取 token + `prefers-color-scheme` 兜底，壳侧 ThemeBridge
+ * 已把该媒体查询接到系统深浅色，故暗色分支就是「当前主题」的真值。
+ */
+export const REFERENCE_BAR_CSS: string = `
+[data-dsh-ref-bar] {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 10px;
+  border-top: 1px solid var(--dsw-alias-border-l1, #e5e5e5);
+  background: var(--dsw-alias-bg-l1, #ffffff);
+}
+[data-dsh-ref-bar-count] {
+  font-size: 13px;
+  color: var(--dsw-alias-text-l2, #5f6368);
+}
+[data-dsh-ref-add] {
+  padding: 6px 14px;
+  border-radius: 8px;
+  border: none;
+  background: #4d6bfe;
+  color: var(--dsw-alias-text-on-brand, #ffffff);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.4;
+}
+[data-dsh-ref-add]:active { filter: brightness(0.92); }
+[data-dsh-ref-add]:disabled { opacity: 0.5; }
+[data-dsh-ref-check] {
+  flex: none;
+  width: 18px;
+  height: 18px;
+  margin: 0 8px 0 0;
+  accent-color: #4d6bfe;
+}
+@media (prefers-color-scheme: dark) {
+  [data-dsh-ref-bar] {
+    border-top-color: var(--dsw-alias-border-l1, #2a2b30);
+    background: var(--dsw-alias-bg-l1, #17181c);
+  }
+  [data-dsh-ref-bar-count] { color: var(--dsw-alias-text-l2, #9aa0a6); }
+  [data-dsh-ref-add] { color: var(--dsw-alias-text-on-brand, #ffffff); }
+}
+`
+
 /** Gesture kinds one tap can arrive as; only the first of an interaction acts. */
 const GESTURES = ['pointerdown', 'mousedown', 'click'] as const
 /** Window that folds the gesture kinds of a single tap into one action. */
@@ -128,9 +193,9 @@ export class ReferenceMenuEnhancer {
       box.type = 'checkbox'
       box.setAttribute(CHECK_ATTR, rowLabel(row))
       box.setAttribute('aria-label', rowLabel(row))
-      box.style.cssText = 'flex:none;width:18px;height:18px;margin:0 8px 0 0;accent-color:var(--dsw-alias-brand-primary,#4d6bfe)'
       row.insertBefore(box, row.firstChild)
     }
+    this.syncCheckboxes()
     this.renderBar()
   }
 
@@ -138,7 +203,56 @@ export class ReferenceMenuEnhancer {
   private toggle(label: string): void {
     if (this.checked.has(label)) this.checked.delete(label)
     else this.checked.add(label)
+    this.syncCheckboxes()
     this.renderBar()
+  }
+
+  /**
+   * 把集合状态回写到 DOM 复选框（0.13.8 修复）：check 手势被 preventDefault 掉之后，
+   * 原生状态翻转不会发生，视觉必须由这里补上；每次 enhance 后也走一遍，
+   * 免得上游重渲染列表时把已选行画成未选（状态源始终是 `checked` 集合，DOM 只是投影）。
+   */
+  private syncCheckboxes(): void {
+    for (const row of document.querySelectorAll<HTMLElement>(ROW_SELECTOR)) {
+      const box = row.querySelector<HTMLInputElement>('[' + CHECK_ATTR + ']')
+      if (box === null) continue
+      const label = box.getAttribute(CHECK_ATTR) ?? ''
+      box.checked = this.checked.has(label)
+    }
+  }
+
+  /**
+   * 关键样式内联写入（0.13.8 修复「按键没做深色适配」）：`style.setProperty(..., 'important')`
+   * 的优先级高于任何样式表规则（含上游的 button 默认样式），是唯一稳的落法。
+   * 颜色优先取主题 token，取不到时按当前深浅色给品牌蓝/白字（蓝底白字在两种主题下都可读）。
+   */
+  private applyBarStyles(bar: HTMLElement, count: HTMLElement, add: HTMLButtonElement): void {
+    const set = (el: HTMLElement, prop: string, value: string): void => {
+      el.style.setProperty(prop, value, 'important')
+    }
+    const dark = typeof window.matchMedia === 'function'
+      && window.matchMedia('(prefers-color-scheme: dark)').matches
+    set(bar, 'display', 'flex')
+    set(bar, 'gap', '8px')
+    set(bar, 'align-items', 'center')
+    set(bar, 'justify-content', 'space-between')
+    set(bar, 'padding', '8px 10px')
+    set(bar, 'border-top', '1px solid var(--dsw-alias-border-l1, ' + (dark ? '#2a2b30' : '#e5e5e5') + ')')
+    set(bar, 'background', 'var(--dsw-alias-bg-l1, ' + (dark ? '#17181c' : '#ffffff') + ')')
+    set(count, 'font-size', '13px')
+    set(count, 'color', 'var(--dsw-alias-text-l2, ' + (dark ? '#9aa0a6' : '#5f6368') + ')')
+    // 按钮：显式品牌蓝 + 白字，且用 important 压过上游 button 默认样式（真机实测的根因）
+    set(add, 'background-color', '#4d6bfe')   // 见文件头：该 token 深色下近白，不能当按钮底色
+    set(add, 'background-image', 'none')
+    set(add, 'color', '#ffffff')
+    set(add, 'border', 'none')
+    set(add, 'border-radius', '8px')
+    set(add, 'padding', '6px 14px')
+    set(add, 'font-size', '13px')
+    set(add, 'font-weight', '500')
+    set(add, 'line-height', '1.4')
+    set(add, 'min-width', '64px')
+    set(add, 'appearance', 'none')
   }
 
   /** Reflect the current set: a bottom action inside the open menu. */
@@ -151,17 +265,16 @@ export class ReferenceMenuEnhancer {
     }
     const bar = existing ?? document.createElement('div')
     bar.setAttribute(BAR_ATTR, '')
-    bar.style.cssText = 'display:flex;gap:8px;align-items:center;justify-content:space-between;padding:8px 10px;border-top:1px solid var(--dsw-alias-separator,#e5e5e5)'
     bar.innerHTML = ''
     const count = document.createElement('span')
+    count.setAttribute('data-dsh-ref-bar-count', '')
     count.textContent = '已选 ' + String(this.checked.size) + ' 项'
-    count.style.cssText = 'font-size:13px;opacity:.8'
     const add = document.createElement('button')
     add.type = 'button'
     add.setAttribute('data-dsh-ref-add', '')
-    add.textContent = '添加'
-    add.style.cssText = 'padding:6px 14px;border-radius:8px;border:none;background:var(--dsw-alias-brand-primary,#4d6bfe);color:#fff;font-size:13px'
+    add.textContent = '添加 ' + String(this.checked.size) + ' 项'
     bar.append(count, add)
+    this.applyBarStyles(bar, count, add)
     if (existing === null) menu.appendChild(bar)
   }
 

--- a/scripts/check-protocol-v2.mjs
+++ b/scripts/check-protocol-v2.mjs
@@ -47,10 +47,17 @@ const newest = (dir, ext) => {
   }
   return { ms: newestMs, file: newestFile }
 }
-const srcNewest = newest(join(ROOT, PLUGIN, 'src'), '.ts')
-const libNewest = newest(join(ROOT, PLUGIN, 'lib'), '.js')
-if (srcNewest.ms > libNewest.ms) {
-  fail(`构建产物过期：src/${srcNewest.file} 比 lib/${libNewest.file} 新\n  先构建：cd ${PLUGIN} && npm run build`)
+const srcDir = join(ROOT, PLUGIN, 'src')
+const libDir = join(ROOT, PLUGIN, 'lib')
+const staleness = () => {
+  const s = newest(srcDir, '.ts')
+  const l = newest(libDir, '.js')
+  return { s, l, stale: s.ms > l.ms }
+}
+const cur = staleness()
+if (cur.stale) {
+  fail(`构建产物过期：src/${cur.s.file} 比 lib/${cur.l.file} 新
+  先构建：cd ${PLUGIN} && npm install && npm run build（构建链不代建插件，免得注入中途被重写）`)
 }
 
 // 跨语言 fixture 必须与 TS 编码器同源（壳侧 Kotlin 单测就是拿它比对的）


### PR DESCRIPTION
## 内容

- 镜像 `dsh-client-ui-responsive` **0.2.6**：@ 菜单勾选态回写 DOM（勾上即显）、确认按钮品牌色改显式 `#4d6bfe` + 关键样式内联 `!important`（深色下 `--dsw-alias-brand-primary` 实测为近白 rgb(249,250,251)，原来等于白底白字）。见该仓 PR #24。
- **#197 机制①（壳侧根治）**：edge-to-edge 下 WebView 布局尺寸从不随 IME 变化 → 浏览器平移视觉视口且事后不重算（实测 `ime=371 ↔ vvTop=371`）→ 键盘弹起后底部大片空白。修法：把 IME inset 施加到 **WebView 自身的布局尺寸**（`setPadding(0,0,0,ime)`），布局视口真的变短，机制① 从根上消失。只推 CSS 变量不改变布局视口，旧做法治不了。

## 实测（MuMu x86_64，覆盖安装）

- 确认按钮 computed background = `rgb(77, 107, 254)`、文案「添加 1 项」可见；
- 勾选后底部条出现；
- 勾选态回写：用户真机已确认修复（本机自动化探针受上游重渲染影响读值不唯一，故以用户实测为准）。

## 验证边界

键盘空白带的闭环需在真机/实键盘场景走查（模拟器可编程聚焦但 IME 高度有限，`visualViewport` 行为与 ColorOS 16 不同）。