### PR TITLE
chore: 0.13.8 版本号（vc37）+ 收尾登记（滚动条吸附等三项）

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,15 +14,20 @@ android {
     // (the embedded engine, bash, and every child command would need linker64
     // wrappers); 34 keeps native exec working on Android 15/16 devices.
     targetSdk = 34
-    // 0.13.7fx-1 修订构建：versionCode 36（发布后 issue 修复批：会话迁移 link(2) 回退 #154、
-    // 引擎启动目录改到应用工作区根，未分组会话不再把 / 当工作区；修复 0.1.5 起失效的移动端 Enter 换行守卫；
-    // 退役空转的 web-frontend-index.html 运行时补丁；覆盖安装 0.13.7(34)）。
-    versionCode = 36
+    // 0.13.8：versionCode 37（覆盖安装 0.13.7fx-1(36)）。本版主题：
+    // ① 控制协议 V2（列式载荷 428 B/节点 → 54.7 B/行，413 自动降级 view=target，行句柄动作回指）；
+    // ② E6 能力补齐（全局动作面 getSystemActions 驱动、无障碍截屏回落 ADB）；
+    // ③ P2 收口（android_ui_detail 两级披露 + DetailStore、android_privilege_status 结构化 route +
+    //    协议协商）；④ 启动页 APK 自更新（仅手动 + 同按钮二次确认 + 安装授权）；
+    // ⑤ 悬浮球动效 M4-M8；⑥ @ 菜单勾选框（状态由行属性派生 + 原生风格自绘）；
+    // ⑦ 键盘空白带根治（IME inset 施加到 WebView 布局尺寸，apk #197）；
+    // ⑧ 构建门禁链自身缺陷修复（Join-Path 拼写、镜像比对面、协议 V2 门禁）。
+    versionCode = 37
     // Snapshot builds append a suffix (e.g. -SN-1-RC13) via -PversionNameSuffix; release builds pass none.
     val snapshotSuffix = providers.gradleProperty("versionNameSuffix").getOrElse("")
     // 版本号单一来源：UI（GuidePageRenderer）、桥（androidBridge.version）、诊断日志、引擎环境变量
     // （DSH_APP_VERSION，见 EngineManager.engineEnv）全部读这里，禁止任何地方再硬编码版本字面量。
-    versionName = "0.13.7fx-1" + snapshotSuffix
+    versionName = "0.13.8" + snapshotSuffix
     buildConfigField("String", "TERMUX_VERSION", "\"0.118.3\"")
   }
 

--- a/docs/AGENTS/known-gaps.md
+++ b/docs/AGENTS/known-gaps.md
@@ -20,6 +20,21 @@
 - **API <30 设备**：无障碍截屏不可用（`takeScreenshot` 需要 API 30），仍需 ADB `screencap`；`GLOBAL_ACTION_TAKE_SCREENSHOT`(28) 只存相册不回传数据。
 - **arm64 真机验证**：无障碍通道目前仅在 x86_64 模拟器验证（无 arm64 设备在线）。
 
+## 0.13.8 收尾新增登记（2026-09-12 晚）
+
+- **滚动条未吸附到最右侧（布局边界不匹配）**：用户真机反馈——滚动条与容器右边界之间有缝，
+  没有贴在屏/面板最右（与 apk #197 的布局视口/边界同族，但独立现象，本轮未修）。待定位：
+  ① WebView 右侧是否残留 padding 或系统手势区（壳侧 `setPadding` 目前只动 bottom）；
+  ② 页面侧滚动容器的 `scrollbar-gutter`/`padding-right`/`max-width` 与
+  `--dsh-mobile-popup-max-width` 等钳制变量是否把滚动条挤离边界（`composer-menu.css.ts` 的
+  viewport 宽度钳制是重点嫌疑）；③ 移动形态下轨道宽度是否被 `ComposerPopupGuard` 按 CSS 宽度
+  而非内容盒计算。定位方法：设备上量 `scrollContainer.getBoundingClientRect().right` 与
+  `innerWidth`，以及 `getComputedStyle(el).scrollbarGutter / paddingRight`——先取数再改。
+- **悬浮球动效手感（M4-M8）**：时长/幅度未经人眼走查（静态截图断言不了），发布前真机确认一次。
+- **`KeyboardBoundary` 机制①的最终形态**：壳侧已把 IME inset 施加到 WebView 布局尺寸，
+  页面侧的 `visualViewport.offsetTop` 补偿因此**刻意没有实现**（按 #197 建议修法 1，机制①
+  从根上消失后该补偿即冗余）。若真机仍见残留平移，再补页面侧补偿——届时它是第二道防线而非主修。
+
 ## 0.13.8 批 F 收尾登记（2026-09-12）
 
 - **API 33+「无障碍输入法」（E6d）无法实现**：`javap` 校验 android-36 的 `android.jar`，


### PR DESCRIPTION
0.13.8 收尾：versionCode 37 / versionName 0.13.8（覆盖 0.13.7fx-1(36)）；版本块注释列全本版主题（协议 V2 / E6 / P2 / APK 自更新 / 悬浮球动效 / @ 菜单勾选框 / 键盘空白带 / 构建门禁自身缺陷）；known-gaps 登记滚动条未吸附最右、动效手感待走查、KeyboardBoundary 机制①最终形态。
