### PR TITLE
fix: 补 E6 全局动作面（apk #195 遗漏合入；0.13.8 补丁）

### DIFF
--- a/app/src/main/java/com/dsharnessmobile/shell/DeviceControlService.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/DeviceControlService.kt
@@ -818,6 +818,7 @@ class DeviceControlService : AccessibilityService() {
    * 代次变化或 invalidated=true 即界面确实变了。
    */
   private fun handleState(): JSONObject = JSONObject()
+    .put("globals", org.json.JSONArray(availableGlobalActions() as Collection<*>))
     .put("gen", synchronized(lock) { snapshot?.gen ?: -1 })
     .put("invalidated", invalidated)
     .put("enabled", true)
@@ -954,15 +955,33 @@ class DeviceControlService : AccessibilityService() {
     return walk(root, 0)
   }
 
+  /**
+   * 当前设备可用全局动作（目录与判定在 GlobalActionCatalog——纯函数、可单测）。
+   * 诊断面（state.globals）与失败回填共用。
+   */
+  fun availableGlobalActions(): List<String> =
+    GlobalActionCatalog.available(systemGlobalActionIds(), Build.VERSION.SDK_INT)
+
+  private fun systemGlobalActionIds(): Set<Int> = try {
+    getSystemActions()?.map { it.id }?.toSet() ?: emptySet()
+  } catch (_: Throwable) {
+    emptySet()
+  }
+
+  /** 全局动作（0.13.8 E6：getSystemActions 驱动；不可用时回可用清单，不静默失败）。 */
   private fun handleGlobal(args: JSONObject): JSONObject {
-    val action = when (args.optString("action", "")) {
-      "back" -> GLOBAL_ACTION_BACK
-      "home" -> GLOBAL_ACTION_HOME
-      "recents" -> GLOBAL_ACTION_RECENTS
-      "notifications" -> GLOBAL_ACTION_NOTIFICATIONS
-      else -> return error("未知全局动作")
+    val name = args.optString("action", "")
+    val available = availableGlobalActions()
+    val entry = GlobalActionCatalog.find(name)
+      ?: return error("未知全局动作 $name——可用：${available.joinToString(" / ")}")
+    if (!available.contains(entry.name)) {
+      return error(
+        "设备不支持全局动作 ${entry.name}" +
+          (if (Build.VERSION.SDK_INT < entry.minSdk) "（需要 Android API ${entry.minSdk}，本机 ${Build.VERSION.SDK_INT}）" else "（系统未报告该动作）") +
+          "——可用：${available.joinToString(" / ")}",
+      )
     }
-    val ok = performGlobalAction(action)
-    return if (ok) JSONObject().put("global", args.optString("action")) else error("全局动作被系统拒绝")
+    val ok = performGlobalAction(entry.id)
+    return if (ok) JSONObject().put("global", entry.name) else error("全局动作 ${entry.name} 被系统拒绝（执行返回 false）")
   }
 }

--- a/app/src/main/java/com/dsharnessmobile/shell/GlobalActionCatalog.kt
+++ b/app/src/main/java/com/dsharnessmobile/shell/GlobalActionCatalog.kt
@@ -1,0 +1,53 @@
+package com.dsharnessmobile.shell
+
+import android.accessibilityservice.AccessibilityService
+
+/**
+ * 全局动作目录（0.13.8 E6）——名称 ↔ 平台常量 ↔ 最低 API，**纯数据 + 纯函数**（可 JVM 单测）。
+ *
+ * 为什么单独一个文件：可用性判定必须能单测。原实现把 `when(action)` 硬编码在
+ * `AccessibilityService` 子类里，任何一条可用性规则都只能上真机试——而「工具说能做、
+ * 点了没反应」正是最难查的一类失败，恰恰需要离线断言把它钉住。
+ *
+ * 可用性由 `getSystemActions()` 驱动：系统报不出来的动作不执行、也不宣传。
+ */
+object GlobalActionCatalog {
+
+  /** 一条全局动作：`name` 是工具面用的名字，`id` 是平台常量，`minSdk` 是引入版本。 */
+  class Entry(val name: String, val id: Int, val minSdk: Int, val core: Boolean = false)
+
+  /**
+   * 目录表。`core = true` 的四条（back/home/recents/notifications）在所有 Android 上都存在，
+   * 恒放行——不能让一个不可靠的 `getSystemActions()` 结果把它们砍掉（防回归）。
+   */
+  val TABLE: List<Entry> = listOf(
+    Entry("back", AccessibilityService.GLOBAL_ACTION_BACK, 1, core = true),
+    Entry("home", AccessibilityService.GLOBAL_ACTION_HOME, 1, core = true),
+    Entry("recents", AccessibilityService.GLOBAL_ACTION_RECENTS, 1, core = true),
+    Entry("notifications", AccessibilityService.GLOBAL_ACTION_NOTIFICATIONS, 1, core = true),
+    Entry("quickSettings", AccessibilityService.GLOBAL_ACTION_QUICK_SETTINGS, 1),
+    Entry("powerDialog", AccessibilityService.GLOBAL_ACTION_POWER_DIALOG, 1),
+    Entry("toggleSplitScreen", AccessibilityService.GLOBAL_ACTION_TOGGLE_SPLIT_SCREEN, 24),
+    Entry("lockScreen", AccessibilityService.GLOBAL_ACTION_LOCK_SCREEN, 28),
+    Entry("takeScreenshot", AccessibilityService.GLOBAL_ACTION_TAKE_SCREENSHOT, 28),
+    Entry("menu", AccessibilityService.GLOBAL_ACTION_MENU, 31),
+    Entry("mediaPlayPause", AccessibilityService.GLOBAL_ACTION_MEDIA_PLAY_PAUSE, 31),
+    Entry("dismissNotificationShade", AccessibilityService.GLOBAL_ACTION_DISMISS_NOTIFICATION_SHADE, 31),
+    Entry("accessibilityShortcut", AccessibilityService.GLOBAL_ACTION_ACCESSIBILITY_SHORTCUT, 31),
+  )
+
+  /**
+   * 给定系统报出的动作 id 集合与 API 级别，返回可用动作名（顺序同目录表）。
+   *
+   * 规则（顺序即优先级）：
+   * ① 低于该动作的最低 API → 不可用；
+   * ② 核心四条 → 恒可用；
+   * ③ 其余：系统列表为空（部分 ROM 不报）时按 API 下限放行，非空时以系统列表为准。
+   */
+  fun available(ids: Set<Int>, sdk: Int): List<String> =
+    TABLE.filter { entry -> sdk >= entry.minSdk && (entry.core || ids.isEmpty() || ids.contains(entry.id)) }
+      .map { entry -> entry.name }
+
+  /** 按名称查条目（未知名称返回 null，由调用方回可读错误）。 */
+  fun find(name: String): Entry? = TABLE.firstOrNull { it.name == name }
+}

--- a/app/src/test/java/com/dsharnessmobile/shell/GlobalActionCatalogTest.kt
+++ b/app/src/test/java/com/dsharnessmobile/shell/GlobalActionCatalogTest.kt
@@ -1,0 +1,73 @@
+package com.dsharnessmobile.shell
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * 全局动作可用性判定（0.13.8 E6）——把「工具说能做、点了没反应」这类最难查的失败钉在离线断言里。
+ *
+ * 判定输入是 `getSystemActions()` 报出的 id 集合与 API 级别；核心四条必须恒在
+ * （ROM 不报也不能砍），高版本动作按 API 下限与系统报告双门放行。
+ */
+class GlobalActionCatalogTest {
+
+  /** 从目录里取回动作 id（测试不硬编码平台常量值，避免与 SDK 常量脱钩）。 */
+  private fun idOf(name: String): Int {
+    val e = GlobalActionCatalog.find(name)
+    assertNotNull("目录缺少 $name", e)
+    return e!!.id
+  }
+
+  @Test
+  fun coreActionsAreAlwaysAvailable() {
+    // 系统什么都不报（部分 ROM 如此）+ 现代 API：核心四条必须在
+    val avail = GlobalActionCatalog.available(emptySet(), 35)
+    for (name in listOf("back", "home", "recents", "notifications")) {
+      assertTrue("核心动作 $name 不应被系统列表砍掉", avail.contains(name))
+    }
+    // 系统报告一个与核心无关的集合：核心四条仍必须保留（防「getSystemActions 口径不合」回归）
+    val avail2 = GlobalActionCatalog.available(setOf(idOf("quickSettings")), 35)
+    assertTrue(avail2.contains("back"))
+    assertTrue(avail2.contains("home"))
+  }
+
+  @Test
+  fun unsupportedBySystemIsExcluded() {
+    // 系统只报 quickSettings → 高版本动作（menu/lockScreen 等）不得对外宣传
+    val avail = GlobalActionCatalog.available(setOf(idOf("quickSettings")), 35)
+    assertTrue(avail.contains("quickSettings"))
+    assertFalse("系统未报告的动作不得宣传", avail.contains("menu"))
+    assertFalse(avail.contains("lockScreen"))
+    // 空列表 = ROM 不报，按 API 下限放行（此时 menu 可用）
+    val romSilent = GlobalActionCatalog.available(emptySet(), 35)
+    assertTrue(romSilent.contains("menu"))
+  }
+
+  @Test
+  fun minApiGateHolds() {
+    // API 26（Android 8）：lockScreen/takeScreenshot 需要 28 → 不可用；quickSettings 可用
+    val api26 = GlobalActionCatalog.available(emptySet(), 26)
+    assertFalse(api26.contains("lockScreen"))
+    assertFalse(api26.contains("takeScreenshot"))
+    assertTrue(api26.contains("quickSettings"))
+    // API 28：放行锁屏与截图；menu（31）仍不可用
+    val api28 = GlobalActionCatalog.available(emptySet(), 28)
+    assertTrue(api28.contains("lockScreen"))
+    assertTrue(api28.contains("takeScreenshot"))
+    assertFalse(api28.contains("menu"))
+    // API 31：全表放行
+    val api31 = GlobalActionCatalog.available(GlobalActionCatalog.TABLE.map { it.id }.toSet(), 31)
+    assertEquals(GlobalActionCatalog.TABLE.size, api31.size)
+  }
+
+  @Test
+  fun unknownActionIsRejected() {
+    assertNull(GlobalActionCatalog.find("reboot"))
+    assertNull(GlobalActionCatalog.find(""))
+    assertNotNull(GlobalActionCatalog.find("takeScreenshot"))
+  }
+}


### PR DESCRIPTION
镜像 dsh-client-ui-responsive 0.3.2：列表铺满弹层卡片（滚动条吸卡片右缘，delta 64px→4px 设备实测）。
